### PR TITLE
fix: 選択中の駒を再クリックで選択解除 #7

### DIFF
--- a/src/hooks/use-shogi-game.ts
+++ b/src/hooks/use-shogi-game.ts
@@ -29,6 +29,7 @@ import { saveMove, updateGameStatus } from "@/app/actions/game";
 
 type GameAction =
   | { type: "SELECT_SQUARE"; pos: Position }
+  | { type: "DESELECT" }
   | { type: "SELECT_HAND_PIECE"; pieceType: string }
   | { type: "MAKE_MOVE"; move: Move }
   | { type: "SET_STATE"; state: GameState }
@@ -49,6 +50,9 @@ interface ShogiGameState {
 
 function shogiReducer(state: ShogiGameState, action: GameAction): ShogiGameState {
   switch (action.type) {
+    case "DESELECT":
+      return { ...state, selectedSquare: null, selectedHandPiece: null, legalMoves: [] };
+
     case "SELECT_SQUARE": {
       const { pos } = action;
       const { gameState, selectedSquare, selectedHandPiece, legalMoves } = state;
@@ -332,6 +336,12 @@ export function useShogiGame({
         makePlayerMove(dropMove);
       }
       dispatch({ type: "SELECT_SQUARE", pos });
+      return;
+    }
+
+    // 選択中の駒を再クリック → 選択解除
+    if (selectedSquare?.row === pos.row && selectedSquare?.col === pos.col) {
+      dispatch({ type: "DESELECT" });
       return;
     }
 


### PR DESCRIPTION
## Summary
- `DESELECT` アクションを reducer に追加
- `selectSquare` で同一マスを再クリックした場合に `DESELECT` を dispatch
- 選択状態・合法手ハイライトをクリア

## Test plan
- [ ] 駒を選択後、同じ駒をクリックすると選択解除されることを確認
- [ ] 選択解除後、別の駒を選択できることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)