### PR TITLE
fix: 棋譜欄の縦幅制御・自動スクロール #8

### DIFF
--- a/src/components/game/move-history.tsx
+++ b/src/components/game/move-history.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { moveToNotation } from "@/lib/shogi/notation";
 import type { Move } from "@/lib/shogi/types";
@@ -10,6 +11,13 @@ interface MoveHistoryProps {
 }
 
 export function MoveHistory({ moves }: MoveHistoryProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // 手が追加されるたびに最新手へ自動スクロール
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [moves.length]);
+
   return (
     <div className="flex flex-col h-full">
       <div className="text-sm font-medium text-muted-foreground mb-1">棋譜</div>
@@ -42,6 +50,7 @@ export function MoveHistory({ moves }: MoveHistoryProps) {
               );
             })
           )}
+          <div ref={bottomRef} />
         </div>
       </ScrollArea>
     </div>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -195,7 +195,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </Card>
 
         {/* 棋譜 */}
-        <Card className="p-3 flex-1 min-h-48">
+        <Card className="p-3 flex-1 min-h-48 max-h-[50vh] overflow-hidden">
           <MoveHistory moves={gameState.moveHistory} />
         </Card>
 


### PR DESCRIPTION
## Summary
- 棋譜 Card に `max-h-[50vh]` を設定し画面高さの50%を上限に
- `overflow-hidden` で Card 自体が伸びないよう制御（ScrollArea が機能）
- 手が追加されるたびに最新手へ自動スクロール

## Test plan
- [ ] 棋譜が長くなっても棋譜欄がそれ以上伸びずスクロールできることを確認
- [ ] 手を指すたびに最新手が表示されることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)