### PR TITLE
fix: 棋譜欄の縦幅制御・スクロール対応 #8

### DIFF
--- a/src/components/game/move-history.tsx
+++ b/src/components/game/move-history.tsx
@@ -21,7 +21,7 @@ export function MoveHistory({ moves }: MoveHistoryProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="text-sm font-medium text-muted-foreground mb-1">棋譜</div>
-      <ScrollArea className="flex-1 border rounded-md bg-muted/30">
+      <ScrollArea className="max-h-[45vh] border rounded-md bg-muted/30">
         <div className="p-2 space-y-0.5">
           {moves.length === 0 ? (
             <p className="text-xs text-muted-foreground p-2">棋譜はまだありません</p>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -195,7 +195,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </Card>
 
         {/* 棋譜 */}
-        <Card className="p-3 flex-1 min-h-48 max-h-[50vh] overflow-hidden">
+        <Card className="p-3 flex-1 min-h-48">
           <MoveHistory moves={gameState.moveHistory} />
         </Card>
 


### PR DESCRIPTION
## Summary
- ScrollAreaに`max-h-[45vh]`を直接指定し縦幅の上限を設定
- 上限を超えた場合はスクロールバーが表示されスクロール可能
- 手が追加されるたびに最新手へ自動スクロール

## Test plan
- [x] 棋譜が長くなってもスクロールバーが表示されることを確認
- [x] 手を指すたびに最新手へ自動スクロールされることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)