### PR TITLE
fix: 成りダイアログの✗ボタン・外クリックで指し手をキャンセル (#19)

### DIFF
--- a/src/components/game/promotion-dialog.tsx
+++ b/src/components/game/promotion-dialog.tsx
@@ -6,16 +6,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { PIECE_DEF_MAP } from "@/lib/shogi/variants/standard";
 import type { Move } from "@/lib/shogi/types";
 
 interface PromotionDialogProps {
   move: Move | null;
   onConfirm: (promote: boolean) => void;
+  onCancel: () => void;
 }
 
-export function PromotionDialog({ move, onConfirm }: PromotionDialogProps) {
+export function PromotionDialog({ move, onConfirm, onCancel }: PromotionDialogProps) {
   if (!move) return null;
 
   const def = PIECE_DEF_MAP.get(move.piece);
@@ -23,7 +23,7 @@ export function PromotionDialog({ move, onConfirm }: PromotionDialogProps) {
   const promotedDef = promotedType ? PIECE_DEF_MAP.get(promotedType) : null;
 
   return (
-    <Dialog open={!!move} onOpenChange={() => {}}>
+    <Dialog open={!!move} onOpenChange={(open) => { if (!open) onCancel(); }}>
       <DialogContent className="max-w-xs">
         <DialogHeader>
           <DialogTitle>成りますか？</DialogTitle>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -70,6 +70,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
     selectSquare,
     selectHandPiece,
     confirmPromotion,
+    cancelPromotion,
     resign,
     undo,
     deselect,
@@ -250,6 +251,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
       <PromotionDialog
         move={promotionPendingMove}
         onConfirm={confirmPromotion}
+        onCancel={cancelPromotion}
       />
     </div>
   );

--- a/src/hooks/use-shogi-game.ts
+++ b/src/hooks/use-shogi-game.ts
@@ -36,6 +36,7 @@ type GameAction =
   | { type: "SET_AI_THINKING"; thinking: boolean }
   | { type: "SHOW_PROMOTION_DIALOG"; move: Move }
   | { type: "CONFIRM_PROMOTION"; promote: boolean }
+  | { type: "CANCEL_PROMOTION" }
   | { type: "RESIGN" }
   | { type: "UNDO" };
 
@@ -192,6 +193,14 @@ function shogiReducer(state: ShogiGameState, action: GameAction): ShogiGameState
         legalMoves: [],
       };
     }
+
+    case "CANCEL_PROMOTION":
+      return {
+        ...state,
+        promotionPendingMove: null,
+        selectedSquare: null,
+        legalMoves: [],
+      };
 
     case "RESIGN": {
       const winner: Player = state.gameState.currentPlayer === "sente" ? "gote" : "sente";
@@ -415,6 +424,10 @@ export function useShogiGame({
     dispatch({ type: "DESELECT" });
   }, []);
 
+  const cancelPromotion = useCallback(() => {
+    dispatch({ type: "CANCEL_PROMOTION" });
+  }, []);
+
   return {
     gameState: state.gameState,
     selectedSquare: state.selectedSquare,
@@ -425,6 +438,7 @@ export function useShogiGame({
     selectSquare,
     selectHandPiece,
     confirmPromotion,
+    cancelPromotion,
     resign,
     undo,
     deselect,


### PR DESCRIPTION
Closes #19