### PR TITLE
fix: 持ち駒エリア空白クリックで選択解除できるよう修正

### DIFF
--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -45,8 +45,8 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number } | null>(null);
   const boardRef = useRef<HTMLDivElement>(null);
-  const capturedPiecesAiRef = useRef<HTMLDivElement>(null);
-  const capturedPiecesPlayerRef = useRef<HTMLDivElement>(null);
+  // 持ち駒の駒をクリックした直後にdocumentリスナーがdeselect()を呼ばないようにするフラグ
+  const handPieceClickedRef = useRef(false);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -148,18 +148,24 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   }, [isReady]);
 
   // document全体のクリックで選択解除
-  // 盤面グリッド内・持ち駒エリアのクリックは除外（それぞれ独自のハンドラで処理）
+  // 盤面グリッド内クリックと持ち駒の駒クリック直後はスキップ
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (boardRef.current?.contains(target)) return;
-      if (capturedPiecesAiRef.current?.contains(target)) return;
-      if (capturedPiecesPlayerRef.current?.contains(target)) return;
+      if (boardRef.current?.contains(e.target as Node)) return;
+      if (handPieceClickedRef.current) {
+        handPieceClickedRef.current = false;
+        return;
+      }
       deselect();
     };
     document.addEventListener("click", handleClick);
     return () => document.removeEventListener("click", handleClick);
   }, [deselect]);
+
+  const handleSelectHandPiece = useCallback((pieceType: string) => {
+    handPieceClickedRef.current = true;
+    selectHandPiece(pieceType);
+  }, [selectHandPiece]);
 
   return (
     <div className="flex flex-col lg:flex-row gap-4 w-full max-w-5xl mx-auto p-4">
@@ -183,16 +189,14 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </div>
 
         {/* 後手（AI）の持ち駒 */}
-        <div ref={capturedPiecesAiRef}>
-          <CapturedPieces
-            hand={gameState.hand}
-            player={aiColor}
-            isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
-            selectedHandPiece={null}
-            onPieceClick={() => {}}
-            label={character.name}
-          />
-        </div>
+        <CapturedPieces
+          hand={gameState.hand}
+          player={aiColor}
+          isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
+          selectedHandPiece={null}
+          onPieceClick={() => {}}
+          label={character.name}
+        />
 
         {/* 将棋盤 */}
         <div className="relative">
@@ -212,16 +216,14 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </div>
 
         {/* 先手（プレイヤー）の持ち駒 */}
-        <div ref={capturedPiecesPlayerRef}>
-          <CapturedPieces
-            hand={gameState.hand}
-            player={playerColor}
-            isCurrentPlayer={isPlayerTurn && isGameActive}
-            selectedHandPiece={selectedHandPiece}
-            onPieceClick={selectHandPiece}
-            label="あなた"
-          />
-        </div>
+        <CapturedPieces
+          hand={gameState.hand}
+          player={playerColor}
+          isCurrentPlayer={isPlayerTurn && isGameActive}
+          selectedHandPiece={selectedHandPiece}
+          onPieceClick={handleSelectHandPiece}
+          label="あなた"
+        />
 
         {/* ゲームコントロール */}
         <GameControls


### PR DESCRIPTION
持ち駒の駒クリック→手駒選択（解除しない）、空白クリック→選択解除、の動作を分離。