### PR TITLE
refactor: 選択解除ロジックをシンプルなイベントバブリング方式に変更

### DIFF
--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -49,7 +49,7 @@ export function CapturedPieces({
           sortedPieces.map(({ type, count }) => (
             <button
               key={type}
-              onClick={() => isCurrentPlayer && onPieceClick(type)}
+              onClick={(e) => { if (isCurrentPlayer) { e.stopPropagation(); onPieceClick(type); } }}
               disabled={!isCurrentPlayer}
               className={cn(
                 "relative flex items-center justify-center",

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
 import type { Board, Move, Player, Position } from "@/lib/shogi/types";
@@ -22,7 +21,7 @@ const FILE_LABELS = ["9", "8", "7", "6", "5", "4", "3", "2", "1"];
 // 行ラベル（段）
 const RANK_LABELS = ["一", "二", "三", "四", "五", "六", "七", "八", "九"];
 
-export const ShogiBoard = forwardRef<HTMLDivElement, ShogiBoardProps>(function ShogiBoard({
+export function ShogiBoard({
   board,
   currentPlayer,
   playerColor,
@@ -32,7 +31,7 @@ export const ShogiBoard = forwardRef<HTMLDivElement, ShogiBoardProps>(function S
   isAiThinking,
   inCheck,
   onSquareClick,
-}, ref) {
+}: ShogiBoardProps) {
   const legalMoveSet = new Set(
     legalMoves.map((m) => `${m.to.row}-${m.to.col}`)
   );
@@ -75,7 +74,6 @@ export const ShogiBoard = forwardRef<HTMLDivElement, ShogiBoardProps>(function S
 
         {/* 盤面グリッド */}
         <div
-          ref={ref}
           className={cn(
             "grid border-2 border-amber-800",
             "relative"
@@ -98,7 +96,7 @@ export const ShogiBoard = forwardRef<HTMLDivElement, ShogiBoardProps>(function S
               return (
                 <div
                   key={`${rowIdx}-${colIdx}`}
-                  onClick={() => onSquareClick(pos)}
+                  onClick={(e) => { e.stopPropagation(); onSquareClick(pos); }}
                   className={cn(
                     "w-10 h-10 border border-amber-700/60 relative flex items-center justify-center",
                     "cursor-pointer transition-colors duration-100",
@@ -148,4 +146,4 @@ export const ShogiBoard = forwardRef<HTMLDivElement, ShogiBoardProps>(function S
 
     </div>
   );
-});
+}

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useShogiGame } from "@/hooks/use-shogi-game";
 import { useSound } from "@/hooks/use-sound";
 import { ShogiBoard } from "./shogi-board";
@@ -44,9 +44,6 @@ interface ShogiGameProps {
 export function ShogiGame({ initialGameState, gameId, gameConfig: serializableConfig }: ShogiGameProps) {
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number } | null>(null);
-  const boardRef = useRef<HTMLDivElement>(null);
-  // 持ち駒の駒をクリックした直後にdocumentリスナーがdeselect()を呼ばないようにするフラグ
-  const handPieceClickedRef = useRef(false);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -147,28 +144,9 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
     setTimeout(() => handleComment("game_start"), 500);
   }, [isReady]);
 
-  // document全体のクリックで選択解除
-  // 盤面グリッド内クリックと持ち駒の駒クリック直後はスキップ
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (boardRef.current?.contains(e.target as Node)) return;
-      if (handPieceClickedRef.current) {
-        handPieceClickedRef.current = false;
-        return;
-      }
-      deselect();
-    };
-    document.addEventListener("click", handleClick);
-    return () => document.removeEventListener("click", handleClick);
-  }, [deselect]);
-
-  const handleSelectHandPiece = useCallback((pieceType: string) => {
-    handPieceClickedRef.current = true;
-    selectHandPiece(pieceType);
-  }, [selectHandPiece]);
 
   return (
-    <div className="flex flex-col lg:flex-row gap-4 w-full max-w-5xl mx-auto p-4">
+    <div className="flex flex-col lg:flex-row gap-4 w-full max-w-5xl mx-auto p-4" onClick={deselect}>
       {/* メインエリア */}
       <div className="flex flex-col gap-3 flex-1">
         {/* ステータスバー */}
@@ -201,7 +179,6 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         {/* 将棋盤 */}
         <div className="relative">
           <ShogiBoard
-            ref={boardRef}
             board={gameState.board}
             currentPlayer={gameState.currentPlayer}
             playerColor={playerColor}
@@ -221,7 +198,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
           player={playerColor}
           isCurrentPlayer={isPlayerTurn && isGameActive}
           selectedHandPiece={selectedHandPiece}
-          onPieceClick={handleSelectHandPiece}
+          onPieceClick={selectHandPiece}
           label="あなた"
         />
 


### PR DESCRIPTION
documentリスナー・boardRef・handPieceClickedRefフラグを廃止。最外側divのonClickでデセレクト、盤面マス・持ち駒ボタンのstopPropagationで伝搬を止めるシンプルな構成に変更。