### PR TITLE
fix: 幅固定対応 - 持ち駒欄と棋譜欄の高さを固定

### DIFF
--- a/src/components/game/move-history.tsx
+++ b/src/components/game/move-history.tsx
@@ -13,7 +13,7 @@ export function MoveHistory({ moves }: MoveHistoryProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="text-sm font-medium text-muted-foreground mb-1">棋譜</div>
-      <ScrollArea className="max-h-[45vh] border rounded-md bg-muted/30">
+      <ScrollArea className="h-full border rounded-md bg-muted/30">
         <div className="p-2 space-y-0.5">
           {moves.length === 0 ? (
             <p className="text-xs text-muted-foreground p-2">棋譜はまだありません</p>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -178,14 +178,16 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </div>
 
         {/* 後手（AI）の持ち駒 */}
-        <CapturedPieces
-          hand={gameState.hand}
-          player={aiColor}
-          isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
-          selectedHandPiece={null}
-          onPieceClick={() => {}}
-          label={character.name}
-        />
+        <div className="h-20">
+          <CapturedPieces
+            hand={gameState.hand}
+            player={aiColor}
+            isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
+            selectedHandPiece={null}
+            onPieceClick={() => {}}
+            label={character.name}
+          />
+        </div>
 
         {/* 将棋盤 */}
         <div className="relative">
@@ -204,14 +206,16 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </div>
 
         {/* 先手（プレイヤー）の持ち駒 */}
-        <CapturedPieces
-          hand={gameState.hand}
-          player={playerColor}
-          isCurrentPlayer={isPlayerTurn && isGameActive}
-          selectedHandPiece={selectedHandPiece}
-          onPieceClick={selectHandPiece}
-          label="あなた"
-        />
+        <div className="h-20">
+          <CapturedPieces
+            hand={gameState.hand}
+            player={playerColor}
+            isCurrentPlayer={isPlayerTurn && isGameActive}
+            selectedHandPiece={selectedHandPiece}
+            onPieceClick={selectHandPiece}
+            label="あなた"
+          />
+        </div>
 
         {/* ゲームコントロール */}
         <GameControls
@@ -236,7 +240,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         </Card>
 
         {/* 棋譜 */}
-        <Card className="p-3 flex-1 min-h-48">
+        <Card className="p-3 h-64">
           <MoveHistory moves={gameState.moveHistory} />
         </Card>
 


### PR DESCRIPTION
## Summary
- AI・プレイヤー両方の持ち駒欄を `h-20` ラッパーで固定（駒増加による高さ変動を防止）
- 棋譜欄カードを `h-64` に固定（ゲーム進行による伸縮を防止）
- MoveHistory の ScrollArea を `h-full` に変更しスクロールが正常に機能するよう調整

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)