### PR TITLE
fix: モバイルUI/UX微調整 — スクロール・ズーム・レイアウト修正 (#46)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,12 +127,13 @@
   html {
     @apply font-sans;
     overscroll-behavior: none;
+    touch-action: manipulation;
   }
 }
 
 /* ゲーム盤面のタッチ操作最適化 */
 .shogi-game-area {
-  touch-action: manipulation;
+  touch-action: pan-x pan-y;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -26,6 +26,27 @@ export default function Home() {
   const [isLoading, setIsLoading] = useState(false);
   const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty>("beginner");
   const [selectedColor, setSelectedColor] = useState<ColorOption>("sente");
+
+  // Safari互換: CSS 100dvh ではなく JS window.innerHeight を使用
+  const [viewportHeight, setViewportHeight] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const update = () => setViewportHeight(window.innerHeight);
+    update();
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const handleResize = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(update, 100);
+    };
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("orientationchange", handleResize);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("orientationchange", handleResize);
+    };
+  }, []);
 
   const selectedCharacter = CHARACTERS.find((c) => c.difficulty === selectedDifficulty)!;
 
@@ -58,7 +79,10 @@ export default function Home() {
   ];
 
   return (
-    <main className="h-[100dvh] h-screen flex flex-col bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background safe-area-inset overflow-hidden">
+    <main
+      className="flex flex-col bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background safe-area-inset overflow-hidden"
+      style={{ height: viewportHeight ?? "100dvh" }}
+    >
       {/* ヘッダー */}
       <div className="relative text-center py-4 sm:py-8 px-4 shrink-0">
         <div className="absolute top-3 right-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,17 +68,57 @@ export default function Home() {
         <p className="text-sm text-muted-foreground">AIと対局しよう</p>
       </div>
 
-      <div className="flex-1 overflow-y-auto max-w-2xl mx-auto w-full px-4 pb-4 space-y-4">
+      <div className="flex-1 flex flex-col max-w-2xl mx-auto w-full px-4 pb-4 space-y-3 sm:space-y-4 min-h-0">
         {/* 難易度・キャラクター選択 */}
-        <Card>
-          <CardHeader>
+        <Card className="shrink-0">
+          <CardHeader className="pb-2 sm:pb-3">
             <CardTitle className="text-base flex items-center gap-2">
               <Swords className="w-4 h-4" />
               対局相手を選ぶ
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <CardContent className="pb-3">
+            {/* モバイル: コンパクトリスト / デスクトップ: カードグリッド */}
+            <div className="sm:hidden flex flex-col gap-1.5">
+              {CHARACTERS.map((character) => {
+                const diffInfo = DIFFICULTY_INFO[character.difficulty];
+                const isSelected = selectedDifficulty === character.difficulty;
+
+                return (
+                  <button
+                    key={character.id}
+                    onClick={() => setSelectedDifficulty(character.difficulty)}
+                    className={cn(
+                      "flex items-center gap-3 px-3 py-2.5 rounded-lg border-2 text-left transition-all",
+                      "cursor-pointer",
+                      isSelected
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-primary/40"
+                    )}
+                  >
+                    <span className="text-2xl shrink-0">{character.avatarEmoji}</span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-bold text-sm">{character.name}</span>
+                        <Badge
+                          variant="outline"
+                          className={cn("text-[10px] px-1.5 py-0", diffInfo.color)}
+                        >
+                          {diffInfo.label}
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-muted-foreground">{character.title}</div>
+                    </div>
+                    {isSelected && (
+                      <div className="w-2 h-2 rounded-full bg-primary shrink-0" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* デスクトップ: 従来のカードグリッド */}
+            <div className="hidden sm:grid grid-cols-3 gap-3">
               {CHARACTERS.map((character) => {
                 const diffInfo = DIFFICULTY_INFO[character.difficulty];
                 const isSelected = selectedDifficulty === character.difficulty;
@@ -118,12 +158,32 @@ export default function Home() {
         </Card>
 
         {/* 手番選択 */}
-        <Card>
-          <CardHeader>
+        <Card className="shrink-0">
+          <CardHeader className="pb-2 sm:pb-3">
             <CardTitle className="text-base">手番を選ぶ</CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-3 gap-3">
+          <CardContent className="pb-3">
+            {/* モバイル: コンパクト横並び / デスクトップ: カードグリッド */}
+            <div className="sm:hidden flex gap-2">
+              {colorOptions.map(({ value, icon, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setSelectedColor(value)}
+                  className={cn(
+                    "flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-lg border-2 transition-all cursor-pointer",
+                    selectedColor === value
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:border-primary/40"
+                  )}
+                >
+                  <span className="text-base">{icon}</span>
+                  <span className="font-medium text-xs">{label}</span>
+                </button>
+              ))}
+            </div>
+
+            {/* デスクトップ: 従来のカードグリッド */}
+            <div className="hidden sm:grid grid-cols-3 gap-3">
               {colorOptions.map(({ value, icon, label, desc }) => (
                 <button
                   key={value}
@@ -145,10 +205,13 @@ export default function Home() {
           </CardContent>
         </Card>
 
+        {/* スペーサー（モバイルでボタンを下寄せ） */}
+        <div className="flex-1 sm:hidden" />
+
         {/* 対局開始ボタン */}
         <Button
           size="lg"
-          className="w-full text-base py-6"
+          className="w-full text-base py-6 sm:py-6 shrink-0"
           onClick={handleStart}
           disabled={isLoading}
         >
@@ -163,7 +226,7 @@ export default function Home() {
         </Button>
 
         {/* 棋譜履歴へのリンク */}
-        <div className="text-center">
+        <div className="text-center shrink-0">
           <Link
             href="/history"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,17 +58,17 @@ export default function Home() {
   ];
 
   return (
-    <main className="min-h-[100dvh] min-h-screen bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background safe-area-inset">
+    <main className="h-[100dvh] h-screen flex flex-col bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background safe-area-inset overflow-hidden">
       {/* ヘッダー */}
-      <div className="relative text-center py-10 px-4">
-        <div className="absolute top-4 right-4">
+      <div className="relative text-center py-4 sm:py-8 px-4 shrink-0">
+        <div className="absolute top-3 right-4">
           <ThemeSelector />
         </div>
-        <h1 className="text-4xl font-bold tracking-tight mb-2">将棋</h1>
-        <p className="text-muted-foreground">AIと対局しよう</p>
+        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-1">将棋</h1>
+        <p className="text-sm text-muted-foreground">AIと対局しよう</p>
       </div>
 
-      <div className="max-w-2xl mx-auto px-4 pb-12 space-y-6">
+      <div className="flex-1 overflow-y-auto max-w-2xl mx-auto w-full px-4 pb-4 space-y-4">
         {/* 難易度・キャラクター選択 */}
         <Card>
           <CardHeader>

--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -18,6 +18,9 @@ interface CapturedPiecesProps {
 // 手駒の表示順
 const HAND_PIECE_ORDER = ["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"];
 
+// 固定高さ: 52px（ラベル14px + gap2px + 駒行36px = 52px）
+export const CAPTURED_PIECES_HEIGHT = 52;
+
 export function CapturedPieces({
   hand,
   player,
@@ -41,8 +44,9 @@ export function CapturedPieces({
         "px-2 py-1.5 rounded-lg border overflow-hidden",
         isCurrentPlayer ? "border-primary bg-primary/5" : "border-border bg-muted/30"
       )}
+      style={{ height: CAPTURED_PIECES_HEIGHT }}
     >
-      <div className="text-xs text-muted-foreground mb-0.5 font-medium">{label}の持ち駒</div>
+      <div className="text-xs text-muted-foreground mb-0.5 font-medium leading-none">{label}の持ち駒</div>
       <div className="flex flex-wrap gap-1">
         {sortedPieces.length === 0 ? (
           <span className="text-xs text-muted-foreground">なし</span>

--- a/src/components/game/game-controls.tsx
+++ b/src/components/game/game-controls.tsx
@@ -20,6 +20,9 @@ interface GameControlsProps {
   gameActive: boolean;
 }
 
+// 固定高さ: 36px
+export const GAME_CONTROLS_HEIGHT = 36;
+
 export function GameControls({
   onResign,
   onUndo,
@@ -32,7 +35,10 @@ export function GameControls({
 
   return (
     <>
-      <div className="flex gap-2 flex-wrap">
+      <div
+        className="flex gap-2 flex-wrap items-center"
+        style={{ height: GAME_CONTROLS_HEIGHT }}
+      >
         <Button
           variant="outline"
           size="sm"

--- a/src/components/game/mobile-drawer.tsx
+++ b/src/components/game/mobile-drawer.tsx
@@ -43,6 +43,30 @@ export function MobileDrawer({
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-20 safe-area-bottom">
+      {/* ゲーム終了表示（ドロワー外・タブバー上に常時表示） */}
+      {!isGameActive && (
+        <div
+          className="bg-card/95 backdrop-blur-sm border-t border-border px-3 py-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5">
+            <p className="text-sm font-bold mb-2">
+              {gameResultText(gameStatus, gameWinner)}
+            </p>
+            <div className="flex gap-2 justify-center">
+              <Link href="/">
+                <Button size="sm" variant="outline">
+                  ホームへ
+                </Button>
+              </Link>
+              <Button size="sm" onClick={onPlayAgain} disabled={isPending}>
+                {isPending ? "準備中..." : "もう一局"}
+              </Button>
+            </div>
+          </Card>
+        </div>
+      )}
+
       {/* タブバー（常に表示） */}
       <div
         className={cn(
@@ -101,27 +125,6 @@ export function MobileDrawer({
             </div>
           )}
         </div>
-
-        {/* ゲーム終了表示 */}
-        {!isGameActive && (
-          <div className="px-3 pb-3">
-            <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5">
-              <p className="text-sm font-bold mb-2">
-                {gameResultText(gameStatus, gameWinner)}
-              </p>
-              <div className="flex gap-2 justify-center">
-                <Link href="/">
-                  <Button size="sm" variant="outline">
-                    ホームへ
-                  </Button>
-                </Link>
-                <Button size="sm" onClick={onPlayAgain} disabled={isPending}>
-                  {isPending ? "準備中..." : "もう一局"}
-                </Button>
-              </div>
-            </Card>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -160,12 +160,12 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   }, [isReady]);
 
   return (
-    <div className="shogi-game-area h-[100dvh] h-[100vh] w-full safe-area-inset" onClick={deselect}>
-      <div className="flex flex-col lg:flex-row h-full w-full max-w-5xl mx-auto">
+    <div className="shogi-game-area h-[100dvh] h-screen w-full" onClick={deselect}>
+      <div className="flex flex-col lg:flex-row h-full w-full max-w-5xl mx-auto overflow-hidden">
         {/* メインエリア */}
-        <div className="flex flex-col items-center flex-1 min-h-0 px-2 py-1 lg:py-2">
-          {/* ステータスバー */}
-          <div className="flex items-center justify-between w-full px-1 py-1 shrink-0">
+        <div className="flex flex-col items-center flex-1 min-h-0 px-2 py-0.5 lg:py-2">
+          {/* ステータスバー（固定高さ 28px） */}
+          <div className="flex items-center justify-between w-full px-1 shrink-0" style={{ height: 28 }}>
             <div className="flex items-center gap-2">
               <Badge variant={isPlayerTurn ? "default" : "secondary"} className="text-xs">
                 {isPlayerTurn ? "あなたの番" : "相手の番"}
@@ -199,7 +199,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
           </div>
 
           {/* 将棋盤 */}
-          <div className="relative shrink-0 my-1">
+          <div className="relative shrink-0 my-0.5">
             <ShogiBoard
               board={gameState.board}
               currentPlayer={gameState.currentPlayer}
@@ -230,7 +230,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
           </div>
 
           {/* ゲームコントロール */}
-          <div className="shrink-0 mt-1">
+          <div className="shrink-0 mt-0.5">
             <GameControls
               onResign={resign}
               onUndo={undo}

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -58,7 +58,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number } | null>(null);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const { squareSize } = useBoardSize();
+  const { squareSize, viewportHeight } = useBoardSize();
 
   // クライアント側でバリアントを復元（関数を含むため props では渡せない）
   const gameConfig: GameConfig = {
@@ -160,7 +160,11 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   }, [isReady]);
 
   return (
-    <div className="shogi-game-area h-[100dvh] h-screen w-full" onClick={deselect}>
+    <div
+      className="shogi-game-area w-full overflow-hidden"
+      style={{ height: viewportHeight }}
+      onClick={deselect}
+    >
       <div className="flex flex-col lg:flex-row h-full w-full max-w-5xl mx-auto overflow-hidden">
         {/* メインエリア */}
         <div className="flex flex-col items-center flex-1 min-h-0 px-2 py-0.5 lg:py-2">

--- a/src/components/sw-register.tsx
+++ b/src/components/sw-register.tsx
@@ -4,11 +4,26 @@ import { useEffect } from "react";
 
 export function ServiceWorkerRegister() {
   useEffect(() => {
+    // Service Worker登録
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.register("/sw.js").catch(() => {
         // SW登録失敗は無視（開発環境など）
       });
     }
+
+    // iOS Safari向け: ピンチズームを完全に無効化
+    // gesturestart/gesturechange はiOS Safari固有のイベントで、
+    // CSS touch-action だけでは防げないピンチ操作を抑制する
+    const preventGesture = (e: Event) => {
+      e.preventDefault();
+    };
+    document.addEventListener("gesturestart", preventGesture, { passive: false });
+    document.addEventListener("gesturechange", preventGesture, { passive: false });
+
+    return () => {
+      document.removeEventListener("gesturestart", preventGesture);
+      document.removeEventListener("gesturechange", preventGesture);
+    };
   }, []);
 
   return null;

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -7,44 +7,35 @@ interface BoardSize {
   isReady: boolean;
 }
 
-// 予約スペース（px）
-const VERTICAL_RESERVED = {
-  statusBar: 36,
-  capturedPiecesX2: 96,
-  controls: 44,
-  gaps: 32,
-  safeArea: 0,
-};
+// 各エリアの固定高さ（px） — コンポーネントと同期させること
+const STATUS_BAR_HEIGHT = 28;
+const CAPTURED_PIECES_HEIGHT = 52; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
+const GAME_CONTROLS_HEIGHT = 36;  // game-controls.tsx の GAME_CONTROLS_HEIGHT と同値
+const MOBILE_DRAWER_TAB_HEIGHT = 40; // mobile-drawer.tsx のタブバー高さ
+const BOARD_LABEL_HEIGHT = 16; // ファイルラベル（上）
+const GAPS = 20; // マージン・パディング合計
+
+const VERTICAL_RESERVED =
+  STATUS_BAR_HEIGHT +
+  CAPTURED_PIECES_HEIGHT * 2 +
+  GAME_CONTROLS_HEIGHT +
+  MOBILE_DRAWER_TAB_HEIGHT +
+  BOARD_LABEL_HEIGHT +
+  GAPS;
 
 const MIN_SQUARE_SIZE = 32;
 const MAX_SQUARE_SIZE = 64;
 const HORIZONTAL_PADDING = 48; // 左右パディング + ラベル分
 const BOARD_CELLS = 9;
 
-function getSafeAreaInset(): number {
-  if (typeof window === "undefined") return 0;
-  const style = getComputedStyle(document.documentElement);
-  const top = parseInt(style.getPropertyValue("env(safe-area-inset-top)") || "0", 10);
-  const bottom = parseInt(style.getPropertyValue("env(safe-area-inset-bottom)") || "0", 10);
-  return (isNaN(top) ? 0 : top) + (isNaN(bottom) ? 0 : bottom);
-}
-
 function calculateSquareSize(): number {
   if (typeof window === "undefined") return 40;
 
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  const safeArea = getSafeAreaInset();
-
-  const reservedV =
-    VERTICAL_RESERVED.statusBar +
-    VERTICAL_RESERVED.capturedPiecesX2 +
-    VERTICAL_RESERVED.controls +
-    VERTICAL_RESERVED.gaps +
-    safeArea;
 
   const availableWidth = vw - HORIZONTAL_PADDING;
-  const availableHeight = vh - reservedV;
+  const availableHeight = vh - VERTICAL_RESERVED;
 
   const fromWidth = Math.floor(availableWidth / BOARD_CELLS);
   const fromHeight = Math.floor(availableHeight / BOARD_CELLS);

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 
 interface BoardSize {
   squareSize: number;
+  viewportHeight: number;
   isReady: boolean;
 }
 
@@ -28,10 +29,11 @@ const MAX_SQUARE_SIZE = 64;
 const HORIZONTAL_PADDING = 48; // 左右パディング + ラベル分
 const BOARD_CELLS = 9;
 
-function calculateSquareSize(): number {
-  if (typeof window === "undefined") return 40;
+function calculate(): { squareSize: number; viewportHeight: number } {
+  if (typeof window === "undefined") return { squareSize: 40, viewportHeight: 800 };
 
   const vw = window.innerWidth;
+  // window.innerHeight は iOS Safari でもアドレスバー込みの実際の表示領域を返す
   const vh = window.innerHeight;
 
   const availableWidth = vw - HORIZONTAL_PADDING;
@@ -40,15 +42,19 @@ function calculateSquareSize(): number {
   const fromWidth = Math.floor(availableWidth / BOARD_CELLS);
   const fromHeight = Math.floor(availableHeight / BOARD_CELLS);
 
-  return Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, fromWidth, fromHeight));
+  const squareSize = Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, fromWidth, fromHeight));
+  return { squareSize, viewportHeight: vh };
 }
 
 export function useBoardSize(): BoardSize {
   const [squareSize, setSquareSize] = useState(40);
+  const [viewportHeight, setViewportHeight] = useState(800);
   const [isReady, setIsReady] = useState(false);
 
   const recalculate = useCallback(() => {
-    setSquareSize(calculateSquareSize());
+    const result = calculate();
+    setSquareSize(result.squareSize);
+    setViewportHeight(result.viewportHeight);
   }, []);
 
   useEffect(() => {
@@ -71,5 +77,5 @@ export function useBoardSize(): BoardSize {
     };
   }, [recalculate]);
 
-  return { squareSize, isReady };
+  return { squareSize, viewportHeight, isReady };
 }


### PR DESCRIPTION
## Summary
- モバイル対局画面・ホーム画面の縦スクロール解消（CSS `100dvh` → JS `window.innerHeight` でSafari互換）
- iOS Safariピンチズーム無効化（CSS `touch-action` + JS `gesturestart`/`gesturechange` preventDefault）
- モバイル終局ポップアップをドロワー外に移動し常時表示化
- 持ち駒・コントロールバー・ステータスバーの高さ固定化（レイアウトシフト防止）
- ホーム画面の対局相手・手番選択をモバイル向けコンパクトリスト形式に変更

## Changed files
- `src/app/page.tsx` — モバイルレイアウトコンパクト化 + Safari高さ修正
- `src/components/game/shogi-game.tsx` — JS viewportHeight使用、固定高さ適用
- `src/hooks/use-board-size.ts` — VERTICAL_RESERVED再計算
- `src/components/game/mobile-drawer.tsx` — 終局カードをドロワー外に移動
- `src/components/game/captured-pieces.tsx` — 高さ固定化 (52px)
- `src/components/game/game-controls.tsx` — 高さ固定化 (36px)
- `src/app/globals.css` — touch-action: pan-x pan-y 追加
- `src/components/sw-register.tsx` — iOS gestureイベント抑制追加

## Test plan
- [x] iPhone 17e Safari/Chrome でホーム画面スクロールなし確認
- [x] iPhone 17e Safari/Chrome で対局画面スクロールなし確認
- [x] ピンチズーム無効化（実機確認）
- [x] モバイル終局時「ホームへ」「もう一局」常時表示
- [x] デスクトップ表示の回帰確認
- [x] `npx next build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)