### PR TITLE
feat: Noto Sans JPでPC/モバイルのフォントを統一 (Issue #53)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-geist-sans), var(--font-noto-sans-jp), sans-serif;
   --font-mono: var(--font-geist-mono);
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ServiceWorkerRegister } from "@/components/sw-register";
@@ -13,6 +13,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const notoSansJP = Noto_Sans_JP({
+  variable: "--font-noto-sans-jp",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  display: "swap",
 });
 
 // 駒字・オーバーレイに使う文字のみのサブセット（約10KB）を自己ホスト。
@@ -59,7 +66,7 @@ export default function RootLayout({
     <html
       lang="ja"
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable} ${yujiBoku.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${yujiBoku.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <ThemeProvider>


### PR DESCRIPTION
## Summary

- `--font-sans` が自己参照になっておりOS標準フォントにフォールバックしていた問題を修正
- Noto Sans JP を全プラットフォームで統一的に適用

**フォントスタック:**
- Latin文字 → Geist Sans（UI向けモダンフォント）
- 日本語文字 → Noto Sans JP（Google製、iOS/Android/Windows/macOS全て対応）
- 将棋駒の文字 → Yuji Boku（変更なし）

Closes #53

## Test plan

- [ ] PC（Chrome）でUIテキストのフォントが Noto Sans JP になっているか確認
- [ ] iOS Safari でフォントが統一されているか確認
- [ ] Android Chrome でフォントが統一されているか確認
- [ ] 将棋駒の文字（Yuji Boku）が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)