### PR TITLE
fix: モバイルのタップ操作感を改善 (Issue #52)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-geist-sans), var(--font-noto-sans-jp), sans-serif;
   --font-mono: var(--font-geist-mono);
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,6 +140,26 @@
   overscroll-behavior: none;
 }
 
+/* 将棋盤マスのタッチフィードバック */
+.shogi-square {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.shogi-square:active {
+  filter: brightness(0.88);
+  transition: filter 0ms;
+}
+
+/* 持ち駒ボタンのタッチフィードバック */
+.captured-piece-btn {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.captured-piece-btn:active {
+  transform: scale(0.90);
+  transition: transform 0ms;
+}
+
 /* Safe Area対応 */
 @supports (padding-top: env(safe-area-inset-top)) {
   .safe-area-top { padding-top: env(safe-area-inset-top); }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ServiceWorkerRegister } from "@/components/sw-register";
@@ -13,6 +13,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const notoSansJP = Noto_Sans_JP({
+  variable: "--font-noto-sans-jp",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  display: "swap",
 });
 
 // 駒字・オーバーレイに使う文字のみのサブセット（約10KB）を自己ホスト。
@@ -59,7 +66,7 @@ export default function RootLayout({
     <html
       lang="ja"
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable} ${yujiBoku.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${yujiBoku.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <ThemeProvider>

--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -18,8 +18,8 @@ interface CapturedPiecesProps {
 // 手駒の表示順
 const HAND_PIECE_ORDER = ["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"];
 
-// 固定高さ: 52px（ラベル14px + gap2px + 駒行36px = 52px）
-export const CAPTURED_PIECES_HEIGHT = 52;
+// 固定高さ: 56px（ラベル14px + gap2px + 駒行40px = 56px）
+export const CAPTURED_PIECES_HEIGHT = 56;
 
 export function CapturedPieces({
   hand,
@@ -36,7 +36,7 @@ export function CapturedPieces({
     (type) => (pieces[type] ?? 0) > 0
   ).map((type) => ({ type, count: pieces[type]! }));
 
-  const handPieceSize = Math.max(28, Math.min(36, squareSize * 0.8));
+  const handPieceSize = Math.max(36, Math.min(44, squareSize * 0.85));
 
   return (
     <div
@@ -57,7 +57,7 @@ export function CapturedPieces({
               onClick={(e) => { if (isCurrentPlayer) { e.stopPropagation(); onPieceClick(type); } }}
               disabled={!isCurrentPlayer}
               className={cn(
-                "relative rounded-sm flex items-center justify-center",
+                "captured-piece-btn relative rounded-sm flex items-center justify-center",
                 isCurrentPlayer && "cursor-pointer",
                 !isCurrentPlayer && "cursor-default opacity-80",
                 selectedHandPiece === type && isCurrentPlayer && "ring-2 ring-blue-500",

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
+import { useTouchHandler } from "@/hooks/use-touch-handler";
 import type { Board, Move, Player, Position } from "@/lib/shogi/types";
 
 interface ShogiBoardProps {
@@ -41,6 +42,15 @@ export function ShogiBoard({
     legalMoves.map((m) => `${m.to.row}-${m.to.col}`)
   );
 
+  const isGote = playerColor === "gote";
+  const { gridRef, pointerHandlers } = useTouchHandler({
+    squareSize,
+    legalMoves,
+    selectedSquare,
+    isGote,
+    onSquareClick,
+  });
+
   const isLastMoveSquare = (row: number, col: number) => {
     if (!lastMove) return false;
     const matchTo = lastMove.to.row === row && lastMove.to.col === col;
@@ -49,7 +59,6 @@ export function ShogiBoard({
   };
 
   const isPlayerTurn = currentPlayer === playerColor;
-  const isGote = playerColor === "gote";
 
   // 後手番時は行・列を逆順にして後手目線の盤面にする
   const rowIndices = isGote ? [8, 7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7, 8];
@@ -91,13 +100,17 @@ export function ShogiBoard({
 
         {/* 盤面グリッド */}
         <div
+          ref={gridRef}
           role="grid"
           aria-label="将棋盤"
           className="grid border-2 border-amber-800 dark:border-amber-600 relative"
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,
+            touchAction: "none",
           }}
+          onClick={(e) => e.stopPropagation()}
+          {...pointerHandlers}
         >
           {rowIndices.map((rowIdx) =>
             colIndices.map((colIdx) => {
@@ -116,10 +129,10 @@ export function ShogiBoard({
               return (
                 <div
                   key={`${rowIdx}-${colIdx}`}
-                  onClick={(e) => { e.stopPropagation(); onSquareClick(pos); }}
+                  data-legal={isLegalTarget}
                   className={cn(
-                    "border border-amber-700/60 dark:border-amber-600/40 relative flex items-center justify-center",
-                    "cursor-pointer transition-colors duration-100",
+                    "shogi-square border border-amber-700/60 dark:border-amber-600/40 relative flex items-center justify-center",
+                    "cursor-pointer",
                     // 通常背景
                     "bg-amber-50 dark:bg-amber-900/40",
                     // 直前の手（移動前・移動後）

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -10,7 +10,7 @@ interface BoardSize {
 
 // 各エリアの固定高さ（px） — コンポーネントと同期させること
 const STATUS_BAR_HEIGHT = 28;
-const CAPTURED_PIECES_HEIGHT = 52; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
+const CAPTURED_PIECES_HEIGHT = 56; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
 const GAME_CONTROLS_HEIGHT = 36;  // game-controls.tsx の GAME_CONTROLS_HEIGHT と同値
 const MOBILE_DRAWER_TAB_HEIGHT = 40; // mobile-drawer.tsx のタブバー高さ
 const BOARD_LABEL_HEIGHT = 16; // ファイルラベル（上）
@@ -24,9 +24,9 @@ const VERTICAL_RESERVED =
   BOARD_LABEL_HEIGHT +
   GAPS;
 
-const MIN_SQUARE_SIZE = 32;
+const MIN_SQUARE_SIZE = 36;
 const MAX_SQUARE_SIZE = 64;
-const HORIZONTAL_PADDING = 48; // 左右パディング + ラベル分
+const HORIZONTAL_PADDING = 40; // 左右パディング + ラベル分
 const BOARD_CELLS = 9;
 
 function calculate(): { squareSize: number; viewportHeight: number } {

--- a/src/hooks/use-touch-handler.ts
+++ b/src/hooks/use-touch-handler.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import type { Move, Position } from "@/lib/shogi/types";
+
+interface UseTouchHandlerOptions {
+  squareSize: number;
+  legalMoves: Move[];
+  selectedSquare: Position | null;
+  isGote: boolean;
+  onSquareClick: (pos: Position) => void;
+}
+
+// タップ位置から合法手マスへのスナップ補正閾値（マスサイズの40%）
+const SNAP_THRESHOLD_RATIO = 0.4;
+
+export function useTouchHandler({
+  squareSize,
+  legalMoves,
+  selectedSquare,
+  isGote,
+  onSquareClick,
+}: UseTouchHandlerOptions) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  // pointerdown時の座標を記録（スクロールとタップを区別するため）
+  const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+
+  const getGridPosition = useCallback(
+    (clientX: number, clientY: number): Position | null => {
+      const grid = gridRef.current;
+      if (!grid) return null;
+
+      const rect = grid.getBoundingClientRect();
+      const relX = clientX - rect.left;
+      const relY = clientY - rect.top;
+
+      // グリッド外ならnull
+      if (relX < 0 || relY < 0 || relX >= rect.width || relY >= rect.height) {
+        return null;
+      }
+
+      const rawCol = Math.floor(relX / squareSize);
+      const rawRow = Math.floor(relY / squareSize);
+
+      // 後手時は行・列を反転（isGoteの場合rowIndices/colIndicesが逆順）
+      const col = isGote ? 8 - rawCol : rawCol;
+      const row = isGote ? 8 - rawRow : rawRow;
+
+      if (row < 0 || row > 8 || col < 0 || col > 8) return null;
+
+      return { row, col };
+    },
+    [squareSize, isGote]
+  );
+
+  const snapToLegalMove = useCallback(
+    (clientX: number, clientY: number, rawPos: Position): Position => {
+      // 駒が選択されていない場合はスナップ不要
+      if (!selectedSquare) return rawPos;
+
+      const legalTargets = legalMoves.filter((m) => m.type === "move" || m.type === "drop");
+      if (legalTargets.length === 0) return rawPos;
+
+      // タップした座標が既に合法手マスなら補正不要
+      const isAlreadyLegal = legalTargets.some(
+        (m) => m.to.row === rawPos.row && m.to.col === rawPos.col
+      );
+      if (isAlreadyLegal) return rawPos;
+
+      const grid = gridRef.current;
+      if (!grid) return rawPos;
+
+      const rect = grid.getBoundingClientRect();
+      const relX = clientX - rect.left;
+      const relY = clientY - rect.top;
+
+      const threshold = squareSize * SNAP_THRESHOLD_RATIO;
+
+      let nearestTarget: Position | null = null;
+      let minDistance = Infinity;
+
+      for (const move of legalTargets) {
+        const { row: targetRow, col: targetCol } = move.to;
+
+        // 後手時は表示上の行・列を変換
+        const displayRow = isGote ? 8 - targetRow : targetRow;
+        const displayCol = isGote ? 8 - targetCol : targetCol;
+
+        // マスの中心座標（グリッド相対）
+        const centerX = (displayCol + 0.5) * squareSize;
+        const centerY = (displayRow + 0.5) * squareSize;
+
+        const dist = Math.hypot(relX - centerX, relY - centerY);
+        if (dist < minDistance) {
+          minDistance = dist;
+          nearestTarget = move.to;
+        }
+      }
+
+      // 閾値以内の合法手マスがあればスナップ
+      if (nearestTarget && minDistance < threshold) {
+        return nearestTarget;
+      }
+
+      return rawPos;
+    },
+    [selectedSquare, legalMoves, squareSize, isGote]
+  );
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    pointerDownPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // pointerdownがなければ無視
+      if (!pointerDownPos.current) return;
+
+      const downPos = pointerDownPos.current;
+      pointerDownPos.current = null;
+
+      // pointerdown→pointerup間の移動量が大きければスクロール扱いでスキップ
+      const dx = Math.abs(e.clientX - downPos.x);
+      const dy = Math.abs(e.clientY - downPos.y);
+      if (dx > 8 || dy > 8) return;
+
+      const rawPos = getGridPosition(e.clientX, e.clientY);
+      if (!rawPos) return;
+
+      const finalPos = snapToLegalMove(e.clientX, e.clientY, rawPos);
+
+      // ハプティックフィードバック（Android対応、iOS非対応だが害はない）
+      if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+        navigator.vibrate(8);
+      }
+
+      // clickイベントの二重発火を防ぐ（preventDefault でブラウザのclick合成を抑制）
+      e.preventDefault();
+      e.stopPropagation();
+      onSquareClick(finalPos);
+    },
+    [getGridPosition, snapToLegalMove, onSquareClick]
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    pointerDownPos.current = null;
+  }, []);
+
+  return {
+    gridRef,
+    pointerHandlers: {
+      onPointerDown: handlePointerDown,
+      onPointerUp: handlePointerUp,
+      onPointerCancel: handlePointerCancel,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- PointerEvents APIによるグリッドレベルのタップハンドラを実装し、81個の個別onClickを統一
- 駒選択済み時に合法手マスへのスナップ補正を追加（閾値: マスサイズの40%以内）
- 最小マスサイズを32px→36pxに拡大、持ち駒タッチターゲットを28-36px→36-44pxに拡大
- タップ時の即時視覚フィードバック（`:active`輝度変化）を追加
- Androidデバイス向けハプティックフィードバックを追加

Closes #52

## Test plan
- [ ] Chrome DevToolsのモバイルエミュレーション（iPhone SE, iPhone 14等）で動作確認
- [ ] 歩を選択→前1マスへの移動がスムーズにできることを確認
- [ ] 飛車・角等の大駒の移動操作を確認
- [ ] 持ち駒の選択→打ち駒操作を確認
- [ ] 駒選択中に別の自駒をタップ→正しく選択変更されることを確認
- [ ] 盤外タップ→選択解除されることを確認
- [ ] デスクトップブラウザでの既存操作が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)