### PR TITLE
fix: PC版で持ち駒が見切れる問題を修正 (Issue #58)

### DIFF
--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -18,8 +18,10 @@ interface CapturedPiecesProps {
 // 手駒の表示順
 const HAND_PIECE_ORDER = ["rook", "bishop", "gold", "silver", "knight", "lance", "pawn"];
 
-// 固定高さ: 56px（ラベル14px + gap2px + 駒行40px = 56px）
-export const CAPTURED_PIECES_HEIGHT = 56;
+// 固定高さ: 72px（padding上下12px + ラベル12px + gap2px + 駒行最大44px + 余裕2px = 72px）
+// handPieceSize は Math.max(36, Math.min(44, squareSize * 0.85)) で最大44pxになるため、
+// PC(squareSize大)で見切れないよう十分な高さを確保する。
+export const CAPTURED_PIECES_HEIGHT = 72;
 
 export function CapturedPieces({
   hand,

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -10,7 +10,7 @@ interface BoardSize {
 
 // 各エリアの固定高さ（px） — コンポーネントと同期させること
 const STATUS_BAR_HEIGHT = 28;
-const CAPTURED_PIECES_HEIGHT = 56; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
+const CAPTURED_PIECES_HEIGHT = 72; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
 const GAME_CONTROLS_HEIGHT = 36;  // game-controls.tsx の GAME_CONTROLS_HEIGHT と同値
 const MOBILE_DRAWER_TAB_HEIGHT = 40; // mobile-drawer.tsx のタブバー高さ
 const BOARD_LABEL_HEIGHT = 16; // ファイルラベル（上）


### PR DESCRIPTION
## Summary
- 持ち駒エリアの固定高さ `56px` が実際の内容量(70px)に足りず、PC環境で持ち駒・枚数表示が見切れていた問題を修正
- `CAPTURED_PIECES_HEIGHT` を `56 → 72` に引き上げ、[captured-pieces.tsx](src/components/game/captured-pieces.tsx) と [use-board-size.ts](src/hooks/use-board-size.ts) を同期

## 原因
PC では `handPieceSize = Math.max(36, Math.min(44, squareSize * 0.85))` が上限44pxに到達し、
`padding 12px + ラベル 12px + gap 2px + 駒 44px = 70px` となり、固定56pxを超えて `overflow-hidden` で見切れていた。

## デグレ影響
- `VERTICAL_RESERVED` が持ち駒2エリア分で32px増
- PC(vh=900): `squareSize` は引き続き MAX 64px に到達、盤面不変
- Mobile(vh=700): `fromHeight ≈ 46px` で MIN 36px 以上を維持、破綻なし

Closes #58

## Test plan
- [ ] PC環境で持ち駒・枚数表示が見切れず表示されること
- [ ] モバイル環境でデグレがないこと（盤面・持ち駒レイアウト）
- [ ] 盤面サイズが MIN/MAX 範囲内に収まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)