### PR TITLE
fix: 将棋盤の線を細くする (Issue #61-1)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,7 +73,6 @@
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
   --radius: 0.625rem;
-  --board-line-color: rgba(180, 83, 9, 0.3);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -108,7 +107,6 @@
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --board-line-color: rgba(217, 119, 6, 0.2);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,7 @@
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
   --radius: 0.625rem;
+  --board-line-color: rgba(180, 83, 9, 0.3);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -107,6 +108,7 @@
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
+  --board-line-color: rgba(217, 119, 6, 0.2);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -131,7 +131,7 @@ export function ShogiBoard({
                   key={`${rowIdx}-${colIdx}`}
                   data-legal={isLegalTarget}
                   className={cn(
-                    "shogi-square border border-amber-700/30 dark:border-amber-600/20 relative flex items-center justify-center",
+                    "shogi-square border-0 relative flex items-center justify-center",
                     "cursor-pointer",
                     // 通常背景
                     "bg-amber-50 dark:bg-amber-900/40",
@@ -149,7 +149,11 @@ export function ShogiBoard({
                     // ホバー
                     isPlayerTurn && !isAiThinking && "hover:bg-amber-100 dark:hover:bg-amber-800/50"
                   )}
-                  style={{ width: squareSize, height: squareSize }}
+                  style={{
+                    width: squareSize,
+                    height: squareSize,
+                    boxShadow: "inset 0 0 0 0.25px var(--board-line-color)",
+                  }}
                 >
                   {/* 合法手ドット（空きマス） */}
                   {isLegalTarget && !piece && (

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -103,7 +103,7 @@ export function ShogiBoard({
           ref={gridRef}
           role="grid"
           aria-label="将棋盤"
-          className="grid border border-amber-800 dark:border-amber-600 bg-amber-800/60 dark:bg-amber-600/40 relative"
+          className="grid border border-amber-800 dark:border-amber-600 bg-amber-800/60 dark:bg-amber-500/60 relative"
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -107,7 +107,7 @@ export function ShogiBoard({
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,
-            gap: "0.5px",
+            gap: "1px",
             touchAction: "none",
           }}
           onClick={(e) => e.stopPropagation()}

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -103,7 +103,7 @@ export function ShogiBoard({
           ref={gridRef}
           role="grid"
           aria-label="将棋盤"
-          className="grid border-2 border-amber-800 dark:border-amber-600 relative"
+          className="grid border border-amber-800 dark:border-amber-600 relative"
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,
@@ -131,7 +131,7 @@ export function ShogiBoard({
                   key={`${rowIdx}-${colIdx}`}
                   data-legal={isLegalTarget}
                   className={cn(
-                    "shogi-square border border-amber-700/60 dark:border-amber-600/40 relative flex items-center justify-center",
+                    "shogi-square border-[0.5px] border-amber-700/60 dark:border-amber-600/40 relative flex items-center justify-center",
                     "cursor-pointer",
                     // 通常背景
                     "bg-amber-50 dark:bg-amber-900/40",

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -131,7 +131,7 @@ export function ShogiBoard({
                   key={`${rowIdx}-${colIdx}`}
                   data-legal={isLegalTarget}
                   className={cn(
-                    "shogi-square border-[0.5px] border-amber-700/60 dark:border-amber-600/40 relative flex items-center justify-center",
+                    "shogi-square border border-amber-700/30 dark:border-amber-600/20 relative flex items-center justify-center",
                     "cursor-pointer",
                     // 通常背景
                     "bg-amber-50 dark:bg-amber-900/40",

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -103,10 +103,11 @@ export function ShogiBoard({
           ref={gridRef}
           role="grid"
           aria-label="将棋盤"
-          className="grid border border-amber-800 dark:border-amber-600 relative"
+          className="grid border border-amber-800 dark:border-amber-600 bg-amber-800/60 dark:bg-amber-600/40 relative"
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,
+            gap: "0.5px",
             touchAction: "none",
           }}
           onClick={(e) => e.stopPropagation()}
@@ -131,7 +132,7 @@ export function ShogiBoard({
                   key={`${rowIdx}-${colIdx}`}
                   data-legal={isLegalTarget}
                   className={cn(
-                    "shogi-square border-0 relative flex items-center justify-center",
+                    "shogi-square relative flex items-center justify-center",
                     "cursor-pointer",
                     // 通常背景
                     "bg-amber-50 dark:bg-amber-900/40",
@@ -149,11 +150,7 @@ export function ShogiBoard({
                     // ホバー
                     isPlayerTurn && !isAiThinking && "hover:bg-amber-100 dark:hover:bg-amber-800/50"
                   )}
-                  style={{
-                    width: squareSize,
-                    height: squareSize,
-                    boxShadow: "inset 0 0 0 0.25px var(--board-line-color)",
-                  }}
+                  style={{ width: squareSize, height: squareSize }}
                 >
                   {/* 合法手ドット（空きマス） */}
                   {isLegalTarget && !piece && (


### PR DESCRIPTION
## Summary
- 将棋盤の内部罫線が隣接セルのborderで二重化(2px)していた問題を解消
- CSS Grid の `gap: 1px` + コンテナ背景色方式に変更し、均一な1px罫線を実現
- 外枠も `border-2`(2px) → `border`(1px) に変更
- ダークモードの罫線視認性も調整

Closes partially #61 (項目1のみ)

## Test plan
- [x] ライトモードで罫線が均一に細く表示される
- [x] ダークモードで罫線が視認できる
- [x] 外枠が適切な太さで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)