### PR TITLE
fix: ダークモードの将棋盤枠線の視認性向上 (Issue #61)

### DIFF
--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -138,7 +138,7 @@ export function ShogiBoard({
                     "shogi-square relative flex items-center justify-center",
                     "cursor-pointer",
                     // 通常背景
-                    "bg-amber-50 dark:bg-amber-900/40",
+                    "bg-amber-50 dark:bg-amber-950",
                     // 直前の手（移動前・移動後）
                     isLastMoveSq && !isSelected && "bg-emerald-200 dark:bg-emerald-800/60",
                     // 王手中の王

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -103,7 +103,7 @@ export function ShogiBoard({
           ref={gridRef}
           role="grid"
           aria-label="将棋盤"
-          className="grid border border-amber-800 dark:border-amber-600 bg-amber-800/60 dark:bg-amber-500/60 relative"
+          className="grid border border-amber-800 dark:border-amber-400 bg-amber-800/60 dark:bg-amber-400/60 relative"
           style={{
             gridTemplateColumns: `repeat(9, ${squareSize}px)`,
             gridTemplateRows: `repeat(9, ${squareSize}px)`,


### PR DESCRIPTION
## Summary
- ダークモードの外枠・内部罫線色を amber-600/500 → amber-400 に明るく変更
- セル背景を半透明(amber-900/40) → 不透明(amber-950) に変更し、明るいコンテナ背景が透けないように修正

## Test plan
- [x] ダークモードで罫線が明るく視認しやすい
- [x] ダークモードのセル背景色が元の暗さを維持
- [x] ライトモードに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)