### PR TITLE
feat: 将棋駒を縦長にする (Issue #61-3)

### DIFF
--- a/src/components/game/shogi-piece.tsx
+++ b/src/components/game/shogi-piece.tsx
@@ -100,12 +100,12 @@ export function ShogiPiece({
 
   // isSmall（持ち駒・ダイアログ用）の場合は固定サイズ、盤上は駒種別サイズ
   const sizeClass = isSmall
-    ? "w-8 h-8"
+    ? "w-7 h-8"
     : SMALL_PIECES.has(piece.type)
-      ? "w-[85%] h-[85%]"
+      ? "w-[73%] h-[85%]"
       : MEDIUM_PIECES.has(piece.type)
-        ? "w-[90%] h-[90%]"
-        : "w-full h-full";
+        ? "w-[77%] h-[90%]"
+        : "w-[85%] h-full";
 
   return (
     <div
@@ -122,6 +122,7 @@ export function ShogiPiece({
         {/* SVG で五角形を描画（stroke が辺に沿って均一な枠線になる） */}
         <svg
           viewBox="-3 -3 106 106"
+          preserveAspectRatio="none"
           className="absolute inset-0 w-full h-full hover:brightness-90 transition-all duration-150"
         >
           <polygon


### PR DESCRIPTION
## Summary
- 駒の幅を狭くして縦長の伝統的なプロポーションに変更（幅:高さ ≈ 1:1.17）
- SVGに preserveAspectRatio="none" を追加し五角形を新比率に伸縮
- 持ち駒サイズも w-8 → w-7 に調整

## Test plan
- [x] 盤上の駒が縦長に表示される
- [x] 持ち駒も縦長に表示される
- [x] 駒の文字が正しく中央配置される

🤖 Generated with [Claude Code](https://claude.com/claude-code)