### PR TITLE
feat: モバイルでラベルを縮小して盤サイズを拡大 (Issue #61-6)

### DIFF
--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -87,8 +87,8 @@ export function ShogiBoard({
       </div>
 
       <div className="flex">
-        {/* 左側スペーサー（段ラベルと同幅で盤面を中央に揃える） */}
-        <div style={{ width: isMobile ? labelSize : labelSize + 6 }} />
+        {/* 左側スペーサー（段ラベルと同幅で盤面を中央に揃える、モバイルでは省略） */}
+        {!isMobile && <div style={{ width: labelSize + 6 }} />}
 
         {/* 盤面グリッド */}
         <div

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -88,7 +88,7 @@ export function ShogiBoard({
 
       <div className="flex">
         {/* 左側スペーサー（段ラベルと同幅で盤面を中央に揃える） */}
-        <div style={{ width: labelSize + 6 }} />
+        <div style={{ width: labelSize + (isMobile ? 2 : 6) }} />
 
         {/* 盤面グリッド */}
         <div

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -16,6 +16,7 @@ interface ShogiBoardProps {
   inCheck: boolean;
   onSquareClick: (pos: Position) => void;
   squareSize: number;
+  isMobile: boolean;
 }
 
 // 先手目線のラベル
@@ -37,6 +38,7 @@ export function ShogiBoard({
   inCheck,
   onSquareClick,
   squareSize,
+  isMobile,
 }: ShogiBoardProps) {
   const legalMoveSet = new Set(
     legalMoves.map((m) => `${m.to.row}-${m.to.col}`)
@@ -66,7 +68,7 @@ export function ShogiBoard({
   const fileLabels = isGote ? FILE_LABELS_GOTE : FILE_LABELS_SENTE;
   const rankLabels = isGote ? RANK_LABELS_GOTE : RANK_LABELS_SENTE;
 
-  const labelSize = Math.max(16, squareSize * 0.45);
+  const labelSize = isMobile ? Math.max(12, squareSize * 0.3) : Math.max(16, squareSize * 0.45);
   const dotSize = Math.max(8, squareSize * 0.22);
 
   return (

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -88,7 +88,7 @@ export function ShogiBoard({
 
       <div className="flex">
         {/* 左側スペーサー（段ラベルと同幅で盤面を中央に揃える） */}
-        <div style={{ width: labelSize + (isMobile ? 2 : 6) }} />
+        <div style={{ width: isMobile ? labelSize : labelSize + 6 }} />
 
         {/* 盤面グリッド */}
         <div

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -58,7 +58,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number } | null>(null);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const { squareSize, viewportHeight } = useBoardSize();
+  const { squareSize, isMobile, viewportHeight } = useBoardSize();
 
   // クライアント側でバリアントを復元（関数を含むため props では渡せない）
   const gameConfig: GameConfig = {
@@ -215,6 +215,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
               inCheck={inCheck}
               onSquareClick={selectSquare}
               squareSize={squareSize}
+              isMobile={isMobile}
             />
             <BoardOverlay key={overlayEvent?.key} event={overlayEvent?.event ?? null} />
           </div>

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -2,8 +2,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 
+const MOBILE_BREAKPOINT = 768;
+
 interface BoardSize {
   squareSize: number;
+  isMobile: boolean;
   viewportHeight: number;
   isReady: boolean;
 }
@@ -26,34 +29,39 @@ const VERTICAL_RESERVED =
 
 const MIN_SQUARE_SIZE = 36;
 const MAX_SQUARE_SIZE = 64;
-const HORIZONTAL_PADDING = 40; // 左右パディング + ラベル分
+const HORIZONTAL_PADDING = 40;
+const HORIZONTAL_PADDING_MOBILE = 24;
 const BOARD_CELLS = 9;
 
-function calculate(): { squareSize: number; viewportHeight: number } {
-  if (typeof window === "undefined") return { squareSize: 40, viewportHeight: 800 };
+function calculate(): { squareSize: number; isMobile: boolean; viewportHeight: number } {
+  if (typeof window === "undefined") return { squareSize: 40, isMobile: false, viewportHeight: 800 };
 
   const vw = window.innerWidth;
   // window.innerHeight は iOS Safari でもアドレスバー込みの実際の表示領域を返す
   const vh = window.innerHeight;
+  const isMobile = vw < MOBILE_BREAKPOINT;
 
-  const availableWidth = vw - HORIZONTAL_PADDING;
+  const padding = isMobile ? HORIZONTAL_PADDING_MOBILE : HORIZONTAL_PADDING;
+  const availableWidth = vw - padding;
   const availableHeight = vh - VERTICAL_RESERVED;
 
   const fromWidth = Math.floor(availableWidth / BOARD_CELLS);
   const fromHeight = Math.floor(availableHeight / BOARD_CELLS);
 
   const squareSize = Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, fromWidth, fromHeight));
-  return { squareSize, viewportHeight: vh };
+  return { squareSize, isMobile, viewportHeight: vh };
 }
 
 export function useBoardSize(): BoardSize {
   const [squareSize, setSquareSize] = useState(40);
+  const [isMobile, setIsMobile] = useState(false);
   const [viewportHeight, setViewportHeight] = useState(800);
   const [isReady, setIsReady] = useState(false);
 
   const recalculate = useCallback(() => {
     const result = calculate();
     setSquareSize(result.squareSize);
+    setIsMobile(result.isMobile);
     setViewportHeight(result.viewportHeight);
   }, []);
 
@@ -77,5 +85,5 @@ export function useBoardSize(): BoardSize {
     };
   }, [recalculate]);
 
-  return { squareSize, viewportHeight, isReady };
+  return { squareSize, isMobile, viewportHeight, isReady };
 }


### PR DESCRIPTION
## Summary
- モバイル判定 (< 768px) を `useBoardSize` に追加
- モバイル時の HORIZONTAL_PADDING を 40 → 24 に縮小し squareSize を拡大
- モバイル時の labelSize を縮小 (max(12, sq*0.3))
- モバイル時は左スペーサーを非表示にして画面幅を有効活用

## Test plan
- [x] モバイル幅で盤・駒が以前より大きく表示される
- [x] モバイル幅で段ラベルが見切れない
- [x] PC幅では見た目が変わらない

🤖 Generated with [Claude Code](https://claude.com/claude-code)