### PR TITLE
#78 山札ドロー時の中央演出 (Framer Motion・回転・キラリ)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,3 +199,13 @@
 .animate-trap-trigger {
   animation: trap-trigger-flash 1.6s ease-out forwards;
 }
+
+/* カード将棋: ドロー演出完了時に手札の対象カードがふわっと光る (Issue #78) */
+@keyframes hand-card-flash {
+  0%   { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
+  35%  { box-shadow: 0 0 24px 6px rgba(251, 191, 36, 0.85); }
+  100% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
+}
+.animate-hand-card-flash {
+  animation: hand-card-flash 0.9s ease-out forwards;
+}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -78,6 +78,8 @@ export function CardShogiGame({
   // Issue #78: ドロー演出 (山札→中央→手札)。演出完了まで自分の手番継続・操作ロック。
   const [drawFlight, setDrawFlight] = useState<{ card: CardInstance; key: number } | null>(null);
   const isDrawAnimating = drawFlight !== null;
+  // 演出完了直後に手札の対象カードを一瞬光らせる (Issue #78)
+  const [freshlyDrawnId, setFreshlyDrawnId] = useState<string | null>(null);
   // 各レイアウトの山札・手札 DOM ref。表示中のものから矩形を取得する。
   const ownDeckPileTabletRef = useRef<HTMLDivElement>(null);
   const ownDeckPileMobileRef = useRef<HTMLDivElement>(null);
@@ -133,6 +135,7 @@ export function CardShogiGame({
     undo,
     deselect,
     drawCard,
+    finalizeDraw,
     beginPlayCard,
     confirmPlayCard,
     cancelPlayCard,
@@ -288,6 +291,19 @@ export function CardShogiGame({
     return cardState.hand[playerColor].filter((c) => c.instanceId !== drawFlight.card.instanceId);
   }, [cardState.hand, playerColor, drawFlight]);
 
+  // ドロー演出完了: currentPlayer を相手に渡し、手札の対象カードを一瞬フラッシュさせる
+  const handleDrawFlightComplete = useCallback(() => {
+    const id = drawFlight?.card.instanceId ?? null;
+    setDrawFlight(null);
+    finalizeDraw();
+    if (id) {
+      setFreshlyDrawnId(id);
+      window.setTimeout(() => {
+        setFreshlyDrawnId((prev) => (prev === id ? null : prev));
+      }, 900);
+    }
+  }, [drawFlight, finalizeDraw]);
+
   // ----- レイアウト用ヘルパ -----
 
   const opponentManaGauge = (
@@ -392,6 +408,7 @@ export function CardShogiGame({
       onCardClick={handleBeginPlayCard}
       size="md"
       disabled={handDisabled}
+      flashCardId={freshlyDrawnId}
     />
   );
 
@@ -677,6 +694,7 @@ export function CardShogiGame({
             currentMana={cardState.mana[playerColor]}
             size="md"
             disabled={handDisabled}
+            flashCardId={freshlyDrawnId}
             onCardClick={(id) => {
               handleBeginPlayCard(id);
               setDrawerOpen(false);
@@ -757,6 +775,7 @@ export function CardShogiGame({
               size="md"
               disabled={handDisabled}
               fullWidth
+              flashCardId={freshlyDrawnId}
               onCardClick={handleBeginPlayCard}
             />
           </div>
@@ -896,7 +915,7 @@ export function CardShogiGame({
         flightKey={drawFlight?.key ?? null}
         deckRectGetter={getDeckRect}
         handRectGetter={getHandRect}
-        onComplete={() => setDrawFlight(null)}
+        onComplete={handleDrawFlightComplete}
       />
     </div>
   );

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -40,7 +40,7 @@ import { HandArea } from "./hand-area";
 import { TrapSlot } from "./trap-slot";
 import { DeckPile } from "./deck-pile";
 import { CardPlayDialog, CardTargetingNotice } from "./card-play-dialog";
-import { DrawFlightCard, type DrawFlightMode } from "./draw-flight-card";
+import { DrawFlightCard } from "./draw-flight-card";
 
 interface SerializableGameConfig {
   variantId: string;
@@ -75,10 +75,9 @@ export function CardShogiGame({
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  // Issue #78: ドロー演出 (山札→中央→手札方向)
+  // Issue #78: ドロー演出 (山札→中央→手札)。演出完了まで自分の手番継続・操作ロック。
   const [drawFlight, setDrawFlight] = useState<{ card: CardInstance; key: number } | null>(null);
-  // Issue #78: 演出パターン比較用 dev トグル (最終 PR では1つに絞り、トグルは削除予定)
-  const [animationMode, setAnimationMode] = useState<DrawFlightMode>("directional");
+  const isDrawAnimating = drawFlight !== null;
   // 各レイアウトの山札・手札 DOM ref。表示中のものから矩形を取得する。
   const ownDeckPileTabletRef = useRef<HTMLDivElement>(null);
   const ownDeckPileMobileRef = useRef<HTMLDivElement>(null);
@@ -256,6 +255,39 @@ export function CardShogiGame({
     return null;
   }, []);
 
+  // Issue #78: 演出中は盤面・手札・カード操作・背景クリックをロックする
+  const handleSquareClick = useCallback(
+    (pos: Position) => {
+      if (isDrawAnimating) return;
+      selectSquare(pos);
+    },
+    [isDrawAnimating, selectSquare],
+  );
+  const handleHandPieceClick = useCallback(
+    (piece: Parameters<typeof selectHandPiece>[0]) => {
+      if (isDrawAnimating) return;
+      selectHandPiece(piece);
+    },
+    [isDrawAnimating, selectHandPiece],
+  );
+  const handleBeginPlayCard = useCallback(
+    (id: string) => {
+      if (isDrawAnimating) return;
+      beginPlayCard(id);
+    },
+    [isDrawAnimating, beginPlayCard],
+  );
+  const handleDeselect = useCallback(() => {
+    if (isDrawAnimating) return;
+    deselect();
+  }, [isDrawAnimating, deselect]);
+
+  // 演出中は最新ドローカードを手札表示から除外し、演出完了後に手札に現れたように見せる
+  const displayedOwnHand = useMemo(() => {
+    if (!drawFlight) return cardState.hand[playerColor];
+    return cardState.hand[playerColor].filter((c) => c.instanceId !== drawFlight.card.instanceId);
+  }, [cardState.hand, playerColor, drawFlight]);
+
   // ----- レイアウト用ヘルパ -----
 
   const opponentManaGauge = (
@@ -277,7 +309,7 @@ export function CardShogiGame({
   const ownDeckPile = (
     <DeckPile
       count={cardState.deck[playerColor].length}
-      canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck}
+      canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck && !isDrawAnimating}
       onDraw={drawCard}
       size="md"
       showDrawCost
@@ -289,7 +321,7 @@ export function CardShogiGame({
   const ownDeckPileMobile = (
     <DeckPile
       count={cardState.deck[playerColor].length}
-      canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck}
+      canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck && !isDrawAnimating}
       onDraw={drawCard}
       size="md"
       showDrawCost
@@ -308,7 +340,8 @@ export function CardShogiGame({
   );
 
   // 王手中はカード使用・ドロー禁止 (P10) → 駒指しでの王手回避のみ可能
-  const handDisabled = !isPlayerTurn || !isGameActive || cardState.pendingCard !== null || inCheck;
+  // ドロー演出中も操作ロック (Issue #78)
+  const handDisabled = !isPlayerTurn || !isGameActive || cardState.pendingCard !== null || inCheck || isDrawAnimating;
 
   // 待った可否 (P28): 駒指し2手以上 / 自分の手番 / AI 思考中でない / pendingCard 無し / 過去2手の間にカード操作なし
   const canUndo = useMemo(() => {
@@ -354,9 +387,9 @@ export function CardShogiGame({
   }, [cardState.pendingCard, gameState.board, playerColor]);
   const ownHand = (
     <HandArea
-      hand={cardState.hand[playerColor]}
+      hand={displayedOwnHand}
       currentMana={cardState.mana[playerColor]}
-      onCardClick={(id) => beginPlayCard(id)}
+      onCardClick={handleBeginPlayCard}
       size="md"
       disabled={handDisabled}
     />
@@ -366,7 +399,7 @@ export function CardShogiGame({
     <div
       className="shogi-game-area w-full overflow-hidden flex flex-col"
       style={{ height: viewportHeight }}
-      onClick={deselect}
+      onClick={handleDeselect}
     >
       {/* ===== 相手ゾーン ===== */}
       {/* PC タブレット相当 (md..xl-1): 詳細ゾーン */}
@@ -465,7 +498,7 @@ export function CardShogiGame({
               lastMove={gameState.moveHistory[gameState.moveHistory.length - 1] ?? null}
               isAiThinking={isAiThinking}
               inCheck={inCheck}
-              onSquareClick={selectSquare}
+              onSquareClick={handleSquareClick}
               squareSize={squareSize}
               isMobile={isMobile}
               cardTargetSquares={cardTargetSquares}
@@ -485,7 +518,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               isCurrentPlayer={isPlayerTurn && isGameActive}
               selectedHandPiece={selectedHandPiece}
-              onPieceClick={selectHandPiece}
+              onPieceClick={handleHandPieceClick}
               label="あなた"
               squareSize={squareSize}
               compact={isMobile}
@@ -609,7 +642,7 @@ export function CardShogiGame({
                 onClick={() => setDrawerOpen((v) => !v)}
               >
                 {drawerOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronUp className="w-4 h-4" />}
-                手札 {cardState.hand[playerColor].length}
+                手札 {displayedOwnHand.length}
               </Button>
             </div>
             <div className="flex-1 min-w-0">{ownManaGaugeCompact}</div>
@@ -640,12 +673,12 @@ export function CardShogiGame({
         </div>
         <div className="p-3 overflow-x-auto">
           <HandArea
-            hand={cardState.hand[playerColor]}
+            hand={displayedOwnHand}
             currentMana={cardState.mana[playerColor]}
             size="md"
             disabled={handDisabled}
             onCardClick={(id) => {
-              beginPlayCard(id);
+              handleBeginPlayCard(id);
               setDrawerOpen(false);
             }}
           />
@@ -703,7 +736,7 @@ export function CardShogiGame({
             <div ref={ownDeckPileXlRef} className="flex-1 min-w-0">
               <DeckPile
                 count={cardState.deck[playerColor].length}
-                canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck}
+                canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck && !isDrawAnimating}
                 onDraw={drawCard}
                 size="lg"
                 showDrawCost
@@ -715,16 +748,16 @@ export function CardShogiGame({
               <TrapSlot trap={cardState.trap[playerColor]} size="lg" fullWidth />
             </div>
           </div>
-          <div className="text-xs text-muted-foreground font-medium shrink-0 text-center">手札 {cardState.hand[playerColor].length}枚</div>
+          <div className="text-xs text-muted-foreground font-medium shrink-0 text-center">手札 {displayedOwnHand.length}枚</div>
           <div ref={ownHandXlRef} className="flex-1 min-h-0 overflow-y-auto">
             <HandArea
-              hand={cardState.hand[playerColor]}
+              hand={displayedOwnHand}
               currentMana={cardState.mana[playerColor]}
               layout="vertical"
               size="md"
               disabled={handDisabled}
               fullWidth
-              onCardClick={(id) => beginPlayCard(id)}
+              onCardClick={handleBeginPlayCard}
             />
           </div>
           <div className="shrink-0 pt-2 border-t flex justify-center">
@@ -765,7 +798,7 @@ export function CardShogiGame({
               lastMove={gameState.moveHistory[gameState.moveHistory.length - 1] ?? null}
               isAiThinking={isAiThinking}
               inCheck={inCheck}
-              onSquareClick={selectSquare}
+              onSquareClick={handleSquareClick}
               squareSize={squareSize}
               isMobile={isMobile}
               cardTargetSquares={cardTargetSquares}
@@ -783,7 +816,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               isCurrentPlayer={isPlayerTurn && isGameActive}
               selectedHandPiece={selectedHandPiece}
-              onPieceClick={selectHandPiece}
+              onPieceClick={handleHandPieceClick}
               label="あなた"
               squareSize={squareSize}
             />
@@ -857,39 +890,14 @@ export function CardShogiGame({
         onCancel={cancelPlayCard}
       />
 
-      {/* Issue #78: ドロー中央演出 */}
+      {/* Issue #78: ドロー中央演出 (山札→中央→手札の DOMRect 追従) */}
       <DrawFlightCard
         cardInstance={drawFlight?.card ?? null}
         flightKey={drawFlight?.key ?? null}
-        mode={animationMode}
         deckRectGetter={getDeckRect}
         handRectGetter={getHandRect}
         onComplete={() => setDrawFlight(null)}
       />
-
-      {/* Issue #78: 演出パターン比較 dev トグル (最終 PR で削除予定) */}
-      <div
-        className="fixed top-1 right-1 z-[70] flex items-center gap-1 rounded border bg-card/95 px-2 py-1 text-[10px] shadow-md"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <span className="text-muted-foreground">演出</span>
-        <Button
-          size="sm"
-          variant={animationMode === "directional" ? "default" : "outline"}
-          className="h-5 px-1.5 text-[10px]"
-          onClick={() => setAnimationMode("directional")}
-        >
-          A
-        </Button>
-        <Button
-          size="sm"
-          variant={animationMode === "tracking" ? "default" : "outline"}
-          className="h-5 px-1.5 text-[10px]"
-          onClick={() => setAnimationMode("tracking")}
-        >
-          B
-        </Button>
-      </div>
     </div>
   );
 }

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -31,7 +31,7 @@ import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import { getVariantById } from "@/lib/shogi/variants/index";
 import type { Difficulty, GameConfig, GameState, Move, Player, Position } from "@/lib/shogi/types";
 import type { CommentaryEvent } from "@/app/actions/commentary";
-import type { CardGameState } from "@/lib/shogi/cards/types";
+import type { CardGameState, CardInstance } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
 import { createGame } from "@/app/actions/game";
 
@@ -40,6 +40,7 @@ import { HandArea } from "./hand-area";
 import { TrapSlot } from "./trap-slot";
 import { DeckPile } from "./deck-pile";
 import { CardPlayDialog, CardTargetingNotice } from "./card-play-dialog";
+import { DrawFlightCard, type DrawFlightMode } from "./draw-flight-card";
 
 interface SerializableGameConfig {
   variantId: string;
@@ -74,6 +75,17 @@ export function CardShogiGame({
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Issue #78: ドロー演出 (山札→中央→手札方向)
+  const [drawFlight, setDrawFlight] = useState<{ card: CardInstance; key: number } | null>(null);
+  // Issue #78: 演出パターン比較用 dev トグル (最終 PR では1つに絞り、トグルは削除予定)
+  const [animationMode, setAnimationMode] = useState<DrawFlightMode>("directional");
+  // 各レイアウトの山札・手札 DOM ref。表示中のものから矩形を取得する。
+  const ownDeckPileTabletRef = useRef<HTMLDivElement>(null);
+  const ownDeckPileMobileRef = useRef<HTMLDivElement>(null);
+  const ownDeckPileXlRef = useRef<HTMLDivElement>(null);
+  const ownHandTabletRef = useRef<HTMLDivElement>(null);
+  const ownHandMobileBtnRef = useRef<HTMLDivElement>(null);
+  const ownHandXlRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const { squareSize, isMobile, viewportHeight } = useCardBoardSize();
@@ -193,6 +205,10 @@ export function CardShogiGame({
       switch (ev.kind) {
         case "drawEvent":
           playSfx("card_draw");
+          // Issue #78: 自分のドローのみ中央演出 (AI ドローは Phase 0 では発生しない想定だが防御的に絞る)
+          if (ev.player === playerColor) {
+            setDrawFlight({ card: ev.instance, key: Date.now() });
+          }
           break;
         case "cardPlayEvent":
           playSfx("card_play");
@@ -216,7 +232,29 @@ export function CardShogiGame({
       }
     }
     lastEventIndexRef.current = eventLog.length;
-  }, [eventLog, isReady, playSfx]);
+  }, [eventLog, isReady, playSfx, playerColor]);
+
+  // 表示中の山札ラッパーから矩形を取得 (xl 以上 → タブレット → モバイル の順に visibility 判定)
+  const getDeckRect = useCallback((): DOMRect | null => {
+    for (const ref of [ownDeckPileXlRef, ownDeckPileTabletRef, ownDeckPileMobileRef]) {
+      const el = ref.current;
+      if (el && el.offsetParent !== null) {
+        return el.getBoundingClientRect();
+      }
+    }
+    return null;
+  }, []);
+
+  // 表示中の手札ラッパーから矩形を取得 (モバイルでドロワー閉のとき手札ボタン位置に着地)
+  const getHandRect = useCallback((): DOMRect | null => {
+    for (const ref of [ownHandXlRef, ownHandTabletRef, ownHandMobileBtnRef]) {
+      const el = ref.current;
+      if (el && el.offsetParent !== null) {
+        return el.getBoundingClientRect();
+      }
+    }
+    return null;
+  }, []);
 
   // ----- レイアウト用ヘルパ -----
 
@@ -523,8 +561,8 @@ export function CardShogiGame({
       >
         <Badge className="shrink-0" variant="default">▲ 自分</Badge>
         {ownTrapSlot}
-        <div className="flex-1 min-w-0">{ownHand}</div>
-        {ownDeckPile}
+        <div ref={ownHandTabletRef} className="flex-1 min-w-0">{ownHand}</div>
+        <div ref={ownDeckPileTabletRef} className="shrink-0">{ownDeckPile}</div>
         <div className="shrink-0">{ownManaGauge}</div>
         <div className="shrink-0 ml-2 border-l pl-2">
           <GameControls
@@ -563,20 +601,22 @@ export function CardShogiGame({
           </div>
           {/* 段2: 手札ボタン + マナゲージ (flex-1 で残り高さを取る) */}
           <div className="flex-1 flex items-center gap-2">
-            <Button
-              size="sm"
-              variant={drawerOpen ? "outline" : "default"}
-              className="h-9 gap-1 text-xs shrink-0"
-              onClick={() => setDrawerOpen((v) => !v)}
-            >
-              {drawerOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronUp className="w-4 h-4" />}
-              手札 {cardState.hand[playerColor].length}
-            </Button>
+            <div ref={ownHandMobileBtnRef} className="shrink-0">
+              <Button
+                size="sm"
+                variant={drawerOpen ? "outline" : "default"}
+                className="h-9 gap-1 text-xs"
+                onClick={() => setDrawerOpen((v) => !v)}
+              >
+                {drawerOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronUp className="w-4 h-4" />}
+                手札 {cardState.hand[playerColor].length}
+              </Button>
+            </div>
             <div className="flex-1 min-w-0">{ownManaGaugeCompact}</div>
           </div>
         </div>
         {/* 中央: 山札 (左2段の高さに合わせて伸びる) */}
-        <div className="shrink-0 flex">{ownDeckPileMobile}</div>
+        <div ref={ownDeckPileMobileRef} className="shrink-0 flex">{ownDeckPileMobile}</div>
         {/* 右: トラップ */}
         <div className="shrink-0 flex">{ownTrapSlotMobile}</div>
       </section>
@@ -660,7 +700,7 @@ export function CardShogiGame({
           <Badge variant="default" className="self-center shrink-0">▲ 自分</Badge>
           <div className="shrink-0 w-full">{ownManaGauge}</div>
           <div className="flex gap-2 shrink-0 w-full">
-            <div className="flex-1 min-w-0">
+            <div ref={ownDeckPileXlRef} className="flex-1 min-w-0">
               <DeckPile
                 count={cardState.deck[playerColor].length}
                 canDraw={cardState.mana[playerColor] >= 5 && isPlayerTurn && isGameActive && !inCheck}
@@ -676,7 +716,7 @@ export function CardShogiGame({
             </div>
           </div>
           <div className="text-xs text-muted-foreground font-medium shrink-0 text-center">手札 {cardState.hand[playerColor].length}枚</div>
-          <div className="flex-1 min-h-0 overflow-y-auto">
+          <div ref={ownHandXlRef} className="flex-1 min-h-0 overflow-y-auto">
             <HandArea
               hand={cardState.hand[playerColor]}
               currentMana={cardState.mana[playerColor]}
@@ -816,6 +856,40 @@ export function CardShogiGame({
         pendingCard={cardState.pendingCard}
         onCancel={cancelPlayCard}
       />
+
+      {/* Issue #78: ドロー中央演出 */}
+      <DrawFlightCard
+        cardInstance={drawFlight?.card ?? null}
+        flightKey={drawFlight?.key ?? null}
+        mode={animationMode}
+        deckRectGetter={getDeckRect}
+        handRectGetter={getHandRect}
+        onComplete={() => setDrawFlight(null)}
+      />
+
+      {/* Issue #78: 演出パターン比較 dev トグル (最終 PR で削除予定) */}
+      <div
+        className="fixed top-1 right-1 z-[70] flex items-center gap-1 rounded border bg-card/95 px-2 py-1 text-[10px] shadow-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="text-muted-foreground">演出</span>
+        <Button
+          size="sm"
+          variant={animationMode === "directional" ? "default" : "outline"}
+          className="h-5 px-1.5 text-[10px]"
+          onClick={() => setAnimationMode("directional")}
+        >
+          A
+        </Button>
+        <Button
+          size="sm"
+          variant={animationMode === "tracking" ? "default" : "outline"}
+          className="h-5 px-1.5 text-[10px]"
+          onClick={() => setAnimationMode("tracking")}
+        >
+          B
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -4,29 +4,96 @@ import { cn } from "@/lib/utils";
 import type { CardInstance } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
 
+export type CardViewSize = "sm" | "md" | "lg" | "xl";
+
 interface CardViewProps {
   card: CardInstance;
   faceDown?: boolean;
   onClick?: () => void;
   disabled?: boolean;
-  size?: "sm" | "md" | "lg";
+  size?: CardViewSize;
   selected?: boolean;
-  // true のとき横幅を親に合わせる(縦並び・中央揃えで使用)
   fullWidth?: boolean;
 }
 
 // "sm" はサムネイル(裏向きの相手手札用、縦長)
 // "md" / "lg" は表向きの手札(横長、コスト+アイコン+名前+説明)
-const SIZE_CLASS = {
+// "xl" はドロー演出用の中央拡大表示(Issue #78)
+const SIZE_CLASS: Record<CardViewSize, string> = {
   sm: "w-12 h-16 text-[10px]",
   md: "w-32 h-[80px] text-[13px]",
   lg: "w-40 h-24 text-sm",
+  xl: "w-72 h-44 text-base",
 };
 
-const ICON_SIZE_CLASS = {
+const FULL_WIDTH_HEIGHT: Record<CardViewSize, string> = {
+  sm: "h-16",
+  md: "h-[80px]",
+  lg: "h-24",
+  xl: "h-44",
+};
+
+const FULL_WIDTH_TEXT: Record<CardViewSize, string> = {
+  sm: "text-[10px]",
+  md: "text-[13px]",
+  lg: "text-sm",
+  xl: "text-base",
+};
+
+const ICON_SIZE_CLASS: Record<CardViewSize, string> = {
   sm: "text-base",
   md: "text-3xl",
   lg: "text-4xl",
+  xl: "text-7xl",
+};
+
+const LEFT_W_CLASS: Record<CardViewSize, string> = {
+  sm: "w-10",
+  md: "w-10",
+  lg: "w-10",
+  xl: "w-20",
+};
+
+const COST_TEXT_CLASS: Record<CardViewSize, string> = {
+  sm: "text-xs",
+  md: "text-xs",
+  lg: "text-xs",
+  xl: "text-2xl",
+};
+
+const NAME_TEXT_CLASS: Record<CardViewSize, string> = {
+  sm: "",
+  md: "",
+  lg: "",
+  xl: "text-2xl",
+};
+
+const DESC_TEXT_CLASS: Record<CardViewSize, string> = {
+  sm: "text-[10px]",
+  md: "text-[11px]",
+  lg: "text-[11px]",
+  xl: "text-base",
+};
+
+const TRAP_BADGE_TEXT_CLASS: Record<CardViewSize, string> = {
+  sm: "text-[8px]",
+  md: "text-[8px]",
+  lg: "text-[8px]",
+  xl: "text-sm",
+};
+
+const PADDING_CLASS: Record<CardViewSize, string> = {
+  sm: "p-1",
+  md: "p-2",
+  lg: "p-2",
+  xl: "p-4",
+};
+
+const GAP_CLASS: Record<CardViewSize, string> = {
+  sm: "gap-1",
+  md: "gap-2",
+  lg: "gap-2",
+  xl: "gap-3",
 };
 
 export function CardView({
@@ -46,7 +113,7 @@ export function CardView({
         className={cn(
           "rounded-md border-2 border-indigo-700 bg-gradient-to-br from-indigo-700 to-indigo-900",
           "flex items-center justify-center text-white/80 font-bold shrink-0",
-          fullWidth ? cn("w-full", size === "sm" ? "h-16" : size === "md" ? "h-[80px]" : "h-24") : SIZE_CLASS[size],
+          fullWidth ? cn("w-full", FULL_WIDTH_HEIGHT[size]) : SIZE_CLASS[size],
           fullWidth && "text-2xl",
         )}
         aria-label="伏せられたカード"
@@ -57,10 +124,9 @@ export function CardView({
   }
 
   const sizeClass = fullWidth
-    ? cn("w-full", size === "sm" ? "h-16 text-[10px]" : size === "md" ? "h-[80px] text-[13px]" : "h-24 text-sm")
+    ? cn("w-full", FULL_WIDTH_HEIGHT[size], FULL_WIDTH_TEXT[size])
     : SIZE_CLASS[size];
 
-  // 横長レイアウト: 左にコスト+アイコン、右に名前+説明
   return (
     <button
       type="button"
@@ -68,7 +134,9 @@ export function CardView({
       disabled={disabled}
       className={cn(
         "rounded-md border-2 bg-card text-card-foreground shadow-sm shrink-0",
-        "flex flex-row items-stretch gap-2 p-2 text-left transition-all",
+        "flex flex-row items-stretch text-left transition-all",
+        PADDING_CLASS[size],
+        GAP_CLASS[size],
         sizeClass,
         disabled
           ? "opacity-50 cursor-not-allowed border-border"
@@ -79,10 +147,11 @@ export function CardView({
       aria-label={`${def.name} (コスト${def.cost})`}
     >
       {/* 左: コストとアイコン */}
-      <div className="flex flex-col items-center justify-center gap-0.5 shrink-0 w-10">
+      <div className={cn("flex flex-col items-center justify-center gap-0.5 shrink-0", LEFT_W_CLASS[size])}>
         <span
           className={cn(
-            "rounded-full px-2 leading-tight font-bold text-xs tabular-nums",
+            "rounded-full px-2 leading-tight font-bold tabular-nums",
+            COST_TEXT_CLASS[size],
             def.kind === "trap"
               ? "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
               : "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
@@ -97,14 +166,19 @@ export function CardView({
       {/* 右: 名前 + 説明 + (TRAPバッジ) */}
       <div className="flex-1 min-w-0 flex flex-col justify-center gap-0.5">
         <div className="flex items-center gap-1">
-          <span className="font-bold leading-tight truncate">{def.name}</span>
+          <span className={cn("font-bold leading-tight truncate", NAME_TEXT_CLASS[size])}>{def.name}</span>
           {def.kind === "trap" && (
-            <span className="text-[8px] bg-purple-200 dark:bg-purple-900/60 text-purple-900 dark:text-purple-100 px-1 rounded font-bold leading-tight shrink-0">
+            <span
+              className={cn(
+                "bg-purple-200 dark:bg-purple-900/60 text-purple-900 dark:text-purple-100 px-1 rounded font-bold leading-tight shrink-0",
+                TRAP_BADGE_TEXT_CLASS[size],
+              )}
+            >
               TRAP
             </span>
           )}
         </div>
-        <div className="text-[11px] text-muted-foreground leading-tight line-clamp-2">
+        <div className={cn("text-muted-foreground leading-tight line-clamp-2", DESC_TEXT_CLASS[size])}>
           {def.description}
         </div>
       </div>

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -18,82 +18,89 @@ interface CardViewProps {
 
 // "sm" はサムネイル(裏向きの相手手札用、縦長)
 // "md" / "lg" は表向きの手札(横長、コスト+アイコン+名前+説明)
-// "xl" はドロー演出用の中央拡大表示(Issue #78)
+// "xl" はドロー演出用の中央拡大表示(Issue #78、576x352px)
 const SIZE_CLASS: Record<CardViewSize, string> = {
   sm: "w-12 h-16 text-[10px]",
   md: "w-32 h-[80px] text-[13px]",
   lg: "w-40 h-24 text-sm",
-  xl: "w-72 h-44 text-base",
+  xl: "w-[36rem] h-[22rem] text-2xl",
 };
 
 const FULL_WIDTH_HEIGHT: Record<CardViewSize, string> = {
   sm: "h-16",
   md: "h-[80px]",
   lg: "h-24",
-  xl: "h-44",
+  xl: "h-[22rem]",
 };
 
 const FULL_WIDTH_TEXT: Record<CardViewSize, string> = {
   sm: "text-[10px]",
   md: "text-[13px]",
   lg: "text-sm",
-  xl: "text-base",
+  xl: "text-2xl",
 };
 
 const ICON_SIZE_CLASS: Record<CardViewSize, string> = {
   sm: "text-base",
   md: "text-3xl",
   lg: "text-4xl",
-  xl: "text-7xl",
+  xl: "text-9xl",
 };
 
 const LEFT_W_CLASS: Record<CardViewSize, string> = {
   sm: "w-10",
   md: "w-10",
   lg: "w-10",
-  xl: "w-20",
+  xl: "w-40",
 };
 
 const COST_TEXT_CLASS: Record<CardViewSize, string> = {
   sm: "text-xs",
   md: "text-xs",
   lg: "text-xs",
-  xl: "text-2xl",
+  xl: "text-4xl",
 };
 
 const NAME_TEXT_CLASS: Record<CardViewSize, string> = {
   sm: "",
   md: "",
   lg: "",
-  xl: "text-2xl",
+  xl: "text-4xl",
 };
 
 const DESC_TEXT_CLASS: Record<CardViewSize, string> = {
   sm: "text-[10px]",
   md: "text-[11px]",
   lg: "text-[11px]",
-  xl: "text-base",
+  xl: "text-2xl",
 };
 
 const TRAP_BADGE_TEXT_CLASS: Record<CardViewSize, string> = {
   sm: "text-[8px]",
   md: "text-[8px]",
   lg: "text-[8px]",
-  xl: "text-sm",
+  xl: "text-base",
 };
 
 const PADDING_CLASS: Record<CardViewSize, string> = {
   sm: "p-1",
   md: "p-2",
   lg: "p-2",
-  xl: "p-4",
+  xl: "p-6",
 };
 
 const GAP_CLASS: Record<CardViewSize, string> = {
   sm: "gap-1",
   md: "gap-2",
   lg: "gap-2",
-  xl: "gap-3",
+  xl: "gap-5",
+};
+
+const FACEDOWN_SYMBOL_CLASS: Record<CardViewSize, string> = {
+  sm: "text-2xl",
+  md: "text-2xl",
+  lg: "text-2xl",
+  xl: "text-9xl",
 };
 
 export function CardView({
@@ -114,7 +121,7 @@ export function CardView({
           "rounded-md border-2 border-indigo-700 bg-gradient-to-br from-indigo-700 to-indigo-900",
           "flex items-center justify-center text-white/80 font-bold shrink-0",
           fullWidth ? cn("w-full", FULL_WIDTH_HEIGHT[size]) : SIZE_CLASS[size],
-          fullWidth && "text-2xl",
+          fullWidth && FACEDOWN_SYMBOL_CLASS[size],
         )}
         aria-label="伏せられたカード"
       >

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -151,8 +151,9 @@ function DrawFlightInner({
     >
       <motion.div
         animate={{
-          rotateY: [0, 540, 540, 1080],
-          // rotateZ で時計回りの円運動 (山札→中央 1周、中央→手札 1周、計2周)
+          // 山札→中央でフリップ (0→540, 1.5周)、中央→手札では rotateY を維持して表向きのまま
+          rotateY: [0, 540, 540, 540],
+          // rotateZ は時計回りに継続 (山札→中央 1周、中央→手札 1周、計2周)
           rotateZ: [0, 360, 360, 720],
         }}
         transition={{

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -15,11 +15,10 @@ interface DrawFlightCardProps {
   onComplete: () => void;
 }
 
-// CardView size="xl" の素サイズ (w-72 = 288px, h-44 = 176px)
-const CARD_W = 288;
-const CARD_H = 176;
+// CardView size="xl" の素サイズ (w-[36rem] = 576, h-[22rem] = 352)
+const CARD_W = 576;
+const CARD_H = 352;
 
-// タイミング (合計 1250ms。速度 UP 後)
 const FADE_IN_MS = 350;
 const HOLD_MS = 600;
 const FADE_OUT_MS = 300;
@@ -43,7 +42,7 @@ export function DrawFlightCard({
   return createPortal(
     <div
       className="fixed inset-0 pointer-events-none z-[60]"
-      style={{ perspective: 1400 }}
+      style={{ perspective: 1600 }}
     >
       <AnimatePresence>
         {cardInstance && flightKey !== null && (
@@ -84,7 +83,7 @@ function DrawFlightInner({
 
     const startX = deckRect ? deckRect.x + deckRect.width / 2 - CARD_W / 2 : centerX;
     const startY = deckRect ? deckRect.y + deckRect.height / 2 - CARD_H / 2 : centerY;
-    const startScale = deckRect ? Math.max(0.25, deckRect.width / CARD_W) : 0.4;
+    const startScale = deckRect ? Math.max(0.15, deckRect.width / CARD_W) : 0.2;
 
     let endX: number;
     let endY: number;
@@ -92,11 +91,11 @@ function DrawFlightInner({
     if (handRect) {
       endX = handRect.x + handRect.width / 2 - CARD_W / 2;
       endY = handRect.y + handRect.height / 2 - CARD_H / 2;
-      endScale = Math.max(0.25, handRect.width / CARD_W);
+      endScale = Math.max(0.15, handRect.width / CARD_W);
     } else {
       endX = centerX;
       endY = centerY + 240;
-      endScale = 0.4;
+      endScale = 0.2;
     }
 
     return { startX, startY, centerX, centerY, endX, endY, startScale, endScale };
@@ -109,11 +108,14 @@ function DrawFlightInner({
   const t1 = FADE_IN_MS / TOTAL_MS;
   const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
 
-  // 回転は累積で表現:
-  // - 0deg → 180deg (山札→中央): 裏向き開始 → 中央到着で表向き
-  // - 180deg ホールド: 表向き
-  // - 180deg → 360deg (中央→手札): 表向き → 裏向きに戻る
-  // 表/裏の切替は子要素の backface-visibility で自動
+  // 回転は累積で 0 → 540 → 540 → 1080:
+  //   0deg     裏面手前 (山札位置スタート)
+  //   540deg   = 180deg 相当 → 表面手前 (中央到着・ホールド)
+  //   1080deg  = 0deg 相当 → 裏面手前 (手札到着)
+  // 山札→中央 で 1.5周、中央→手札 で 1.5周、合計 3周。
+  // 表/裏切替は子要素の backface-visibility hidden で自動。
+  // 注意: filter 系プロパティ(drop-shadow 等)は preserve-3d を flatten させるため
+  //       外側 motion.div には付けず、内側面に box-shadow ベースの shadow-2xl を当てる。
   return (
     <motion.div
       initial={{
@@ -121,14 +123,12 @@ function DrawFlightInner({
         top: startY,
         scale: startScale,
         opacity: 0,
-        rotateY: 0,
       }}
       animate={{
         left: [startX, centerX, centerX, endX],
         top: [startY, centerY, centerY, endY],
         scale: [startScale, 1, 1, endScale],
         opacity: [0, 1, 1, 0],
-        rotateY: [0, 180, 180, 360],
       }}
       transition={{
         duration: TOTAL_MS / 1000,
@@ -140,33 +140,46 @@ function DrawFlightInner({
         position: "fixed",
         width: CARD_W,
         height: CARD_H,
-        transformOrigin: "center center",
         transformStyle: "preserve-3d",
         willChange: "transform, opacity, left, top",
       }}
-      className="drop-shadow-2xl"
     >
-      {/* 裏面 (rotateY 0 のとき手前) */}
-      <div
-        className="absolute inset-0"
+      <motion.div
+        animate={{ rotateY: [0, 540, 540, 1080] }}
+        transition={{
+          duration: TOTAL_MS / 1000,
+          times: [0, t1, t2, 1],
+          ease: ["easeOut", "linear", "easeIn"],
+        }}
         style={{
-          backfaceVisibility: "hidden",
-          WebkitBackfaceVisibility: "hidden",
+          width: "100%",
+          height: "100%",
+          transformStyle: "preserve-3d",
+          transformOrigin: "center center",
         }}
       >
-        <CardView card={cardInstance} faceDown size="xl" fullWidth />
-      </div>
-      {/* 表面 (rotateY 180 のとき手前) */}
-      <div
-        className="absolute inset-0"
-        style={{
-          backfaceVisibility: "hidden",
-          WebkitBackfaceVisibility: "hidden",
-          transform: "rotateY(180deg)",
-        }}
-      >
-        <CardView card={cardInstance} size="xl" fullWidth />
-      </div>
+        {/* 裏面 (rotateY 0 のとき手前) */}
+        <div
+          className="absolute inset-0 rounded-md shadow-2xl"
+          style={{
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+          }}
+        >
+          <CardView card={cardInstance} faceDown size="xl" fullWidth />
+        </div>
+        {/* 表面 (rotateY 180 のとき手前) */}
+        <div
+          className="absolute inset-0 rounded-md shadow-2xl"
+          style={{
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+            transform: "rotateY(180deg)",
+          }}
+        >
+          <CardView card={cardInstance} size="xl" fullWidth />
+        </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
+
+import type { CardInstance } from "@/lib/shogi/cards/types";
+import { CardView } from "./card-view";
+
+// SSR 中は false、クライアントマウント後 true。hydration mismatch を起こさず Portal を遅延マウントする。
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export type DrawFlightMode = "directional" | "tracking";
+
+interface DrawFlightCardProps {
+  cardInstance: CardInstance | null;
+  flightKey: number | null;
+  mode: DrawFlightMode;
+  deckRectGetter: () => DOMRect | null;
+  handRectGetter?: () => DOMRect | null;
+  onComplete: () => void;
+}
+
+// CardView size="lg" の素サイズ (w-40 h-24)
+const CARD_W = 160;
+const CARD_H = 96;
+
+// 中央表示時の拡大率
+const CENTER_SCALE = 1.6;
+
+// タイミング (合計 2100ms)
+const FADE_IN_MS = 300;
+const HOLD_MS = 1200;
+const FADE_OUT_MS = 600;
+const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
+
+export function DrawFlightCard({
+  cardInstance,
+  flightKey,
+  mode,
+  deckRectGetter,
+  handRectGetter,
+  onComplete,
+}: DrawFlightCardProps) {
+  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+
+  if (!isClient) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 pointer-events-none z-[60]">
+      <AnimatePresence>
+        {cardInstance && flightKey !== null && (
+          <DrawFlightInner
+            key={flightKey}
+            cardInstance={cardInstance}
+            mode={mode}
+            deckRectGetter={deckRectGetter}
+            handRectGetter={handRectGetter}
+            onComplete={onComplete}
+          />
+        )}
+      </AnimatePresence>
+    </div>,
+    document.body,
+  );
+}
+
+function DrawFlightInner({
+  cardInstance,
+  mode,
+  deckRectGetter,
+  handRectGetter,
+  onComplete,
+}: {
+  cardInstance: CardInstance;
+  mode: DrawFlightMode;
+  deckRectGetter: () => DOMRect | null;
+  handRectGetter?: () => DOMRect | null;
+  onComplete: () => void;
+}) {
+  const [coords] = useState(() => {
+    if (typeof window === "undefined") return null;
+    const deckRect = deckRectGetter();
+    const handRect = mode === "tracking" ? handRectGetter?.() ?? null : null;
+
+    const winW = window.innerWidth;
+    const winH = window.innerHeight;
+    const centerX = (winW - CARD_W) / 2;
+    const centerY = (winH - CARD_H) / 2;
+
+    const startX = deckRect ? deckRect.x + deckRect.width / 2 - CARD_W / 2 : centerX;
+    const startY = deckRect ? deckRect.y + deckRect.height / 2 - CARD_H / 2 : centerY;
+    // 山札の見かけサイズに開始スケールを合わせる (山札 md/lg のいずれでも近似)
+    const startScale = deckRect ? Math.max(0.45, deckRect.width / CARD_W) : 0.6;
+
+    let endX: number;
+    let endY: number;
+    let endScale: number;
+    if (mode === "tracking" && handRect) {
+      endX = handRect.x + handRect.width / 2 - CARD_W / 2;
+      endY = handRect.y + handRect.height / 2 - CARD_H / 2;
+      // 手札サイズ (md = w-32 h-[80px] = 128x80) に近い縮小
+      endScale = Math.max(0.4, handRect.width / CARD_W);
+    } else {
+      // directional: 中央からやや下方向 (手札方向) に縮小しつつフェード
+      endX = centerX;
+      endY = centerY + 120;
+      endScale = 0.9;
+    }
+
+    return { startX, startY, centerX, centerY, endX, endY, startScale, endScale };
+  });
+
+  if (!coords) return null;
+
+  const { startX, startY, centerX, centerY, endX, endY, startScale, endScale } = coords;
+
+  const t1 = FADE_IN_MS / TOTAL_MS;
+  const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
+
+  return (
+    <motion.div
+      initial={{
+        left: startX,
+        top: startY,
+        scale: startScale,
+        opacity: 0,
+      }}
+      animate={{
+        left: [startX, centerX, centerX, endX],
+        top: [startY, centerY, centerY, endY],
+        scale: [startScale, CENTER_SCALE, CENTER_SCALE, endScale],
+        opacity: [0, 1, 1, 0],
+      }}
+      transition={{
+        duration: TOTAL_MS / 1000,
+        times: [0, t1, t2, 1],
+        ease: ["easeOut", "linear", "easeIn"],
+      }}
+      onAnimationComplete={onComplete}
+      style={{
+        position: "fixed",
+        width: CARD_W,
+        height: CARD_H,
+        transformOrigin: "center center",
+        willChange: "transform, opacity, left, top",
+      }}
+      className="drop-shadow-2xl"
+    >
+      <CardView card={cardInstance} size="lg" />
+    </motion.div>
+  );
+}

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -7,39 +7,31 @@ import { AnimatePresence, motion } from "framer-motion";
 import type { CardInstance } from "@/lib/shogi/cards/types";
 import { CardView } from "./card-view";
 
-// SSR 中は false、クライアントマウント後 true。hydration mismatch を起こさず Portal を遅延マウントする。
+interface DrawFlightCardProps {
+  cardInstance: CardInstance | null;
+  flightKey: number | null;
+  deckRectGetter: () => DOMRect | null;
+  handRectGetter: () => DOMRect | null;
+  onComplete: () => void;
+}
+
+// CardView size="xl" の素サイズ (w-72 = 288px, h-44 = 176px)
+const CARD_W = 288;
+const CARD_H = 176;
+
+// タイミング (合計 1250ms。速度 UP 後)
+const FADE_IN_MS = 350;
+const HOLD_MS = 600;
+const FADE_OUT_MS = 300;
+const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
+
 const subscribe = () => () => {};
 const getClientSnapshot = () => true;
 const getServerSnapshot = () => false;
 
-export type DrawFlightMode = "directional" | "tracking";
-
-interface DrawFlightCardProps {
-  cardInstance: CardInstance | null;
-  flightKey: number | null;
-  mode: DrawFlightMode;
-  deckRectGetter: () => DOMRect | null;
-  handRectGetter?: () => DOMRect | null;
-  onComplete: () => void;
-}
-
-// CardView size="lg" の素サイズ (w-40 h-24)
-const CARD_W = 160;
-const CARD_H = 96;
-
-// 中央表示時の拡大率
-const CENTER_SCALE = 1.6;
-
-// タイミング (合計 2100ms)
-const FADE_IN_MS = 300;
-const HOLD_MS = 1200;
-const FADE_OUT_MS = 600;
-const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
-
 export function DrawFlightCard({
   cardInstance,
   flightKey,
-  mode,
   deckRectGetter,
   handRectGetter,
   onComplete,
@@ -49,13 +41,15 @@ export function DrawFlightCard({
   if (!isClient) return null;
 
   return createPortal(
-    <div className="fixed inset-0 pointer-events-none z-[60]">
+    <div
+      className="fixed inset-0 pointer-events-none z-[60]"
+      style={{ perspective: 1400 }}
+    >
       <AnimatePresence>
         {cardInstance && flightKey !== null && (
           <DrawFlightInner
             key={flightKey}
             cardInstance={cardInstance}
-            mode={mode}
             deckRectGetter={deckRectGetter}
             handRectGetter={handRectGetter}
             onComplete={onComplete}
@@ -69,21 +63,19 @@ export function DrawFlightCard({
 
 function DrawFlightInner({
   cardInstance,
-  mode,
   deckRectGetter,
   handRectGetter,
   onComplete,
 }: {
   cardInstance: CardInstance;
-  mode: DrawFlightMode;
   deckRectGetter: () => DOMRect | null;
-  handRectGetter?: () => DOMRect | null;
+  handRectGetter: () => DOMRect | null;
   onComplete: () => void;
 }) {
   const [coords] = useState(() => {
     if (typeof window === "undefined") return null;
     const deckRect = deckRectGetter();
-    const handRect = mode === "tracking" ? handRectGetter?.() ?? null : null;
+    const handRect = handRectGetter();
 
     const winW = window.innerWidth;
     const winH = window.innerHeight;
@@ -92,22 +84,19 @@ function DrawFlightInner({
 
     const startX = deckRect ? deckRect.x + deckRect.width / 2 - CARD_W / 2 : centerX;
     const startY = deckRect ? deckRect.y + deckRect.height / 2 - CARD_H / 2 : centerY;
-    // 山札の見かけサイズに開始スケールを合わせる (山札 md/lg のいずれでも近似)
-    const startScale = deckRect ? Math.max(0.45, deckRect.width / CARD_W) : 0.6;
+    const startScale = deckRect ? Math.max(0.25, deckRect.width / CARD_W) : 0.4;
 
     let endX: number;
     let endY: number;
     let endScale: number;
-    if (mode === "tracking" && handRect) {
+    if (handRect) {
       endX = handRect.x + handRect.width / 2 - CARD_W / 2;
       endY = handRect.y + handRect.height / 2 - CARD_H / 2;
-      // 手札サイズ (md = w-32 h-[80px] = 128x80) に近い縮小
-      endScale = Math.max(0.4, handRect.width / CARD_W);
+      endScale = Math.max(0.25, handRect.width / CARD_W);
     } else {
-      // directional: 中央からやや下方向 (手札方向) に縮小しつつフェード
       endX = centerX;
-      endY = centerY + 120;
-      endScale = 0.9;
+      endY = centerY + 240;
+      endScale = 0.4;
     }
 
     return { startX, startY, centerX, centerY, endX, endY, startScale, endScale };
@@ -120,6 +109,11 @@ function DrawFlightInner({
   const t1 = FADE_IN_MS / TOTAL_MS;
   const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
 
+  // 回転は累積で表現:
+  // - 0deg → 180deg (山札→中央): 裏向き開始 → 中央到着で表向き
+  // - 180deg ホールド: 表向き
+  // - 180deg → 360deg (中央→手札): 表向き → 裏向きに戻る
+  // 表/裏の切替は子要素の backface-visibility で自動
   return (
     <motion.div
       initial={{
@@ -127,12 +121,14 @@ function DrawFlightInner({
         top: startY,
         scale: startScale,
         opacity: 0,
+        rotateY: 0,
       }}
       animate={{
         left: [startX, centerX, centerX, endX],
         top: [startY, centerY, centerY, endY],
-        scale: [startScale, CENTER_SCALE, CENTER_SCALE, endScale],
+        scale: [startScale, 1, 1, endScale],
         opacity: [0, 1, 1, 0],
+        rotateY: [0, 180, 180, 360],
       }}
       transition={{
         duration: TOTAL_MS / 1000,
@@ -145,11 +141,32 @@ function DrawFlightInner({
         width: CARD_W,
         height: CARD_H,
         transformOrigin: "center center",
+        transformStyle: "preserve-3d",
         willChange: "transform, opacity, left, top",
       }}
       className="drop-shadow-2xl"
     >
-      <CardView card={cardInstance} size="lg" />
+      {/* 裏面 (rotateY 0 のとき手前) */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backfaceVisibility: "hidden",
+          WebkitBackfaceVisibility: "hidden",
+        }}
+      >
+        <CardView card={cardInstance} faceDown size="xl" fullWidth />
+      </div>
+      {/* 表面 (rotateY 180 のとき手前) */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backfaceVisibility: "hidden",
+          WebkitBackfaceVisibility: "hidden",
+          transform: "rotateY(180deg)",
+        }}
+      >
+        <CardView card={cardInstance} size="xl" fullWidth />
+      </div>
     </motion.div>
   );
 }

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -20,9 +20,14 @@ const CARD_W = 576;
 const CARD_H = 352;
 
 const FADE_IN_MS = 350;
-const HOLD_MS = 600;
+const HOLD_MS = 2000;
 const FADE_OUT_MS = 300;
 const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
+
+// 中央到着直後にカード上を斜めに走るシマー (光) と、周辺を一瞬光らせる黄金グロウ
+const FLASH_DELAY_S = FADE_IN_MS / 1000;
+const SHIMMER_DURATION_S = 0.7;
+const GLOW_DURATION_S = 0.8;
 
 const subscribe = () => () => {};
 const getClientSnapshot = () => true;
@@ -145,7 +150,11 @@ function DrawFlightInner({
       }}
     >
       <motion.div
-        animate={{ rotateY: [0, 540, 540, 1080] }}
+        animate={{
+          rotateY: [0, 540, 540, 1080],
+          // rotateZ で時計回りの円運動 (山札→中央 1周、中央→手札 1周、計2周)
+          rotateZ: [0, 360, 360, 720],
+        }}
         transition={{
           duration: TOTAL_MS / 1000,
           times: [0, t1, t2, 1],
@@ -170,14 +179,56 @@ function DrawFlightInner({
         </div>
         {/* 表面 (rotateY 180 のとき手前) */}
         <div
-          className="absolute inset-0 rounded-md shadow-2xl"
+          className="absolute inset-0"
           style={{
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",
             transform: "rotateY(180deg)",
           }}
         >
-          <CardView card={cardInstance} size="xl" fullWidth />
+          {/* 黄金グロウ: 中央到着の瞬間カード周辺がふわっと光る (はみ出し可) */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: [0, 0.95, 0], scale: [0.92, 1.08, 1] }}
+            transition={{
+              duration: GLOW_DURATION_S,
+              delay: FLASH_DELAY_S,
+              times: [0, 0.45, 1],
+              ease: "easeOut",
+            }}
+            style={{
+              position: "absolute",
+              inset: -12,
+              borderRadius: "0.6rem",
+              boxShadow: "0 0 90px 14px rgba(251, 191, 36, 0.9)",
+              pointerEvents: "none",
+            }}
+          />
+          {/* カード本体 + シマー (シマーはカード矩形内に収める) */}
+          <div className="absolute inset-0 rounded-md shadow-2xl overflow-hidden">
+            <CardView card={cardInstance} size="xl" fullWidth />
+            <motion.div
+              initial={{ x: "-110%", opacity: 0 }}
+              animate={{
+                x: ["-110%", "-110%", "210%"],
+                opacity: [0, 1, 0],
+              }}
+              transition={{
+                duration: SHIMMER_DURATION_S,
+                delay: FLASH_DELAY_S,
+                times: [0, 0.05, 1],
+                ease: "easeOut",
+              }}
+              style={{
+                position: "absolute",
+                inset: 0,
+                background:
+                  "linear-gradient(115deg, transparent 35%, rgba(255,255,255,0.9) 50%, transparent 65%)",
+                pointerEvents: "none",
+                mixBlendMode: "overlay",
+              }}
+            />
+          </div>
         </div>
       </motion.div>
     </motion.div>

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -86,6 +86,10 @@ function DrawFlightInner({
     const centerX = (winW - CARD_W) / 2;
     const centerY = (winH - CARD_H) / 2;
 
+    // モバイル等で 576x352 がそのまま入らない場合、ビューポートにフィットする倍率まで縮小。
+    // transform: scale なので 高解像度フォントを保ったまま縮小描画される (ボケなし)。
+    const centerScale = Math.min(1, (winW * 0.92) / CARD_W, (winH * 0.85) / CARD_H);
+
     const startX = deckRect ? deckRect.x + deckRect.width / 2 - CARD_W / 2 : centerX;
     const startY = deckRect ? deckRect.y + deckRect.height / 2 - CARD_H / 2 : centerY;
     const startScale = deckRect ? Math.max(0.15, deckRect.width / CARD_W) : 0.2;
@@ -103,12 +107,12 @@ function DrawFlightInner({
       endScale = 0.2;
     }
 
-    return { startX, startY, centerX, centerY, endX, endY, startScale, endScale };
+    return { startX, startY, centerX, centerY, endX, endY, startScale, centerScale, endScale };
   });
 
   if (!coords) return null;
 
-  const { startX, startY, centerX, centerY, endX, endY, startScale, endScale } = coords;
+  const { startX, startY, centerX, centerY, endX, endY, startScale, centerScale, endScale } = coords;
 
   const t1 = FADE_IN_MS / TOTAL_MS;
   const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
@@ -132,7 +136,7 @@ function DrawFlightInner({
       animate={{
         left: [startX, centerX, centerX, endX],
         top: [startY, centerY, centerY, endY],
-        scale: [startScale, 1, 1, endScale],
+        scale: [startScale, centerScale, centerScale, endScale],
         opacity: [0, 1, 1, 0],
       }}
       transition={{

--- a/src/components/game/card-shogi/draw-flight-card.tsx
+++ b/src/components/game/card-shogi/draw-flight-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -76,6 +76,22 @@ function DrawFlightInner({
   handRectGetter: () => DOMRect | null;
   onComplete: () => void;
 }) {
+  // タブ非アクティブ時に Framer Motion の onAnimationComplete が throttling で
+  // 遅延すると finalizeDraw が呼ばれず AI が永久に動かないリスクがある。
+  // 想定時間 + 500ms 経過しても発火しない場合は強制的に完了通知する保険。
+  // onAnimationComplete でも通知されるので completedRef で重複呼出しを防ぐ。
+  const completedRef = useRef(false);
+  const handleComplete = useCallback(() => {
+    if (completedRef.current) return;
+    completedRef.current = true;
+    onComplete();
+  }, [onComplete]);
+
+  useEffect(() => {
+    const id = window.setTimeout(handleComplete, TOTAL_MS + 500);
+    return () => window.clearTimeout(id);
+  }, [handleComplete]);
+
   const [coords] = useState(() => {
     if (typeof window === "undefined") return null;
     const deckRect = deckRectGetter();
@@ -144,7 +160,7 @@ function DrawFlightInner({
         times: [0, t1, t2, 1],
         ease: ["easeOut", "linear", "easeIn"],
       }}
-      onAnimationComplete={onComplete}
+      onAnimationComplete={handleComplete}
       style={{
         position: "fixed",
         width: CARD_W,

--- a/src/components/game/card-shogi/hand-area.tsx
+++ b/src/components/game/card-shogi/hand-area.tsx
@@ -18,6 +18,8 @@ interface HandAreaProps {
   disabled?: boolean;
   // true のとき各カードを横幅一杯に展開(vertical layout で使用)
   fullWidth?: boolean;
+  // Issue #78: 直前にドローしたカードを一瞬光らせる (instanceId 一致のカードに animate-hand-card-flash を付与)
+  flashCardId?: string | null;
 }
 
 export function HandArea({
@@ -30,6 +32,7 @@ export function HandArea({
   emptyLabel = "手札なし",
   disabled = false,
   fullWidth = false,
+  flashCardId = null,
 }: HandAreaProps) {
   if (hand.length === 0) {
     return <div className="text-xs text-muted-foreground py-2 px-3">{emptyLabel}</div>;
@@ -71,15 +74,20 @@ export function HandArea({
       {hand.map((c) => {
         const def = CARD_DEFS[c.defId];
         const cardDisabled = disabled || currentMana < def.cost;
+        const isFresh = c.instanceId === flashCardId;
         return (
-          <CardView
+          <div
             key={c.instanceId}
-            card={c}
-            size={size}
-            disabled={cardDisabled}
-            fullWidth={fullWidth}
-            onClick={() => onCardClick?.(c.instanceId)}
-          />
+            className={cn("rounded-md", isFresh && "animate-hand-card-flash")}
+          >
+            <CardView
+              card={c}
+              size={size}
+              disabled={cardDisabled}
+              fullWidth={fullWidth}
+              onClick={() => onCardClick?.(c.instanceId)}
+            />
+          </div>
         );
       })}
     </div>

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -59,6 +59,10 @@ interface CardShogiGameStateInternal {
   promotionPendingMove: Move | null;
   cardState: CardGameState;
   eventLog: GameEvent[];
+  // Issue #78: ドロー演出中フラグ。DRAW_CARD で true、演出完了時の COMMIT_DRAW で false。
+  // true の間は currentPlayer 反転を保留し、AI 自動応手をブロックする。
+  isDrawing: boolean;
+  pendingDrawPlayer: Player | null;
 }
 
 // 移動 + マナチャージ + トラップフィルタ を一括適用。
@@ -392,12 +396,13 @@ function reducer(
       if (state.gameState.currentPlayer !== action.player) return state;
       // 王手中はドロー禁止 (P10: 王手回避以外の手は禁止)
       if (isInCheck(state.gameState, action.player, CARD_SHOGI_VARIANT)) return state;
+      // 既にドロー演出中なら無視 (連発防止)
+      if (state.isDrawing) return state;
       const [top, ...rest] = deck;
-      const opponent: Player = action.player === "sente" ? "gote" : "sente";
+      // Issue #78: ドロー = 1手相当だが、currentPlayer 反転は演出完了時の COMMIT_DRAW まで保留。
+      // これにより演出中は currentPlayer === playerColor のままで AI 自動応手がブロックされる。
       return {
         ...state,
-        // ドロー = 1手相当。currentPlayer を反転 + lastTurnStartedAt をクリア (B1)
-        gameState: { ...state.gameState, currentPlayer: opponent },
         cardState: {
           ...state.cardState,
           mana: {
@@ -409,10 +414,6 @@ function reducer(
             ...state.cardState.hand,
             [action.player]: [...state.cardState.hand[action.player], top],
           },
-          lastTurnStartedAt: {
-            ...state.cardState.lastTurnStartedAt,
-            [action.player]: null,
-          },
         },
         // 駒選択状態もクリア
         selectedSquare: null,
@@ -422,6 +423,27 @@ function reducer(
           ...state.eventLog,
           { kind: "drawEvent", player: action.player, instance: top, at: Date.now() },
         ],
+        isDrawing: true,
+        pendingDrawPlayer: action.player,
+      };
+    }
+
+    case "COMMIT_DRAW": {
+      if (!state.isDrawing || !state.pendingDrawPlayer) return state;
+      const drawer = state.pendingDrawPlayer;
+      const opponent: Player = drawer === "sente" ? "gote" : "sente";
+      return {
+        ...state,
+        gameState: { ...state.gameState, currentPlayer: opponent },
+        cardState: {
+          ...state.cardState,
+          lastTurnStartedAt: {
+            ...state.cardState.lastTurnStartedAt,
+            [drawer]: null,
+          },
+        },
+        isDrawing: false,
+        pendingDrawPlayer: null,
       };
     }
 
@@ -644,6 +666,8 @@ export function useCardShogiGame({
     promotionPendingMove: null,
     cardState: initialCardState,
     eventLog: [],
+    isDrawing: false,
+    pendingDrawPlayer: null,
   });
 
   const aiPlayer: Player = gameConfig.playerColor === "sente" ? "gote" : "sente";
@@ -666,7 +690,9 @@ export function useCardShogiGame({
       gameState.status !== "active" ||
       gameState.currentPlayer !== aiPlayer ||
       state.isAiThinking ||
-      state.cardState.pendingCard !== null
+      state.cardState.pendingCard !== null ||
+      // Issue #78: ドロー演出中は AI 思考をブロック (COMMIT_DRAW 後に再評価される)
+      state.isDrawing
     ) {
       return;
     }
@@ -692,7 +718,7 @@ export function useCardShogiGame({
       }, 500);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.gameState.currentPlayer, state.gameState.status, state.cardState.pendingCard]);
+  }, [state.gameState.currentPlayer, state.gameState.status, state.cardState.pendingCard, state.isDrawing]);
 
   // DB 保存(state 変更を監視して、最新の moveCount で保存)
   const lastSavedMoveCountRef = useRef(initialState.moveCount);
@@ -839,6 +865,11 @@ export function useCardShogiGame({
     dispatch({ type: "DRAW_CARD", player: gameConfig.playerColor });
   }, [gameConfig.playerColor]);
 
+  // Issue #78: ドロー演出完了時に呼ぶ。currentPlayer を相手に渡し AI 思考を解禁する。
+  const finalizeDraw = useCallback(() => {
+    dispatch({ type: "COMMIT_DRAW" });
+  }, []);
+
   const beginPlayCard = useCallback(
     (instanceId: string) => {
       dispatch({ type: "BEGIN_PLAY_CARD", player: gameConfig.playerColor, instanceId });
@@ -875,9 +906,11 @@ export function useCardShogiGame({
     undo,
     deselect,
     drawCard,
+    finalizeDraw,
     beginPlayCard,
     selectCardTarget,
     confirmPlayCard,
     cancelPlayCard,
+    isDrawing: state.isDrawing,
   };
 }

--- a/src/lib/shogi/cards/types.ts
+++ b/src/lib/shogi/cards/types.ts
@@ -65,6 +65,8 @@ export interface CardGameState {
 export type CardAction =
   | { type: "CHARGE_MANA"; player: Player; amount: number; reason: "turn" | "card" }
   | { type: "DRAW_CARD"; player: Player }
+  // ドロー演出完了時に呼ぶ。currentPlayer を相手に渡し、isDrawing をクリア。
+  | { type: "COMMIT_DRAW" }
   | { type: "BEGIN_PLAY_CARD"; player: Player; instanceId: string }
   | { type: "SELECT_CARD_TARGET"; target: CardTarget }
   | { type: "CONFIRM_PLAY_CARD" }


### PR DESCRIPTION
## Summary

Issue #78 「カード将棋ドロー時の中央演出」の実装。Framer Motion + Portal でドローしたカードを「山札 → 画面中央 → 手札」へ DOMRect 完全追従で飛ばし、表/裏フリップ・時計回り回転・キラリ演出を加える。演出中はプレイヤーの手番を維持し AI を待たせる。

Closes #78

### 主な変更
- **DrawFlightCard 新規** (`draw-flight-card.tsx`): Portal + Framer Motion で document.body に描画。位置/スケール/不透明度と回転を別 motion.div に分離 (filter による preserve-3d flatten 回避)
  - 山札→中央 (350ms): rotateY 0→540 (1.5周フリップ、最後表向き)、rotateZ 0→360 (時計回り1周)
  - 中央ホールド (2000ms): 表向きで停止、シマー(白い斜光)+黄金グロウ で「キラリ」演出
  - 中央→手札 (300ms): rotateY 維持・rotateZ もう1周、scale 縮小して手札位置へ吸込み
- **CardView size=\"xl\"** (`card-view.tsx`): 576x352px、フォント・アイコン・パディングを2倍化 (倍率拡大ではなく解像度を保つ)
- **Reducer 2段階化** (`use-card-shogi-game.ts`, `cards/types.ts`): DRAW_CARD は currentPlayer を維持しつつ isDrawing=true、新アクション COMMIT_DRAW で currentPlayer 反転 + isDrawing クリア。AI 自動応手 useEffect に state.isDrawing ガードを追加し、演出完了まで AI を待機
- **手札フラッシュ** (`hand-area.tsx`, `globals.css`): 演出完了 900ms 間、手札の対象カードを `animate-hand-card-flash` (黄金 box-shadow ふわっと) で点灯
- **モバイル対応** (`draw-flight-card.tsx`): 中央 scale をビューポートにフィットする倍率に動的計算 (`min(1, winW*0.92/576, winH*0.85/352)`)
- **保険タイマー** (`draw-flight-card.tsx`): タブ非アクティブ時の Framer Motion throttling 対策で TOTAL_MS+500ms の強制完了タイマー、completedRef で重複防止

## Test plan

- [x] PC (Chromium 1556px幅) で山札クリック → 中央演出 → 手札に着地
- [x] モバイル (~390px幅) で中央カードが画面内に収まる
- [x] 中央到着時に表向きで停止、キラリ演出が見える
- [x] ドロー演出中は AI が動かない
- [x] 演出完了後に手札の対象カードが一瞬光る
- [x] 演出中は盤面・手札・カード操作・背景クリックがロックされる
- [x] tsc --noEmit パス
- [x] eslint パス (新規 warning 無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)