### PR TITLE
#77 カード将棋マナ加減算アニメーション

### DIFF
--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -9,7 +9,7 @@ import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
 import { useSound } from "@/hooks/use-sound";
 import { useCardBoardSize } from "@/hooks/use-card-board-size";
 
-import { ShogiBoard } from "../shogi-board";
+import { ShogiBoard, type ShogiBoardHandle } from "../shogi-board";
 import { CapturedPieces } from "../captured-pieces";
 import { CardShogiHistory } from "./card-shogi-history";
 import { GameControls } from "../game-controls";
@@ -32,7 +32,7 @@ import { getVariantById } from "@/lib/shogi/variants/index";
 import type { Difficulty, GameConfig, GameState, Move, Player, Position } from "@/lib/shogi/types";
 import type { CommentaryEvent } from "@/app/actions/commentary";
 import type { CardGameState, CardInstance } from "@/lib/shogi/cards/types";
-import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
+import { CARD_DEFS, PHASE0_DRAW_COST } from "@/lib/shogi/cards/definitions";
 import { createGame } from "@/app/actions/game";
 
 import { ManaGauge } from "./mana-gauge";
@@ -41,6 +41,7 @@ import { TrapSlot } from "./trap-slot";
 import { DeckPile } from "./deck-pile";
 import { CardPlayDialog, CardTargetingNotice } from "./card-play-dialog";
 import { DrawFlightCard } from "./draw-flight-card";
+import { ManaFlightLayer, type ManaFlightItem } from "./mana-flight";
 
 interface SerializableGameConfig {
   variantId: string;
@@ -87,6 +88,15 @@ export function CardShogiGame({
   const ownHandTabletRef = useRef<HTMLDivElement>(null);
   const ownHandMobileBtnRef = useRef<HTMLDivElement>(null);
   const ownHandXlRef = useRef<HTMLDivElement>(null);
+  // 各レイアウトの ShogiBoard ref。表示中のものから盤面マスの矩形を取得する。
+  const boardTabletRef = useRef<ShogiBoardHandle>(null);
+  const boardXlRef = useRef<ShogiBoardHandle>(null);
+  // マナ増減の浮遊テキスト (Issue #77)。各イベントを起点 UI 付近で表示する。
+  const [manaFlights, setManaFlights] = useState<ManaFlightItem[]>([]);
+  const manaFlightIdRef = useRef(0);
+  // カード使用時、reducer がカードを hand から削除する前に DOMRect を保管する。
+  // cardPlayEvent / trapSetEvent / マナUP の manaChargeEvent(reason: card) の起点として使う。
+  const playedCardRectRef = useRef<{ id: string; rect: DOMRect } | null>(null);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const { squareSize, isMobile, viewportHeight } = useCardBoardSize();
@@ -198,43 +208,7 @@ export function CardShogiGame({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady]);
 
-  // カードイベント由来の SE 再生と画面演出 (eventLog の差分監視)
   const lastEventIndexRef = useRef(0);
-  useEffect(() => {
-    if (!isReady) return;
-    const newEvents = eventLog.slice(lastEventIndexRef.current);
-    for (const ev of newEvents) {
-      switch (ev.kind) {
-        case "drawEvent":
-          playSfx("card_draw");
-          // Issue #78: 自分のドローのみ中央演出 (AI ドローは Phase 0 では発生しない想定だが防御的に絞る)
-          if (ev.player === playerColor) {
-            setDrawFlight({ card: ev.instance, key: Date.now() });
-          }
-          break;
-        case "cardPlayEvent":
-          playSfx("card_play");
-          break;
-        case "manaChargeEvent":
-          // ターン由来の自動チャージは駒移動 SE と被るため、カード由来のみ鳴らす
-          if (ev.reason === "card") playSfx("mana_charge");
-          break;
-        case "trapSetEvent":
-          playSfx("card_play");
-          break;
-        case "trapTriggerEvent":
-          playSfx("trap_trigger");
-          // R16/R20: トラップ発動を画面中央オーバーレイで明示、トラップ名も併記
-          setOverlayEvent({
-            event: "trap_trigger",
-            key: Date.now(),
-            trapName: CARD_DEFS[ev.instance.defId].name,
-          });
-          break;
-      }
-    }
-    lastEventIndexRef.current = eventLog.length;
-  }, [eventLog, isReady, playSfx, playerColor]);
 
   // 表示中の山札ラッパーから矩形を取得 (xl 以上 → タブレット → モバイル の順に visibility 判定)
   const getDeckRect = useCallback((): DOMRect | null => {
@@ -258,13 +232,139 @@ export function CardShogiGame({
     return null;
   }, []);
 
+  // 盤面マスの DOMRect。表示中の ShogiBoard (xl→タブレット) から取得する。
+  const getBoardSquareRect = useCallback((row: number, col: number): DOMRect | null => {
+    for (const ref of [boardXlRef, boardTabletRef]) {
+      const handle = ref.current;
+      if (!handle) continue;
+      const rect = handle.getSquareRect(row, col);
+      if (rect && rect.width > 0 && rect.height > 0) return rect;
+    }
+    return null;
+  }, []);
+
+  const triggerManaFlight = useCallback((delta: number, rect: DOMRect | null) => {
+    if (!rect || delta === 0) return;
+    manaFlightIdRef.current += 1;
+    const id = manaFlightIdRef.current;
+    setManaFlights((prev) => [...prev, { id, delta, rect }]);
+  }, []);
+
+  const removeManaFlight = useCallback((id: number) => {
+    setManaFlights((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  // 表示中の手札の中から該当カード DOM を見つけて DOMRect を返す。
+  const findVisibleCardRect = useCallback((instanceId: string): DOMRect | null => {
+    if (typeof document === "undefined") return null;
+    const els = document.querySelectorAll<HTMLElement>(`[data-card-id="${instanceId}"]`);
+    for (const el of els) {
+      if (el.offsetParent !== null) {
+        const rect = el.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) return rect;
+      }
+    }
+    return null;
+  }, []);
+
+  // reducer が hand からカードを削除する前に、使用カードの矩形を捕捉する。
+  // 後続イベント (cardPlayEvent / trapSetEvent / manaChargeEvent reason="card") で起点として参照される。
+  const cachePendingCardRect = useCallback(() => {
+    const pc = cardState.pendingCard;
+    if (!pc) return;
+    const rect = findVisibleCardRect(pc.instance.instanceId);
+    if (rect) playedCardRectRef.current = { id: pc.instance.instanceId, rect };
+  }, [cardState.pendingCard, findVisibleCardRect]);
+
+  const handleConfirmPlayCard = useCallback(() => {
+    cachePendingCardRect();
+    confirmPlayCard();
+  }, [cachePendingCardRect, confirmPlayCard]);
+
+  // カードイベント由来の SE 再生・画面演出・マナ浮遊テキストを eventLog の差分監視で発火
+  useEffect(() => {
+    if (!isReady) return;
+    const startIdx = lastEventIndexRef.current;
+    const newEvents = eventLog.slice(startIdx);
+    for (let i = 0; i < newEvents.length; i++) {
+      const ev = newEvents[i];
+      const absoluteIdx = startIdx + i;
+      switch (ev.kind) {
+        case "drawEvent":
+          playSfx("card_draw");
+          // Issue #78: 自分のドローのみ中央演出 (AI ドローは Phase 0 では発生しない想定だが防御的に絞る)
+          if (ev.player === playerColor) {
+            setDrawFlight({ card: ev.instance, key: Date.now() });
+          }
+          // Issue #77: 山札の位置で -5 マナ表示
+          triggerManaFlight(-PHASE0_DRAW_COST, getDeckRect());
+          break;
+        case "cardPlayEvent": {
+          playSfx("card_play");
+          const def = CARD_DEFS[ev.instance.defId];
+          if (def.cost > 0) {
+            const cached = playedCardRectRef.current;
+            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
+            triggerManaFlight(-def.cost, rect);
+          }
+          break;
+        }
+        case "manaChargeEvent":
+          // ターン由来の自動チャージは駒移動 SE と被るため、カード由来のみ鳴らす
+          if (ev.reason === "card") playSfx("mana_charge");
+          // Issue #77: マナ加算を起点 UI 付近に表示
+          if (ev.reason === "turn") {
+            // 直前の同 player の moveEvent を遡って探し、移動先マスに表示
+            let moveTo: { row: number; col: number } | null = null;
+            for (let j = absoluteIdx - 1; j >= 0; j--) {
+              const m = eventLog[j];
+              if (m.kind === "moveEvent" && m.move.player === ev.player) {
+                moveTo = m.move.to;
+                break;
+              }
+            }
+            const rect = moveTo ? getBoardSquareRect(moveTo.row, moveTo.col) : null;
+            triggerManaFlight(ev.amount, rect);
+          } else {
+            // カード由来 (マナUP等): 直前に使用したカードの位置 (なければ手札中央)
+            const cached = playedCardRectRef.current;
+            const rect = cached?.rect ?? getHandRect();
+            triggerManaFlight(ev.amount, rect);
+          }
+          break;
+        case "trapSetEvent": {
+          playSfx("card_play");
+          const def = CARD_DEFS[ev.instance.defId];
+          if (def.cost > 0) {
+            const cached = playedCardRectRef.current;
+            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
+            triggerManaFlight(-def.cost, rect);
+          }
+          break;
+        }
+        case "trapTriggerEvent":
+          playSfx("trap_trigger");
+          // R16/R20: トラップ発動を画面中央オーバーレイで明示、トラップ名も併記
+          setOverlayEvent({
+            event: "trap_trigger",
+            key: Date.now(),
+            trapName: CARD_DEFS[ev.instance.defId].name,
+          });
+          break;
+      }
+    }
+    lastEventIndexRef.current = eventLog.length;
+  }, [eventLog, isReady, playSfx, playerColor, triggerManaFlight, getDeckRect, getHandRect, getBoardSquareRect]);
+
   // Issue #78: 演出中は盤面・手札・カード操作・背景クリックをロックする
   const handleSquareClick = useCallback(
     (pos: Position) => {
       if (isDrawAnimating) return;
+      // 歩戻し等のターゲット選択フェーズで盤面クリックが confirm に直結するため、ここでも矩形を捕捉
+      if (cardState.pendingCard) cachePendingCardRect();
       selectSquare(pos);
     },
-    [isDrawAnimating, selectSquare],
+    [isDrawAnimating, selectSquare, cardState.pendingCard, cachePendingCardRect],
   );
   const handleHandPieceClick = useCallback(
     (piece: Parameters<typeof selectHandPiece>[0]) => {
@@ -507,6 +607,7 @@ export function CardShogiGame({
           {/* 盤面 */}
           <div className="relative shrink-0 my-0.5">
             <ShogiBoard
+              ref={boardTabletRef}
               board={gameState.board}
               currentPlayer={gameState.currentPlayer}
               playerColor={playerColor}
@@ -809,6 +910,7 @@ export function CardShogiGame({
           </div>
           <div className="relative shrink-0">
             <ShogiBoard
+              ref={boardXlRef}
               board={gameState.board}
               currentPlayer={gameState.currentPlayer}
               playerColor={playerColor}
@@ -901,7 +1003,7 @@ export function CardShogiGame({
       />
       <CardPlayDialog
         pendingCard={cardState.pendingCard}
-        onConfirm={confirmPlayCard}
+        onConfirm={handleConfirmPlayCard}
         onCancel={cancelPlayCard}
       />
       <CardTargetingNotice
@@ -917,6 +1019,9 @@ export function CardShogiGame({
         handRectGetter={getHandRect}
         onComplete={handleDrawFlightComplete}
       />
+
+      {/* Issue #77: マナ加減算の浮遊テキスト (起点 UI 付近に表示) */}
+      <ManaFlightLayer items={manaFlights} onComplete={removeManaFlight} />
     </div>
   );
 }

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -139,6 +139,7 @@ export function CardView({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      data-card-id={card.instanceId}
       className={cn(
         "rounded-md border-2 bg-card text-card-foreground shadow-sm shrink-0",
         "flex flex-row items-stretch text-left transition-all",

--- a/src/components/game/card-shogi/mana-flight.tsx
+++ b/src/components/game/card-shogi/mana-flight.tsx
@@ -65,12 +65,11 @@ function ManaFlightSingle({
 
   return (
     <motion.div
-      initial={{ left: startLeft, top: startTop, opacity: 0, scale: 0.6 }}
+      initial={{ left: startLeft, top: startTop, opacity: 0 }}
       animate={{
         left: startLeft,
         top: endTop,
         opacity: [0, 1, 1, 0],
-        scale: 1,
       }}
       transition={{
         duration: DURATION_S,

--- a/src/components/game/card-shogi/mana-flight.tsx
+++ b/src/components/game/card-shogi/mana-flight.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+export interface ManaFlightItem {
+  id: number;
+  delta: number;
+  rect: DOMRect;
+}
+
+interface ManaFlightLayerProps {
+  items: ManaFlightItem[];
+  onComplete: (id: number) => void;
+}
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+const DURATION_S = 1.1;
+const FLOAT_DISTANCE_PX = 60;
+const BOX_W = 200;
+const BOX_H = 56;
+
+export function ManaFlightLayer({ items, onComplete }: ManaFlightLayerProps) {
+  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+  if (!isClient) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 pointer-events-none z-[55]">
+      <AnimatePresence>
+        {items.map((item) => (
+          <ManaFlightSingle
+            key={item.id}
+            item={item}
+            onComplete={() => onComplete(item.id)}
+          />
+        ))}
+      </AnimatePresence>
+    </div>,
+    document.body,
+  );
+}
+
+function ManaFlightSingle({
+  item,
+  onComplete,
+}: {
+  item: ManaFlightItem;
+  onComplete: () => void;
+}) {
+  const { rect, delta } = item;
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const startLeft = cx - BOX_W / 2;
+  const startTop = cy - BOX_H / 2;
+  const endTop = startTop - FLOAT_DISTANCE_PX;
+
+  const text = delta > 0 ? `💎+${delta}` : `💎${delta}`;
+  const colorClass = delta > 0 ? "text-emerald-400" : "text-rose-400";
+
+  return (
+    <motion.div
+      initial={{ left: startLeft, top: startTop, opacity: 0, scale: 0.6 }}
+      animate={{
+        left: startLeft,
+        top: endTop,
+        opacity: [0, 1, 1, 0],
+        scale: 1,
+      }}
+      transition={{
+        duration: DURATION_S,
+        times: [0, 0.15, 0.7, 1],
+        ease: "easeOut",
+      }}
+      onAnimationComplete={onComplete}
+      style={{
+        position: "fixed",
+        width: BOX_W,
+        height: BOX_H,
+        willChange: "transform, opacity, top, left",
+      }}
+      className="flex items-center justify-center"
+    >
+      <span
+        className={cn(
+          "select-none tabular-nums font-extrabold text-3xl",
+          "drop-shadow-[0_2px_4px_rgba(0,0,0,0.6)]",
+          colorClass,
+        )}
+        style={{
+          textShadow: "0 0 6px rgba(0,0,0,0.5)",
+        }}
+      >
+        {text}
+      </span>
+    </motion.div>
+  );
+}

--- a/src/components/game/card-shogi/mana-gauge.tsx
+++ b/src/components/game/card-shogi/mana-gauge.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
 import { cn } from "@/lib/utils";
 import { PHASE0_DRAW_COST } from "@/lib/shogi/cards/definitions";
 
@@ -10,14 +13,68 @@ interface ManaGaugeProps {
   label?: string;
 }
 
+interface FloatingDelta {
+  id: number;
+  delta: number;
+}
+
+const FLASH_DURATION_MS = 1000;
+
 export function ManaGauge({ current, cap, compact = false, label }: ManaGaugeProps) {
   const ratio = Math.min(1, current / cap);
   const canDraw = current >= PHASE0_DRAW_COST;
 
+  const previousRef = useRef<number>(current);
+  const floatIdRef = useRef<number>(0);
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [floats, setFloats] = useState<FloatingDelta[]>([]);
+  const [flash, setFlash] = useState<"plus" | "minus" | null>(null);
+
+  useEffect(() => {
+    const previous = previousRef.current;
+    if (current === previous) return;
+
+    const delta = current - previous;
+    previousRef.current = current;
+
+    floatIdRef.current += 1;
+    const id = floatIdRef.current;
+    setFloats((prev) => [...prev, { id, delta }]);
+    setFlash(delta > 0 ? "plus" : "minus");
+
+    if (flashTimeoutRef.current) {
+      clearTimeout(flashTimeoutRef.current);
+    }
+    flashTimeoutRef.current = setTimeout(() => {
+      setFlash(null);
+      flashTimeoutRef.current = null;
+    }, FLASH_DURATION_MS);
+  }, [current]);
+
+  useEffect(() => {
+    return () => {
+      if (flashTimeoutRef.current) {
+        clearTimeout(flashTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const removeFloat = (id: number) => {
+    setFloats((prev) => prev.filter((f) => f.id !== id));
+  };
+
+  const gaugeGradientClass =
+    flash === "plus"
+      ? "from-emerald-400 to-green-500"
+      : flash === "minus"
+        ? "from-rose-400 to-red-500"
+        : "from-cyan-400 to-blue-500";
+
   return (
     <div
       className={cn(
-        "flex items-center gap-2 rounded-md border bg-card px-2 py-1",
+        "relative flex items-center gap-2 rounded-md border bg-card px-2 py-1",
         canDraw && "border-amber-400 shadow-sm",
         compact ? "text-[10px]" : "text-xs",
       )}
@@ -40,9 +97,39 @@ export function ManaGauge({ current, cap, compact = false, label }: ManaGaugePro
         )}
       >
         <div
-          className="h-full bg-gradient-to-r from-cyan-400 to-blue-500 transition-all duration-300"
+          className={cn(
+            "h-full bg-gradient-to-r transition-all duration-300",
+            gaugeGradientClass,
+          )}
           style={{ width: `${ratio * 100}%` }}
         />
+      </div>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 z-10 flex flex-col items-center"
+      >
+        <AnimatePresence>
+          {floats.map((f) => (
+            <motion.span
+              key={f.id}
+              initial={{ y: 0, opacity: 0, scale: 0.6 }}
+              animate={{
+                y: compact ? -22 : -28,
+                opacity: [0, 1, 1, 0],
+                scale: 1,
+              }}
+              transition={{ duration: 0.9, times: [0, 0.15, 0.7, 1] }}
+              onAnimationComplete={() => removeFloat(f.id)}
+              className={cn(
+                "inline-block font-bold tabular-nums select-none drop-shadow-sm",
+                compact ? "text-xs" : "text-sm",
+                f.delta > 0 ? "text-emerald-500" : "text-rose-500",
+              )}
+            >
+              {f.delta > 0 ? `+${f.delta}` : f.delta}
+            </motion.span>
+          ))}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/src/components/game/card-shogi/mana-gauge.tsx
+++ b/src/components/game/card-shogi/mana-gauge.tsx
@@ -20,7 +20,7 @@ interface DeltaSegment {
   kind: "plus" | "minus";
 }
 
-const SEGMENT_DURATION_S = 1.2;
+const SEGMENT_DURATION_S = 2.4;
 
 export function ManaGauge({ current, cap, compact = false, label }: ManaGaugeProps) {
   const ratio = Math.min(1, current / cap);
@@ -86,23 +86,32 @@ export function ManaGauge({ current, cap, compact = false, label }: ManaGaugePro
           style={{ width: `${ratio * 100}%` }}
         />
         <AnimatePresence>
-          {segments.map((s) => (
-            <motion.div
-              key={s.id}
-              initial={{ opacity: 1 }}
-              animate={{ opacity: 0 }}
-              transition={{ duration: SEGMENT_DURATION_S, ease: "easeOut" }}
-              onAnimationComplete={() => removeSegment(s.id)}
-              className={cn(
-                "absolute top-0 bottom-0",
-                s.kind === "plus" ? "bg-emerald-500" : "bg-rose-500",
-              )}
-              style={{
-                left: `${s.left * 100}%`,
-                width: `${s.width * 100}%`,
-              }}
-            />
-          ))}
+          {segments.map((s) => {
+            const isPlus = s.kind === "plus";
+            const initialWidth = `${s.width * 100}%`;
+            return (
+              <motion.div
+                key={s.id}
+                // プラス: width 維持で opacity 1→0 にフェードアウト
+                // マイナス: opacity 維持で width を右端から 0% に縮める (右から徐々に消える)
+                initial={{ opacity: 1, width: initialWidth }}
+                animate={
+                  isPlus
+                    ? { opacity: 0, width: initialWidth }
+                    : { opacity: 1, width: "0%" }
+                }
+                transition={{ duration: SEGMENT_DURATION_S, ease: "easeOut" }}
+                onAnimationComplete={() => removeSegment(s.id)}
+                className={cn(
+                  "absolute top-0 bottom-0",
+                  isPlus ? "bg-emerald-500" : "bg-rose-500",
+                )}
+                style={{
+                  left: `${s.left * 100}%`,
+                }}
+              />
+            );
+          })}
         </AnimatePresence>
       </div>
     </div>

--- a/src/components/game/card-shogi/mana-gauge.tsx
+++ b/src/components/game/card-shogi/mana-gauge.tsx
@@ -13,68 +13,53 @@ interface ManaGaugeProps {
   label?: string;
 }
 
-interface FloatingDelta {
+interface DeltaSegment {
   id: number;
-  delta: number;
+  left: number;
+  width: number;
+  kind: "plus" | "minus";
 }
 
-const FLASH_DURATION_MS = 1000;
+const SEGMENT_DURATION_S = 1.2;
 
 export function ManaGauge({ current, cap, compact = false, label }: ManaGaugeProps) {
   const ratio = Math.min(1, current / cap);
   const canDraw = current >= PHASE0_DRAW_COST;
 
   const previousRef = useRef<number>(current);
-  const floatIdRef = useRef<number>(0);
-  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const [floats, setFloats] = useState<FloatingDelta[]>([]);
-  const [flash, setFlash] = useState<"plus" | "minus" | null>(null);
+  const segIdRef = useRef<number>(0);
+  const [segments, setSegments] = useState<DeltaSegment[]>([]);
 
   useEffect(() => {
     const previous = previousRef.current;
     if (current === previous) return;
 
     const delta = current - previous;
+    const prevRatio = Math.min(1, Math.max(0, previous / cap));
+    const newRatio = Math.min(1, Math.max(0, current / cap));
     previousRef.current = current;
 
-    floatIdRef.current += 1;
-    const id = floatIdRef.current;
-    setFloats((prev) => [...prev, { id, delta }]);
-    setFlash(delta > 0 ? "plus" : "minus");
+    const left = delta > 0 ? prevRatio : newRatio;
+    const right = delta > 0 ? newRatio : prevRatio;
+    const width = Math.max(0, right - left);
+    if (width <= 0) return;
 
-    if (flashTimeoutRef.current) {
-      clearTimeout(flashTimeoutRef.current);
-    }
-    flashTimeoutRef.current = setTimeout(() => {
-      setFlash(null);
-      flashTimeoutRef.current = null;
-    }, FLASH_DURATION_MS);
-  }, [current]);
+    segIdRef.current += 1;
+    const id = segIdRef.current;
+    setSegments((prev) => [
+      ...prev,
+      { id, left, width, kind: delta > 0 ? "plus" : "minus" },
+    ]);
+  }, [current, cap]);
 
-  useEffect(() => {
-    return () => {
-      if (flashTimeoutRef.current) {
-        clearTimeout(flashTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const removeFloat = (id: number) => {
-    setFloats((prev) => prev.filter((f) => f.id !== id));
+  const removeSegment = (id: number) => {
+    setSegments((prev) => prev.filter((s) => s.id !== id));
   };
-
-  const gaugeGradientClass =
-    flash === "plus"
-      ? "from-emerald-400 to-green-500"
-      : flash === "minus"
-        ? "from-rose-400 to-red-500"
-        : "from-cyan-400 to-blue-500";
 
   return (
     <div
       className={cn(
-        "relative flex items-center gap-2 rounded-md border bg-card px-2 py-1",
+        "flex items-center gap-2 rounded-md border bg-card px-2 py-1",
         canDraw && "border-amber-400 shadow-sm",
         compact ? "text-[10px]" : "text-xs",
       )}
@@ -92,42 +77,31 @@ export function ManaGauge({ current, cap, compact = false, label }: ManaGaugePro
       </span>
       <div
         className={cn(
-          "flex-1 h-1.5 rounded-full bg-muted overflow-hidden min-w-[60px]",
+          "relative flex-1 h-1.5 rounded-full bg-muted overflow-hidden min-w-[60px]",
           compact && "min-w-[40px]",
         )}
       >
         <div
-          className={cn(
-            "h-full bg-gradient-to-r transition-all duration-300",
-            gaugeGradientClass,
-          )}
+          className="h-full bg-gradient-to-r from-cyan-400 to-blue-500 transition-all duration-300"
           style={{ width: `${ratio * 100}%` }}
         />
-      </div>
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 z-10 flex flex-col items-center"
-      >
         <AnimatePresence>
-          {floats.map((f) => (
-            <motion.span
-              key={f.id}
-              initial={{ y: 0, opacity: 0, scale: 0.6 }}
-              animate={{
-                y: compact ? -22 : -28,
-                opacity: [0, 1, 1, 0],
-                scale: 1,
-              }}
-              transition={{ duration: 0.9, times: [0, 0.15, 0.7, 1] }}
-              onAnimationComplete={() => removeFloat(f.id)}
+          {segments.map((s) => (
+            <motion.div
+              key={s.id}
+              initial={{ opacity: 1 }}
+              animate={{ opacity: 0 }}
+              transition={{ duration: SEGMENT_DURATION_S, ease: "easeOut" }}
+              onAnimationComplete={() => removeSegment(s.id)}
               className={cn(
-                "inline-block font-bold tabular-nums select-none drop-shadow-sm",
-                compact ? "text-xs" : "text-sm",
-                f.delta > 0 ? "text-emerald-500" : "text-rose-500",
+                "absolute top-0 bottom-0",
+                s.kind === "plus" ? "bg-emerald-500" : "bg-rose-500",
               )}
-            >
-              {f.delta > 0 ? `+${f.delta}` : f.delta}
-            </motion.span>
+              style={{
+                left: `${s.left * 100}%`,
+                width: `${s.width * 100}%`,
+              }}
+            />
           ))}
         </AnimatePresence>
       </div>

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { forwardRef, useImperativeHandle, useRef } from "react";
+
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
 import { useTouchHandler } from "@/hooks/use-touch-handler";
 import type { Board, Move, Player, Position } from "@/lib/shogi/types";
+
+export interface ShogiBoardHandle {
+  getSquareRect: (row: number, col: number) => DOMRect | null;
+}
 
 interface ShogiBoardProps {
   board: Board;
@@ -29,20 +35,35 @@ const RANK_LABELS_SENTE = ["一", "二", "三", "四", "五", "六", "七", "八
 const FILE_LABELS_GOTE = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 const RANK_LABELS_GOTE = ["九", "八", "七", "六", "五", "四", "三", "二", "一"];
 
-export function ShogiBoard({
-  board,
-  currentPlayer,
-  playerColor,
-  selectedSquare,
-  legalMoves,
-  lastMove,
-  isAiThinking,
-  inCheck,
-  onSquareClick,
-  squareSize,
-  isMobile,
-  cardTargetSquares,
-}: ShogiBoardProps) {
+export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function ShogiBoard(
+  {
+    board,
+    currentPlayer,
+    playerColor,
+    selectedSquare,
+    legalMoves,
+    lastMove,
+    isAiThinking,
+    inCheck,
+    onSquareClick,
+    squareSize,
+    isMobile,
+    cardTargetSquares,
+  },
+  forwardedRef,
+) {
+  const squareRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      getSquareRect: (row, col) => {
+        const el = squareRefs.current.get(`${row}-${col}`);
+        return el ? el.getBoundingClientRect() : null;
+      },
+    }),
+    [],
+  );
   const legalMoveSet = new Set(
     legalMoves.map((m) => `${m.to.row}-${m.to.col}`)
   );
@@ -132,6 +153,11 @@ export function ShogiBoard({
               return (
                 <div
                   key={`${rowIdx}-${colIdx}`}
+                  ref={(el) => {
+                    const key = `${rowIdx}-${colIdx}`;
+                    if (el) squareRefs.current.set(key, el);
+                    else squareRefs.current.delete(key);
+                  }}
                   data-legal={isLegalTarget}
                   className={cn(
                     "shogi-square relative flex items-center justify-center",
@@ -213,4 +239,4 @@ export function ShogiBoard({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

- カード将棋モードでマナが増減した際の視覚フィードバックを追加
- ゲージ本体は **増減分のみ** 部分セグメントで色変化(プラス=緑フェード/マイナス=右から削れる)、表示時間 2.4s
- 浮遊テキスト `💎+N` / `💎−N` を **増減起点 UI 付近**(指した駒のマス・山札・使用カード)で表示。サイズ一定・上方向に 60px 浮遊しフェード

## 主な変更

- `mana-gauge.tsx`: 部分セグメント方式 (AnimatePresence + 絶対配置オーバーレイ)
- `mana-flight.tsx` (新規): Portal + framer-motion で DOMRect を起点に浮遊テキスト
- `shogi-board.tsx`: forwardRef + useImperativeHandle で `getSquareRect(row, col)` を expose
- `card-view.tsx`: button root に `data-card-id` を付与し可視カードの矩形を querySelectorAll で捕捉
- `card-shogi-game.tsx`: 各レイアウトの ShogiBoard ref を集約、eventLog 差分監視で manaCharge / draw / cardPlay / trapSet ごとに起点 rect を解決して `triggerManaFlight` 発火

## Test plan

- [ ] 駒移動 +1(早指し時 +2) → 移動先マスに `💎+N` 浮遊、ゲージ右端の +N 分が緑フェード
- [ ] 山札ドロー → 山札位置に `💎-5` 浮遊、ゲージ消費分が右から徐々に赤で消える
- [ ] マナUPカード使用 → 使用カード位置に `💎-1` と `💎+3` の両方表示、ゲージは消費分(赤・右から消える)と加算分(緑・フェード)が両方
- [ ] 歩戻し等のターゲット選択カード → 使用カード位置に `💎-cost`
- [ ] PC (xl) / タブレット / モバイル の各レイアウトで起点位置が正しく合う
- [ ] 浮遊テキストのサイズはアニメ中一定(scale 変動なし)

Closes #77