### PR TITLE
feat: カード将棋 マスターカタログ画面追加 (#102)

### DIFF
--- a/src/app/cards/[id]/page.tsx
+++ b/src/app/cards/[id]/page.tsx
@@ -37,7 +37,7 @@ export default async function CardDetailPage({ params }: CardDetailPageProps) {
   const rarityInfo = RARITY_INFO[def.rarity];
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
+    <main className="min-h-dvh bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
       <div className="max-w-4xl mx-auto px-4 py-4 sm:py-6">
         <header className="flex items-center gap-3 mb-4 sm:mb-6">
           <Link

--- a/src/app/cards/[id]/page.tsx
+++ b/src/app/cards/[id]/page.tsx
@@ -6,7 +6,6 @@ import { CardView } from "@/components/game/card-shogi/card-view";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
 import {
   KIND_INFO,
-  PHASE_LABEL,
   RARITY_INFO,
   STATUS_INFO,
   TARGETING_LABEL,
@@ -17,8 +16,6 @@ import { cn } from "@/lib/utils";
 interface CardDetailPageProps {
   params: Promise<{ id: string }>;
 }
-
-const ISSUE_BASE_URL = "https://github.com/ryuichiTtb/Shogi/issues/";
 
 export async function generateMetadata({ params }: CardDetailPageProps) {
   const { id } = await params;
@@ -89,11 +86,6 @@ export default async function CardDetailPage({ params }: CardDetailPageProps) {
               <Badge variant="outline" className={cn("text-xs", rarityInfo.className)}>
                 {rarityInfo.label}
               </Badge>
-              {def.phase && (
-                <Badge variant="outline" className="text-xs">
-                  {PHASE_LABEL[def.phase]}
-                </Badge>
-              )}
             </div>
 
             {/* 説明文 */}
@@ -123,24 +115,6 @@ export default async function CardDetailPage({ params }: CardDetailPageProps) {
               </dl>
             </section>
 
-            {def.relatedIssues && def.relatedIssues.length > 0 && (
-              <section>
-                <h2 className="text-sm font-bold mb-2">関連 Issue</h2>
-                <div className="flex flex-wrap gap-1.5">
-                  {def.relatedIssues.map((num) => (
-                    <a
-                      key={num}
-                      href={`${ISSUE_BASE_URL}${num}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-primary hover:underline"
-                    >
-                      #{num}
-                    </a>
-                  ))}
-                </div>
-              </section>
-            )}
           </div>
         </div>
       </div>

--- a/src/app/cards/[id]/page.tsx
+++ b/src/app/cards/[id]/page.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { CardView } from "@/components/game/card-shogi/card-view";
+import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
+import {
+  KIND_INFO,
+  PHASE_LABEL,
+  RARITY_INFO,
+  STATUS_INFO,
+  TARGETING_LABEL,
+} from "@/lib/shogi/cards/labels";
+import type { CardId } from "@/lib/shogi/cards/types";
+import { cn } from "@/lib/utils";
+
+interface CardDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const ISSUE_BASE_URL = "https://github.com/ryuichiTtb/Shogi/issues/";
+
+export async function generateMetadata({ params }: CardDetailPageProps) {
+  const { id } = await params;
+  const def = CARD_DEFS[id as CardId];
+  if (!def) return { title: "カード詳細 | カード将棋" };
+  return { title: `${def.name} | カード一覧` };
+}
+
+export default async function CardDetailPage({ params }: CardDetailPageProps) {
+  const { id } = await params;
+  const def = CARD_DEFS[id as CardId];
+
+  if (!def) {
+    notFound();
+  }
+
+  const statusInfo = STATUS_INFO[def.status];
+  const kindInfo = KIND_INFO[def.kind];
+  const rarityInfo = RARITY_INFO[def.rarity];
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
+      <div className="max-w-4xl mx-auto px-4 py-4 sm:py-6">
+        <header className="flex items-center gap-3 mb-4 sm:mb-6">
+          <Link
+            href="/cards"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="カード一覧へ戻る"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            カード一覧
+          </Link>
+          <div className="flex-1">
+            <h1 className="text-xl sm:text-2xl font-bold tracking-tight">{def.name}</h1>
+            <p className="text-xs sm:text-sm text-muted-foreground font-mono">{def.id}</p>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[auto_1fr] gap-6 lg:gap-8 items-start">
+          {/* 実物大プレビュー */}
+          <div className="flex justify-center lg:justify-start">
+            {/* xl サイズはモバイルでは大きすぎるので、md 以上で xl 表示。それ未満は lg にスケールダウン */}
+            <div className="hidden md:block">
+              <CardView
+                card={{ instanceId: `detail-${def.id}`, defId: def.id }}
+                size="xl"
+              />
+            </div>
+            <div className="md:hidden w-full max-w-sm">
+              <CardView
+                card={{ instanceId: `detail-${def.id}`, defId: def.id }}
+                size="lg"
+                fullWidth
+              />
+            </div>
+          </div>
+
+          {/* メタ情報 + 詳細 */}
+          <div className="flex flex-col gap-4">
+            {/* バッジ群 */}
+            <div className="flex flex-wrap gap-1.5">
+              <Badge variant="outline" className={cn("text-xs", statusInfo.className)}>
+                {statusInfo.label}
+              </Badge>
+              <Badge variant="outline" className={cn("text-xs", kindInfo.className)}>
+                {kindInfo.label}
+              </Badge>
+              <Badge variant="outline" className={cn("text-xs", rarityInfo.className)}>
+                {rarityInfo.label}
+              </Badge>
+              {def.phase && (
+                <Badge variant="outline" className="text-xs">
+                  {PHASE_LABEL[def.phase]}
+                </Badge>
+              )}
+            </div>
+
+            {/* 説明文 */}
+            <section>
+              <h2 className="text-sm font-bold mb-1">効果概要</h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">{def.description}</p>
+            </section>
+
+            {def.detailDescription && (
+              <section>
+                <h2 className="text-sm font-bold mb-1">効果詳細仕様</h2>
+                <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                  {def.detailDescription}
+                </p>
+              </section>
+            )}
+
+            {/* メタ情報テーブル */}
+            <section>
+              <h2 className="text-sm font-bold mb-2">メタ情報</h2>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+                <MetaRow label="ID" value={<span className="font-mono">{def.id}</span>} />
+                <MetaRow label="コスト" value={`${def.cost} マナ`} />
+                <MetaRow label="ターゲット" value={TARGETING_LABEL[def.targeting]} />
+                <MetaRow label="effectId" value={<span className="font-mono">{def.effectId}</span>} />
+                {def.addedAt && <MetaRow label="追加日" value={def.addedAt} />}
+              </dl>
+            </section>
+
+            {def.relatedIssues && def.relatedIssues.length > 0 && (
+              <section>
+                <h2 className="text-sm font-bold mb-2">関連 Issue</h2>
+                <div className="flex flex-wrap gap-1.5">
+                  {def.relatedIssues.map((num) => (
+                    <a
+                      key={num}
+                      href={`${ISSUE_BASE_URL}${num}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-primary hover:underline"
+                    >
+                      #{num}
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+interface MetaRowProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+function MetaRow({ label, value }: MetaRowProps) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd>{value}</dd>
+    </>
+  );
+}

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { CardCatalogGrid } from "@/components/cards/card-catalog-grid";
+import { ALL_CARD_DEFS } from "@/lib/shogi/cards/definitions";
+
+export const metadata = {
+  title: "カード一覧 | カード将棋",
+};
+
+// マスターカタログ一覧ページ (Issue #102)
+// 全カードを CardView で並べ、ステータス/種別/レア度で絞り込み可能。
+export default function CardsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
+      <div className="max-w-4xl mx-auto px-4 py-4 sm:py-6">
+        <header className="flex items-center gap-3 mb-4 sm:mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="ホームへ戻る"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            ホーム
+          </Link>
+          <div className="flex-1">
+            <h1 className="text-xl sm:text-2xl font-bold tracking-tight">カード一覧</h1>
+            <p className="text-xs sm:text-sm text-muted-foreground">
+              カード将棋のマスターカタログ (BETA)
+            </p>
+          </div>
+        </header>
+
+        <CardCatalogGrid cards={ALL_CARD_DEFS} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -8,12 +8,12 @@ export const metadata = {
 };
 
 // マスターカタログ一覧ページ (Issue #102)
-// 全カードを CardView で並べ、ステータス/種別/レア度で絞り込み可能。
+// ヘッダ+フィルタを上部固定、グリッド領域のみ縦スクロール。
 export default function CardsPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
-      <div className="max-w-4xl mx-auto px-4 py-4 sm:py-6">
-        <header className="flex items-center gap-3 mb-4 sm:mb-6">
+    <main className="h-dvh flex flex-col bg-gradient-to-b from-amber-50 dark:from-amber-950/30 to-background">
+      <div className="max-w-4xl mx-auto px-4 pt-4 sm:pt-6 pb-2 w-full flex flex-col flex-1 min-h-0">
+        <header className="flex items-center gap-3 mb-3 sm:mb-4 shrink-0">
           <Link
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { createGame } from "@/app/actions/game";
 import type { Difficulty, Player } from "@/lib/shogi/types";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
-import { History, Swords } from "lucide-react";
+import { History, Swords, Layers } from "lucide-react";
 import { ThemeSelector } from "@/components/game/theme-selector";
 import { ModeSelector, type GameMode } from "@/components/home/mode-selector";
 
@@ -255,6 +255,23 @@ export default function Home() {
             `${selectedCharacter.name}と対局開始！`
           )}
         </Button>
+
+        {/* カード機能セクション (カード将棋モード時のみ) */}
+        {selectedMode === "card-shogi" && (
+          <div className="grid grid-cols-2 gap-2 shrink-0">
+            <Link
+              href="/cards"
+              className={cn(
+                "flex items-center justify-center gap-1.5 py-2.5 rounded-lg border-2 border-border",
+                "bg-card text-sm font-medium hover:border-primary/40 transition-colors",
+              )}
+            >
+              <Layers className="w-4 h-4" />
+              カード一覧
+            </Link>
+            {/* 将来: デッキ編成 / ガチャ ボタンを追加 (別Issue) */}
+          </div>
+        )}
 
         {/* 棋譜履歴へのリンク */}
         <div className="text-center shrink-0">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,19 +96,19 @@ export default function Home() {
         <p className="text-xs sm:text-sm text-muted-foreground">AIと対局しよう</p>
       </div>
 
-      <div className="flex-1 flex flex-col max-w-2xl mx-auto w-full px-4 pb-2 sm:pb-4 space-y-2 sm:space-y-4 min-h-0">
+      <div className="flex-1 flex flex-col max-w-2xl mx-auto w-full px-4 pb-2 sm:pb-4 space-y-2 min-h-0">
         {/* モード選択 */}
         <ModeSelector mode={selectedMode} onChange={setSelectedMode} className="shrink-0" />
 
         {/* 難易度・キャラクター選択 (モバイル時 padding を詰める) */}
-        <Card className="shrink-0">
-          <CardHeader className="pb-1 sm:pb-2 pt-3 sm:pt-3">
+        <Card size="sm" className="shrink-0">
+          <CardHeader className="pb-0 pt-0">
             <CardTitle className="text-sm sm:text-base flex items-center gap-2">
               <Swords className="w-4 h-4" />
               対局相手を選ぶ
             </CardTitle>
           </CardHeader>
-          <CardContent className="pb-2 sm:pb-3">
+          <CardContent className="pb-0">
             {/* モバイル: コンパクトリスト / デスクトップ: カードグリッド */}
             <div className="sm:hidden flex flex-col gap-1">
               {CHARACTERS.map((character) => {
@@ -189,11 +189,11 @@ export default function Home() {
         </Card>
 
         {/* 手番選択 (モバイル時 padding を詰める) */}
-        <Card className="shrink-0">
-          <CardHeader className="pb-1 sm:pb-2 pt-3 sm:pt-3">
+        <Card size="sm" className="shrink-0">
+          <CardHeader className="pb-0 pt-0">
             <CardTitle className="text-sm sm:text-base">手番を選ぶ</CardTitle>
           </CardHeader>
-          <CardContent className="pb-2 sm:pb-3">
+          <CardContent className="pb-0">
             {/* モバイル: コンパクト横並び / デスクトップ: カードグリッド */}
             <div className="sm:hidden flex gap-2">
               {colorOptions.map(({ value, icon, label }) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -102,7 +102,7 @@ export default function Home() {
 
         {/* 難易度・キャラクター選択 (モバイル時 padding を詰める) */}
         <Card className="shrink-0">
-          <CardHeader className="pb-1 sm:pb-3 pt-3 sm:pt-6">
+          <CardHeader className="pb-1 sm:pb-2 pt-3 sm:pt-3">
             <CardTitle className="text-sm sm:text-base flex items-center gap-2">
               <Swords className="w-4 h-4" />
               対局相手を選ぶ
@@ -159,7 +159,7 @@ export default function Home() {
                     key={character.id}
                     onClick={() => setSelectedDifficulty(character.difficulty)}
                     className={cn(
-                      "relative p-4 rounded-xl border-2 text-left transition-all",
+                      "relative p-3 rounded-xl border-2 text-left transition-all",
                       "hover:shadow-md cursor-pointer",
                       isSelected
                         ? "border-primary bg-primary/5 shadow-sm"
@@ -169,16 +169,16 @@ export default function Home() {
                     {isSelected && (
                       <div className="absolute top-2 right-2 w-2 h-2 rounded-full bg-primary" />
                     )}
-                    <div className="text-3xl mb-2">{character.avatarEmoji}</div>
+                    <div className="text-3xl mb-1">{character.avatarEmoji}</div>
                     <div className="font-bold text-sm">{character.name}</div>
-                    <div className="text-xs text-muted-foreground mb-2">{character.title}</div>
+                    <div className="text-xs text-muted-foreground mb-1">{character.title}</div>
                     <Badge
                       variant="outline"
                       className={cn("text-xs", diffInfo.color)}
                     >
                       {diffInfo.label}
                     </Badge>
-                    <p className="text-xs text-muted-foreground mt-1">
+                    <p className="text-xs text-muted-foreground mt-0.5">
                       {diffInfo.description}
                     </p>
                   </button>
@@ -190,7 +190,7 @@ export default function Home() {
 
         {/* 手番選択 (モバイル時 padding を詰める) */}
         <Card className="shrink-0">
-          <CardHeader className="pb-1 sm:pb-3 pt-3 sm:pt-6">
+          <CardHeader className="pb-1 sm:pb-2 pt-3 sm:pt-3">
             <CardTitle className="text-sm sm:text-base">手番を選ぶ</CardTitle>
           </CardHeader>
           <CardContent className="pb-2 sm:pb-3">
@@ -220,14 +220,14 @@ export default function Home() {
                   key={value}
                   onClick={() => setSelectedColor(value)}
                   className={cn(
-                    "p-4 rounded-xl border-2 text-center transition-all cursor-pointer",
+                    "p-3 rounded-xl border-2 text-center transition-all cursor-pointer",
                     "hover:shadow-md",
                     selectedColor === value
                       ? "border-primary bg-primary/5"
                       : "border-border hover:border-primary/40"
                   )}
                 >
-                  <div className="text-2xl mb-1">{icon}</div>
+                  <div className="text-2xl mb-0.5">{icon}</div>
                   <div className="font-medium text-sm">{label}</div>
                   <div className="text-xs text-muted-foreground">{desc}</div>
                 </button>

--- a/src/components/cards/card-catalog-grid.tsx
+++ b/src/components/cards/card-catalog-grid.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { CardCatalogTile } from "./card-catalog-tile";
+import { CardFilterBar, type CardFilterValue } from "./card-filter-bar";
+import type { CardDefinition } from "@/lib/shogi/cards/types";
+
+interface CardCatalogGridProps {
+  cards: CardDefinition[];
+}
+
+const INITIAL_FILTER: CardFilterValue = {
+  status: "all",
+  kind: "all",
+  rarity: "all",
+};
+
+export function CardCatalogGrid({ cards }: CardCatalogGridProps) {
+  const [filter, setFilter] = useState<CardFilterValue>(INITIAL_FILTER);
+
+  const filtered = useMemo(() => {
+    return cards.filter((c) => {
+      if (filter.status !== "all" && c.status !== filter.status) return false;
+      if (filter.kind !== "all" && c.kind !== filter.kind) return false;
+      if (filter.rarity !== "all" && c.rarity !== filter.rarity) return false;
+      return true;
+    });
+  }, [cards, filter]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg border bg-card p-3">
+        <CardFilterBar value={filter} onChange={setFilter} />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-sm text-muted-foreground">
+          条件に合致するカードがありません
+        </div>
+      ) : (
+        <>
+          <div className="text-xs text-muted-foreground">
+            {filtered.length} 件表示中 (全 {cards.length} 件)
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {filtered.map((def) => (
+              <CardCatalogTile key={def.id} def={def} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/cards/card-catalog-grid.tsx
+++ b/src/components/cards/card-catalog-grid.tsx
@@ -15,6 +15,8 @@ const INITIAL_FILTER: CardFilterValue = {
   rarity: "all",
 };
 
+// フィルタ欄は親 flex の shrink-0 で上部固定、
+// グリッド領域は flex-1 + overflow-y-auto で内部スクロール。
 export function CardCatalogGrid({ cards }: CardCatalogGridProps) {
   const [filter, setFilter] = useState<CardFilterValue>(INITIAL_FILTER);
 
@@ -28,8 +30,8 @@ export function CardCatalogGrid({ cards }: CardCatalogGridProps) {
   }, [cards, filter]);
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="rounded-lg border bg-card p-3">
+    <div className="flex flex-col gap-3 flex-1 min-h-0">
+      <div className="rounded-lg border bg-card p-3 shrink-0">
         <CardFilterBar value={filter} onChange={setFilter} />
       </div>
 
@@ -38,16 +40,16 @@ export function CardCatalogGrid({ cards }: CardCatalogGridProps) {
           条件に合致するカードがありません
         </div>
       ) : (
-        <>
-          <div className="text-xs text-muted-foreground">
+        <div className="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
+          <div className="text-xs text-muted-foreground mb-2 sticky top-0 bg-background/80 backdrop-blur py-1 z-10">
             {filtered.length} 件表示中 (全 {cards.length} 件)
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 pb-3">
             {filtered.map((def) => (
               <CardCatalogTile key={def.id} def={def} />
             ))}
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/components/cards/card-catalog-tile.tsx
+++ b/src/components/cards/card-catalog-tile.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { CardView } from "@/components/game/card-shogi/card-view";
+import { cn } from "@/lib/utils";
+import { STATUS_INFO } from "@/lib/shogi/cards/labels";
+import type { CardDefinition } from "@/lib/shogi/cards/types";
+
+interface CardCatalogTileProps {
+  def: CardDefinition;
+}
+
+// マスターカタログ一覧の各タイル。
+// CardView (md, fullWidth) で実ゲームと同じカード見た目を表示し、
+// 上部にステータスバッジを重ねる。クリックで /cards/[id] 詳細へ遷移。
+export function CardCatalogTile({ def }: CardCatalogTileProps) {
+  const router = useRouter();
+  const statusInfo = STATUS_INFO[def.status];
+
+  return (
+    <div className="relative">
+      <CardView
+        card={{ instanceId: `catalog-${def.id}`, defId: def.id }}
+        size="md"
+        fullWidth
+        onClick={() => router.push(`/cards/${def.id}`)}
+      />
+      <Badge
+        variant="outline"
+        className={cn(
+          "absolute -top-2 -right-1 text-[10px] px-1.5 py-0 leading-tight border-2 pointer-events-none shadow-sm",
+          statusInfo.className,
+        )}
+      >
+        {statusInfo.label}
+      </Badge>
+    </div>
+  );
+}

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -70,9 +70,9 @@ interface FilterRowProps {
 
 function FilterRow({ label, options, selected, onSelect }: FilterRowProps) {
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <span className="text-xs font-medium text-muted-foreground w-16 shrink-0">{label}</span>
-      <div className="flex flex-wrap gap-1.5">
+    <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
+      <span className="text-[10px] sm:text-xs font-medium text-muted-foreground w-11 sm:w-16 shrink-0">{label}</span>
+      <div className="flex flex-wrap gap-1 sm:gap-1.5">
         {options.map((opt) => {
           const active = selected === opt.id;
           return (
@@ -88,7 +88,7 @@ function FilterRow({ label, options, selected, onSelect }: FilterRowProps) {
             >
               <Badge
                 variant="outline"
-                className={cn("text-xs px-2 py-0.5", opt.className || "bg-card")}
+                className={cn("text-[10px] sm:text-xs px-1.5 sm:px-2 py-0 sm:py-0.5", opt.className || "bg-card")}
               >
                 {opt.label}
               </Badge>

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  KIND_INFO,
+  KIND_OPTIONS,
+  RARITY_INFO,
+  RARITY_OPTIONS,
+  STATUS_INFO,
+  STATUS_OPTIONS,
+} from "@/lib/shogi/cards/labels";
+import type {
+  CardKind,
+  CardRarity,
+  CardStatus,
+} from "@/lib/shogi/cards/types";
+
+export interface CardFilterValue {
+  status: CardStatus | "all";
+  kind: CardKind | "all";
+  rarity: CardRarity | "all";
+}
+
+interface CardFilterBarProps {
+  value: CardFilterValue;
+  onChange: (next: CardFilterValue) => void;
+}
+
+export function CardFilterBar({ value, onChange }: CardFilterBarProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <FilterRow
+        label="ステータス"
+        options={[
+          { id: "all", label: "すべて", className: "" },
+          ...STATUS_OPTIONS.map((s) => ({ id: s, label: STATUS_INFO[s].label, className: STATUS_INFO[s].className })),
+        ]}
+        selected={value.status}
+        onSelect={(id) => onChange({ ...value, status: id as CardFilterValue["status"] })}
+      />
+      <FilterRow
+        label="種別"
+        options={[
+          { id: "all", label: "すべて", className: "" },
+          ...KIND_OPTIONS.map((k) => ({ id: k, label: KIND_INFO[k].label, className: KIND_INFO[k].className })),
+        ]}
+        selected={value.kind}
+        onSelect={(id) => onChange({ ...value, kind: id as CardFilterValue["kind"] })}
+      />
+      <FilterRow
+        label="レア度"
+        options={[
+          { id: "all", label: "すべて", className: "" },
+          ...RARITY_OPTIONS.map((r) => ({ id: r, label: RARITY_INFO[r].label, className: RARITY_INFO[r].className })),
+        ]}
+        selected={value.rarity}
+        onSelect={(id) => onChange({ ...value, rarity: id as CardFilterValue["rarity"] })}
+      />
+    </div>
+  );
+}
+
+interface FilterRowProps {
+  label: string;
+  options: { id: string; label: string; className: string }[];
+  selected: string;
+  onSelect: (id: string) => void;
+}
+
+function FilterRow({ label, options, selected, onSelect }: FilterRowProps) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs font-medium text-muted-foreground w-16 shrink-0">{label}</span>
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((opt) => {
+          const active = selected === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => onSelect(opt.id)}
+              className={cn(
+                "cursor-pointer transition-all",
+                active ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : "opacity-60 hover:opacity-100",
+              )}
+              aria-pressed={active}
+            >
+              <Badge
+                variant="outline"
+                className={cn("text-xs px-2 py-0.5", opt.className || "bg-card")}
+              >
+                {opt.label}
+              </Badge>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/shogi/cards/definitions.ts
+++ b/src/lib/shogi/cards/definitions.ts
@@ -13,6 +13,12 @@ export const CARD_DEFS: Record<CardId, CardDefinition> = {
     effectId: "mana_up",
     targeting: "none",
     icon: "💎",
+    status: "active",
+    phase: "0",
+    detailDescription:
+      "使用すると即時にマナを +3 する。\n\n- ターゲット選択なし\n- マナ上限(現状20)を超えてチャージしない\n- 1ターン中の使用上限なし(マナ消費分は支払う必要あり)",
+    addedAt: "2026-04-30",
+    relatedIssues: [68, 80, 82],
   },
   pawn_return: {
     id: "pawn_return",
@@ -24,6 +30,12 @@ export const CARD_DEFS: Record<CardId, CardDefinition> = {
     effectId: "pawn_return",
     targeting: "ownPiece",
     icon: "↩️",
+    status: "active",
+    phase: "0",
+    detailDescription:
+      "自分の盤上の歩(成り歩=と金は対象外)1枚を選び、持ち駒に戻す。\n\n- ターゲット: 自盤上の歩\n- 成った歩(と金)は対象外\n- 持ち駒に戻った歩は次ターン以降に通常通り打てる",
+    addedAt: "2026-04-30",
+    relatedIssues: [68, 80, 82],
   },
   no_promote: {
     id: "no_promote",
@@ -35,6 +47,12 @@ export const CARD_DEFS: Record<CardId, CardDefinition> = {
     effectId: "no_promote",
     targeting: "none",
     icon: "🛡️",
+    status: "active",
+    phase: "0",
+    detailDescription:
+      "自分の盤面に1枚だけセットできるトラップカード。次に相手が成りを宣言したとき、その成りを1回無効化して破棄される。\n\n- 自動発火(セットしておけば該当タイミングで自動で発動)\n- 1枚だけセット可、既にセット済みなら新規セットで上書き(既存は破棄)",
+    addedAt: "2026-04-30",
+    relatedIssues: [68, 80, 82],
   },
 };
 

--- a/src/lib/shogi/cards/labels.ts
+++ b/src/lib/shogi/cards/labels.ts
@@ -1,0 +1,89 @@
+// マスターカタログ画面(Issue #102)で使用する表示ラベル定義。
+// CardStatus / CardKind / CardRarity / CardPhase / CardTargeting の日本語表記と
+// Badge 表示用カラークラスを集約する。
+
+import type {
+  CardKind,
+  CardRarity,
+  CardStatus,
+  CardPhase,
+  CardTargeting,
+} from "./types";
+
+interface LabelInfo {
+  label: string;
+  className: string;
+}
+
+export const STATUS_INFO: Record<CardStatus, LabelInfo> = {
+  draft: {
+    label: "検討中",
+    className:
+      "bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-700",
+  },
+  preparing: {
+    label: "準備中",
+    className:
+      "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-800",
+  },
+  active: {
+    label: "公開中",
+    className:
+      "bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-800",
+  },
+  deprecated: {
+    label: "廃止",
+    className:
+      "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/40 dark:text-red-200 dark:border-red-800",
+  },
+};
+
+export const KIND_INFO: Record<CardKind, LabelInfo> = {
+  normal: {
+    label: "通常",
+    className:
+      "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-800",
+  },
+  trap: {
+    label: "トラップ",
+    className:
+      "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/40 dark:text-purple-200 dark:border-purple-800",
+  },
+};
+
+export const RARITY_INFO: Record<CardRarity, LabelInfo> = {
+  common: {
+    label: "ノーマル",
+    className:
+      "bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-700",
+  },
+  rare: {
+    label: "レア",
+    className:
+      "bg-sky-100 text-sky-800 border-sky-200 dark:bg-sky-900/40 dark:text-sky-200 dark:border-sky-800",
+  },
+  epic: {
+    label: "究極",
+    className:
+      "bg-fuchsia-100 text-fuchsia-800 border-fuchsia-200 dark:bg-fuchsia-900/40 dark:text-fuchsia-200 dark:border-fuchsia-800",
+  },
+};
+
+export const PHASE_LABEL: Record<CardPhase, string> = {
+  "0": "Phase 0",
+  A: "Phase A",
+  B: "Phase B",
+  C: "Phase C",
+};
+
+export const TARGETING_LABEL: Record<CardTargeting, string> = {
+  none: "対象なし",
+  ownPiece: "自分の駒",
+  enemyPiece: "相手の駒",
+  square: "盤面マス",
+};
+
+// フィルタ UI で使用する選択肢配列(順序固定)
+export const STATUS_OPTIONS: CardStatus[] = ["active", "preparing", "draft", "deprecated"];
+export const KIND_OPTIONS: CardKind[] = ["normal", "trap"];
+export const RARITY_OPTIONS: CardRarity[] = ["common", "rare", "epic"];

--- a/src/lib/shogi/cards/types.ts
+++ b/src/lib/shogi/cards/types.ts
@@ -14,6 +14,14 @@ export type CardTargeting = "none" | "ownPiece" | "enemyPiece" | "square";
 
 export type CardRarity = "common" | "rare" | "epic";
 
+// マスターカタログ運用用ステータス(Issue #102)
+// draft: 検討中(本実装前) / preparing: 実装中(プール非公開) /
+// active: 公開中 / deprecated: 廃止
+export type CardStatus = "draft" | "preparing" | "active" | "deprecated";
+
+// 採用フェーズ(設計ドキュメント 2.5)
+export type CardPhase = "0" | "A" | "B" | "C";
+
 export interface CardDefinition {
   id: CardId;
   kind: CardKind;
@@ -26,6 +34,16 @@ export interface CardDefinition {
   targeting: CardTargeting;
   // カードの絵柄/アイコン(Phase 0 は絵文字)。Phase A 以降で SVG/画像差替予定。
   icon: string;
+  // 運用ステータス(マスターカタログでのフィルタ・公開判定に使用)
+  status: CardStatus;
+  // 採用フェーズ
+  phase?: CardPhase;
+  // 詳細仕様(マスターカタログ詳細ページ表示用、改行・箇条書き可)
+  detailDescription?: string;
+  // 追加日(ISO 日付文字列、例: "2026-04-30")
+  addedAt?: string;
+  // 関連 Issue 番号
+  relatedIssues?: number[];
 }
 
 export interface CardInstance {


### PR DESCRIPTION
## Summary
- カード将棋のマスターカタログ一覧 `/cards` と詳細ページ `/cards/[id]` を追加
- ホーム画面のカード将棋モード時に「カード一覧」ボタンを追加(従来将棋では非表示)
- `CardDefinition` を拡張(`status` / `phase` / `detailDescription` / `addedAt` / `relatedIssues`)。既存3種に反映
- ホーム画面の縦余白を整理(shadcn Card `size="sm"`、CardHeader/Content の重複 padding 削減)
- モバイル: フィルタ1行化、フィルタ固定+グリッドのみ縦スクロール、`min-h-dvh` で不要スクロール抑止

## Test plan
- [ ] ホーム画面: カード将棋モード時のみ「カード一覧」ボタン表示
- [ ] `/cards`: フィルタ(ステータス/種別/レア度)が機能
- [ ] `/cards/[id]`: 実物大表示+メタ情報+効果詳細仕様が確認できる
- [ ] `/cards/invalid-id`: 404 ページ
- [ ] モバイル: フィルタ行が1行に収まる
- [ ] モバイル: フィルタが上部固定、グリッド領域のみスクロール
- [ ] モバイル詳細画面: 余分なスクロールが出ない

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)