### PR TITLE
feat: カード使用演出と関連UX調整 (Issue #106)

### DIFF
--- a/src/components/game/card-shogi/card-play-dialog.tsx
+++ b/src/components/game/card-shogi/card-play-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useSyncExternalStore } from "react";
-import { createPortal } from "react-dom";
 
 import {
   Dialog,
@@ -27,50 +26,96 @@ const CARD_W = 576;
 const CARD_H = 352;
 // 中央演出の 75% で表示し「使用時よりやや小さめ」を担保
 const PREVIEW_RATIO = 0.75;
+// プレビューカードと dialog 上端の隙間
+const CARD_GAP = 12;
 
-// Hydration 後にのみ Portal を出すための SSR ガード (DrawFlightCard と同方式)
+// Hydration 後にのみ正確な viewport サイズで配置するための SSR ガード
 const subscribe = () => () => {};
 const getClientSnapshot = () => true;
 const getServerSnapshot = () => false;
 
 export function CardPlayDialog({ pendingCard, onConfirm, onCancel }: CardPlayDialogProps) {
+  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+
   // selectTarget フェーズではダイアログを閉じる(盤面でターゲットを選ぶため)
   if (!pendingCard || pendingCard.phase === "selectTarget") return null;
   const def = CARD_DEFS[pendingCard.instance.defId];
 
-  return (
-    <>
-      <Dialog open={true} onOpenChange={(open) => !open && onCancel()}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              {def.kind === "trap" ? "トラップをセット" : "カードを使用"} —{" "}
-              <span className="text-primary">{def.name}</span>
-            </DialogTitle>
-            <DialogDescription className="text-sm whitespace-pre-line">
-              {`消費マナ: ${def.cost}\n${def.description}`}
-            </DialogDescription>
-          </DialogHeader>
+  // viewport にフィットするスケール (CardPlayFlight と同方式) を計算し、
+  // PREVIEW_RATIO を掛けて常に中央演出より一回り小さく見せる
+  const centerScale = isClient
+    ? Math.min(
+        1,
+        (window.innerWidth * 0.92) / CARD_W,
+        (window.innerHeight * 0.85) / CARD_H,
+      )
+    : 1;
+  const scale = centerScale * PREVIEW_RATIO;
+  const scaledW = CARD_W * scale;
+  const scaledH = CARD_H * scale;
 
-          <DialogFooter className="flex-row gap-2 justify-end">
-            <Button variant="outline" onClick={onCancel}>
-              キャンセル
-            </Button>
-            <Button onClick={onConfirm}>
-              {def.kind === "trap" ? "セットする" : "使用する"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      {/* Issue #106 修正: ダイアログの上層 (z-[55]) に選択カード本体を重ねる。
-        * 効果説明はダイアログ側に書くのでカード上では非表示 (hideDescription)。 */}
-      <SelectedCardPreview cardInstance={pendingCard.instance} />
-    </>
+  return (
+    <Dialog open={true} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent
+        className="sm:max-w-md"
+        style={
+          isClient
+            ? {
+                // Issue #106 修正: カード + ダイアログ全体の重心を画面中央に
+                // 揃えるため、ダイアログ中心を「viewport 中央 + (カード高さ
+                // + gap) / 2」に配置する。
+                // shadcn の DialogContent は translate-y(-50%) で要素の中央
+                // が top の位置に来るため、この補正だけでダイアログ高さに
+                // 依存せず常に中央に揃う。
+                top: `calc(50% + ${(scaledH + CARD_GAP) / 2}px)`,
+              }
+            : undefined
+        }
+      >
+        {/* 選択カードプレビュー: DialogContent の上端のすぐ上に絶対配置 */}
+        {isClient && (
+          <SelectedCardPreview
+            cardInstance={pendingCard.instance}
+            scale={scale}
+            scaledW={scaledW}
+            scaledH={scaledH}
+          />
+        )}
+
+        <DialogHeader>
+          <DialogTitle>
+            {def.kind === "trap" ? "トラップをセット" : "カードを使用"} —{" "}
+            <span className="text-primary">{def.name}</span>
+          </DialogTitle>
+          <DialogDescription className="text-sm whitespace-pre-line">
+            {`消費マナ: ${def.cost}\n${def.description}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="flex-row gap-2 justify-end">
+          <Button variant="outline" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button onClick={onConfirm}>
+            {def.kind === "trap" ? "セットする" : "使用する"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
-function SelectedCardPreview({ cardInstance }: { cardInstance: CardInstance }) {
-  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+function SelectedCardPreview({
+  cardInstance,
+  scale,
+  scaledW,
+  scaledH,
+}: {
+  cardInstance: CardInstance;
+  scale: number;
+  scaledW: number;
+  scaledH: number;
+}) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -78,29 +123,21 @@ function SelectedCardPreview({ cardInstance }: { cardInstance: CardInstance }) {
     return () => cancelAnimationFrame(id);
   }, []);
 
-  if (!isClient) return null;
-
-  // 中央演出と同じビューポートフィット倍率を計算し、PREVIEW_RATIO を掛けて
-  // 常に中央演出より一回り小さく見せる。
-  const centerScale = Math.min(
-    1,
-    (window.innerWidth * 0.92) / CARD_W,
-    (window.innerHeight * 0.85) / CARD_H,
-  );
-  const scale = centerScale * PREVIEW_RATIO;
-  const scaledW = CARD_W * scale;
-  const scaledH = CARD_H * scale;
-
-  return createPortal(
+  return (
     <div
-      className="fixed left-1/2 top-[4%] z-[55] pointer-events-none"
       style={{
-        marginLeft: -scaledW / 2,
+        position: "absolute",
+        left: "50%",
+        bottom: "100%",
+        marginBottom: CARD_GAP,
         width: scaledW,
         height: scaledH,
         opacity: visible ? 1 : 0,
-        transform: visible ? "translateY(0)" : "translateY(-8px)",
+        transform: visible
+          ? "translateX(-50%) translateY(0)"
+          : "translateX(-50%) translateY(-8px)",
         transition: "opacity 0.18s ease-out, transform 0.18s ease-out",
+        pointerEvents: "none",
       }}
     >
       <div
@@ -114,8 +151,7 @@ function SelectedCardPreview({ cardInstance }: { cardInstance: CardInstance }) {
       >
         <CardView card={cardInstance} size="xl" fullWidth hideDescription />
       </div>
-    </div>,
-    document.body,
+    </div>
   );
 }
 

--- a/src/components/game/card-shogi/card-play-dialog.tsx
+++ b/src/components/game/card-shogi/card-play-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import type { PendingCard } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
+import { CardView } from "./card-view";
 
 interface CardPlayDialogProps {
   pendingCard: PendingCard | null;
@@ -28,13 +29,17 @@ export function CardPlayDialog({ pendingCard, onConfirm, onCancel }: CardPlayDia
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            {def.kind === "trap" ? "トラップをセット" : "カードを使用"} —{" "}
-            <span className="text-primary">{def.name}</span>
+            {def.kind === "trap" ? "トラップをセット" : "カードを使用"}
           </DialogTitle>
-          <DialogDescription className="text-sm whitespace-pre-line">
-            {`消費マナ: ${def.cost}\n${def.description}`}
+          <DialogDescription className="text-sm">
+            消費マナ: {def.cost}
           </DialogDescription>
         </DialogHeader>
+
+        {/* Issue #106: 効果テキストだけだとどのカードか分かりにくいため、カード本体も表示 */}
+        <div className="flex justify-center py-2">
+          <CardView card={pendingCard.instance} size="lg" />
+        </div>
 
         <DialogFooter className="flex-row gap-2 justify-end">
           <Button variant="outline" onClick={onCancel}>

--- a/src/components/game/card-shogi/card-play-dialog.tsx
+++ b/src/components/game/card-shogi/card-play-dialog.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+
 import {
   Dialog,
   DialogContent,
@@ -9,7 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import type { PendingCard } from "@/lib/shogi/cards/types";
+import type { PendingCard, CardInstance } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
 import { CardView } from "./card-view";
 
@@ -19,38 +22,100 @@ interface CardPlayDialogProps {
   onCancel: () => void;
 }
 
+// 中央演出 (CardPlayFlight) の xl ベースサイズ
+const CARD_W = 576;
+const CARD_H = 352;
+// 中央演出の 75% で表示し「使用時よりやや小さめ」を担保
+const PREVIEW_RATIO = 0.75;
+
+// Hydration 後にのみ Portal を出すための SSR ガード (DrawFlightCard と同方式)
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export function CardPlayDialog({ pendingCard, onConfirm, onCancel }: CardPlayDialogProps) {
   // selectTarget フェーズではダイアログを閉じる(盤面でターゲットを選ぶため)
   if (!pendingCard || pendingCard.phase === "selectTarget") return null;
   const def = CARD_DEFS[pendingCard.instance.defId];
 
   return (
-    <Dialog open={true} onOpenChange={(open) => !open && onCancel()}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>
-            {def.kind === "trap" ? "トラップをセット" : "カードを使用"}
-          </DialogTitle>
-          <DialogDescription className="text-sm">
-            消費マナ: {def.cost}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={true} onOpenChange={(open) => !open && onCancel()}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {def.kind === "trap" ? "トラップをセット" : "カードを使用"} —{" "}
+              <span className="text-primary">{def.name}</span>
+            </DialogTitle>
+            <DialogDescription className="text-sm whitespace-pre-line">
+              {`消費マナ: ${def.cost}\n${def.description}`}
+            </DialogDescription>
+          </DialogHeader>
 
-        {/* Issue #106: 効果テキストだけだとどのカードか分かりにくいため、カード本体も表示 */}
-        <div className="flex justify-center py-2">
-          <CardView card={pendingCard.instance} size="lg" />
-        </div>
+          <DialogFooter className="flex-row gap-2 justify-end">
+            <Button variant="outline" onClick={onCancel}>
+              キャンセル
+            </Button>
+            <Button onClick={onConfirm}>
+              {def.kind === "trap" ? "セットする" : "使用する"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      {/* Issue #106 修正: ダイアログの上層 (z-[55]) に選択カード本体を重ねる。
+        * 効果説明はダイアログ側に書くのでカード上では非表示 (hideDescription)。 */}
+      <SelectedCardPreview cardInstance={pendingCard.instance} />
+    </>
+  );
+}
 
-        <DialogFooter className="flex-row gap-2 justify-end">
-          <Button variant="outline" onClick={onCancel}>
-            キャンセル
-          </Button>
-          <Button onClick={onConfirm}>
-            {def.kind === "trap" ? "セットする" : "使用する"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+function SelectedCardPreview({ cardInstance }: { cardInstance: CardInstance }) {
+  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  if (!isClient) return null;
+
+  // 中央演出と同じビューポートフィット倍率を計算し、PREVIEW_RATIO を掛けて
+  // 常に中央演出より一回り小さく見せる。
+  const centerScale = Math.min(
+    1,
+    (window.innerWidth * 0.92) / CARD_W,
+    (window.innerHeight * 0.85) / CARD_H,
+  );
+  const scale = centerScale * PREVIEW_RATIO;
+  const scaledW = CARD_W * scale;
+  const scaledH = CARD_H * scale;
+
+  return createPortal(
+    <div
+      className="fixed left-1/2 top-[4%] z-[55] pointer-events-none"
+      style={{
+        marginLeft: -scaledW / 2,
+        width: scaledW,
+        height: scaledH,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(-8px)",
+        transition: "opacity 0.18s ease-out, transform 0.18s ease-out",
+      }}
+    >
+      <div
+        className="rounded-md shadow-2xl overflow-hidden"
+        style={{
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+          width: CARD_W,
+          height: CARD_H,
+        }}
+      >
+        <CardView card={cardInstance} size="xl" fullWidth hideDescription />
+      </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/components/game/card-shogi/card-play-flight.tsx
+++ b/src/components/game/card-shogi/card-play-flight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -10,7 +10,6 @@ import { CardView } from "./card-view";
 interface CardPlayFlightProps {
   cardInstance: CardInstance | null;
   flightKey: number | null;
-  startRectGetter: () => DOMRect | null;
   isTrap: boolean;
   onComplete: () => void;
 }
@@ -19,13 +18,15 @@ interface CardPlayFlightProps {
 const CARD_W = 576;
 const CARD_H = 352;
 
-// Issue #106: ドロー演出 (~2.65s) より短め。手番継続中に挟むため間延びを避ける。
-const FADE_IN_MS = 320;
+// Issue #106 (修正後): 手札→中央の移動はやめ、中央にパッと出現してキラッと
+// 光らせる「カードを使った！」演出。手番継続中に挟むため短時間に収める。
+const POP_IN_MS = 220;
 const HOLD_MS = 700;
-const FADE_OUT_MS = 350;
-const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
+const FADE_OUT_MS = 320;
+const TOTAL_MS = POP_IN_MS + HOLD_MS + FADE_OUT_MS;
 
-const FLASH_DELAY_S = FADE_IN_MS / 1000;
+// 出現直後のシマー (光) と、周辺を一瞬光らせるグロウ
+const FLASH_DELAY_S = POP_IN_MS / 1000;
 const SHIMMER_DURATION_S = 0.6;
 const GLOW_DURATION_S = 0.75;
 
@@ -36,7 +37,6 @@ const getServerSnapshot = () => false;
 export function CardPlayFlight({
   cardInstance,
   flightKey,
-  startRectGetter,
   isTrap,
   onComplete,
 }: CardPlayFlightProps) {
@@ -50,7 +50,6 @@ export function CardPlayFlight({
           <CardPlayFlightInner
             key={flightKey}
             cardInstance={cardInstance}
-            startRectGetter={startRectGetter}
             isTrap={isTrap}
             onComplete={onComplete}
           />
@@ -63,12 +62,10 @@ export function CardPlayFlight({
 
 function CardPlayFlightInner({
   cardInstance,
-  startRectGetter,
   isTrap,
   onComplete,
 }: {
   cardInstance: CardInstance;
-  startRectGetter: () => DOMRect | null;
   isTrap: boolean;
   onComplete: () => void;
 }) {
@@ -86,78 +83,65 @@ function CardPlayFlightInner({
     return () => window.clearTimeout(id);
   }, [handleComplete]);
 
-  const [coords] = useState(() => {
-    if (typeof window === "undefined") return null;
-    const startRect = startRectGetter();
+  // ビューポートにフィットする倍率まで縮小 (モバイル対応)
+  const centerScale =
+    typeof window === "undefined"
+      ? 1
+      : Math.min(1, (window.innerWidth * 0.92) / CARD_W, (window.innerHeight * 0.85) / CARD_H);
 
-    const winW = window.innerWidth;
-    const winH = window.innerHeight;
-    const centerX = (winW - CARD_W) / 2;
-    const centerY = (winH - CARD_H) / 2;
+  const t1 = POP_IN_MS / TOTAL_MS;
+  const t2 = (POP_IN_MS + HOLD_MS) / TOTAL_MS;
 
-    // モバイル等で 576x352 がそのまま入らない場合、ビューポートにフィットする倍率まで縮小。
-    const centerScale = Math.min(1, (winW * 0.92) / CARD_W, (winH * 0.85) / CARD_H);
-
-    const startX = startRect ? startRect.x + startRect.width / 2 - CARD_W / 2 : centerX;
-    const startY = startRect ? startRect.y + startRect.height / 2 - CARD_H / 2 : centerY;
-    const startScale = startRect ? Math.max(0.15, startRect.width / CARD_W) : 0.3;
-
-    return { startX, startY, centerX, centerY, startScale, centerScale };
-  });
-
-  if (!coords) return null;
-  const { startX, startY, centerX, centerY, startScale, centerScale } = coords;
-
-  const t1 = FADE_IN_MS / TOTAL_MS;
-  const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
-
-  // グロウ色: トラップは紫 (BoardOverlay の trap_trigger と揃える)、通常は黄金 (ドロー演出と揃える)
+  // グロウ色: トラップは紫 (BoardOverlay の trap_trigger と揃える)、通常は黄金
   const glowShadow = isTrap
-    ? "0 0 90px 14px rgba(168, 85, 247, 0.85)"
-    : "0 0 90px 14px rgba(251, 191, 36, 0.9)";
+    ? "0 0 100px 18px rgba(168, 85, 247, 0.9)"
+    : "0 0 100px 18px rgba(251, 191, 36, 0.95)";
 
   return (
     <motion.div
-      initial={{ left: startX, top: startY, scale: startScale, opacity: 0 }}
+      initial={{ scale: centerScale * 0.4, opacity: 0 }}
       animate={{
-        left: [startX, centerX, centerX, centerX],
-        top: [startY, centerY, centerY, centerY],
-        scale: [startScale, centerScale, centerScale, centerScale * 1.04],
+        // パッと出現 (オーバーシュート気味) → ホールド → わずかにスケールアップしながらフェードアウト
+        scale: [centerScale * 0.4, centerScale * 1.08, centerScale, centerScale * 1.04],
         opacity: [0, 1, 1, 0],
       }}
       transition={{
         duration: TOTAL_MS / 1000,
         times: [0, t1, t2, 1],
-        ease: ["easeOut", "linear", "easeIn"],
+        ease: ["backOut", "linear", "easeIn"],
       }}
       onAnimationComplete={handleComplete}
       style={{
         position: "fixed",
+        left: "50%",
+        top: "50%",
+        marginLeft: -CARD_W / 2,
+        marginTop: -CARD_H / 2,
         width: CARD_W,
         height: CARD_H,
-        willChange: "transform, opacity, left, top",
+        willChange: "transform, opacity",
       }}
     >
       <div className="relative w-full h-full">
-        {/* グロウ: 中央到着の瞬間カード周辺がふわっと光る */}
+        {/* グロウ: 出現の瞬間カード周辺がふわっと光る */}
         <motion.div
           initial={{ opacity: 0, scale: 0.92 }}
-          animate={{ opacity: [0, 0.95, 0], scale: [0.92, 1.08, 1] }}
+          animate={{ opacity: [0, 1, 0], scale: [0.92, 1.12, 1] }}
           transition={{
             duration: GLOW_DURATION_S,
             delay: FLASH_DELAY_S,
-            times: [0, 0.45, 1],
+            times: [0, 0.4, 1],
             ease: "easeOut",
           }}
           style={{
             position: "absolute",
-            inset: -12,
+            inset: -16,
             borderRadius: "0.6rem",
             boxShadow: glowShadow,
             pointerEvents: "none",
           }}
         />
-        {/* カード本体 + シマー */}
+        {/* カード本体 + シマー (キラッと斜めに走る光) */}
         <div className="absolute inset-0 rounded-md shadow-2xl overflow-hidden">
           <CardView card={cardInstance} size="xl" fullWidth />
           <motion.div
@@ -173,7 +157,7 @@ function CardPlayFlightInner({
               position: "absolute",
               inset: 0,
               background:
-                "linear-gradient(115deg, transparent 35%, rgba(255,255,255,0.9) 50%, transparent 65%)",
+                "linear-gradient(115deg, transparent 35%, rgba(255,255,255,0.95) 50%, transparent 65%)",
               pointerEvents: "none",
               mixBlendMode: "overlay",
             }}
@@ -184,12 +168,12 @@ function CardPlayFlightInner({
           initial={{ opacity: 0, scale: 0.6, y: -16 }}
           animate={{
             opacity: [0, 0, 1, 1, 0],
-            scale: [0.6, 0.6, 1.1, 1, 0.95],
+            scale: [0.6, 0.6, 1.15, 1, 0.95],
             y: [-16, -16, 0, 0, 0],
           }}
           transition={{
             duration: TOTAL_MS / 1000,
-            times: [0, t1 * 0.85, t1, t2, 1],
+            times: [0, t1 * 0.6, t1, t2, 1],
             ease: "easeOut",
           }}
           style={{
@@ -203,8 +187,8 @@ function CardPlayFlightInner({
           <div
             className={
               isTrap
-                ? "px-5 py-1.5 rounded-full bg-purple-700 text-white text-xl font-bold tracking-wider shadow-lg border-2 border-purple-300"
-                : "px-5 py-1.5 rounded-full bg-amber-500 text-amber-950 text-xl font-bold tracking-wider shadow-lg border-2 border-amber-200"
+                ? "px-5 py-1.5 rounded-full bg-purple-700 text-white text-xl font-bold tracking-wider shadow-lg border-2 border-purple-300 whitespace-nowrap"
+                : "px-5 py-1.5 rounded-full bg-amber-500 text-amber-950 text-xl font-bold tracking-wider shadow-lg border-2 border-amber-200 whitespace-nowrap"
             }
           >
             {isTrap ? "セット！" : "発動！"}

--- a/src/components/game/card-shogi/card-play-flight.tsx
+++ b/src/components/game/card-shogi/card-play-flight.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
+
+import type { CardInstance } from "@/lib/shogi/cards/types";
+import { CardView } from "./card-view";
+
+interface CardPlayFlightProps {
+  cardInstance: CardInstance | null;
+  flightKey: number | null;
+  startRectGetter: () => DOMRect | null;
+  isTrap: boolean;
+  onComplete: () => void;
+}
+
+// CardView size="xl" の素サイズ (DrawFlightCard と揃える)
+const CARD_W = 576;
+const CARD_H = 352;
+
+// Issue #106: ドロー演出 (~2.65s) より短め。手番継続中に挟むため間延びを避ける。
+const FADE_IN_MS = 320;
+const HOLD_MS = 700;
+const FADE_OUT_MS = 350;
+const TOTAL_MS = FADE_IN_MS + HOLD_MS + FADE_OUT_MS;
+
+const FLASH_DELAY_S = FADE_IN_MS / 1000;
+const SHIMMER_DURATION_S = 0.6;
+const GLOW_DURATION_S = 0.75;
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function CardPlayFlight({
+  cardInstance,
+  flightKey,
+  startRectGetter,
+  isTrap,
+  onComplete,
+}: CardPlayFlightProps) {
+  const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+  if (!isClient) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 pointer-events-none z-[60]">
+      <AnimatePresence>
+        {cardInstance && flightKey !== null && (
+          <CardPlayFlightInner
+            key={flightKey}
+            cardInstance={cardInstance}
+            startRectGetter={startRectGetter}
+            isTrap={isTrap}
+            onComplete={onComplete}
+          />
+        )}
+      </AnimatePresence>
+    </div>,
+    document.body,
+  );
+}
+
+function CardPlayFlightInner({
+  cardInstance,
+  startRectGetter,
+  isTrap,
+  onComplete,
+}: {
+  cardInstance: CardInstance;
+  startRectGetter: () => DOMRect | null;
+  isTrap: boolean;
+  onComplete: () => void;
+}) {
+  // Issue #78 と同じ理由: タブ非アクティブ時に onAnimationComplete が遅延する
+  // 場合の保険タイマー。completedRef で onAnimationComplete との重複呼出しを防ぐ。
+  const completedRef = useRef(false);
+  const handleComplete = useCallback(() => {
+    if (completedRef.current) return;
+    completedRef.current = true;
+    onComplete();
+  }, [onComplete]);
+
+  useEffect(() => {
+    const id = window.setTimeout(handleComplete, TOTAL_MS + 500);
+    return () => window.clearTimeout(id);
+  }, [handleComplete]);
+
+  const [coords] = useState(() => {
+    if (typeof window === "undefined") return null;
+    const startRect = startRectGetter();
+
+    const winW = window.innerWidth;
+    const winH = window.innerHeight;
+    const centerX = (winW - CARD_W) / 2;
+    const centerY = (winH - CARD_H) / 2;
+
+    // モバイル等で 576x352 がそのまま入らない場合、ビューポートにフィットする倍率まで縮小。
+    const centerScale = Math.min(1, (winW * 0.92) / CARD_W, (winH * 0.85) / CARD_H);
+
+    const startX = startRect ? startRect.x + startRect.width / 2 - CARD_W / 2 : centerX;
+    const startY = startRect ? startRect.y + startRect.height / 2 - CARD_H / 2 : centerY;
+    const startScale = startRect ? Math.max(0.15, startRect.width / CARD_W) : 0.3;
+
+    return { startX, startY, centerX, centerY, startScale, centerScale };
+  });
+
+  if (!coords) return null;
+  const { startX, startY, centerX, centerY, startScale, centerScale } = coords;
+
+  const t1 = FADE_IN_MS / TOTAL_MS;
+  const t2 = (FADE_IN_MS + HOLD_MS) / TOTAL_MS;
+
+  // グロウ色: トラップは紫 (BoardOverlay の trap_trigger と揃える)、通常は黄金 (ドロー演出と揃える)
+  const glowShadow = isTrap
+    ? "0 0 90px 14px rgba(168, 85, 247, 0.85)"
+    : "0 0 90px 14px rgba(251, 191, 36, 0.9)";
+
+  return (
+    <motion.div
+      initial={{ left: startX, top: startY, scale: startScale, opacity: 0 }}
+      animate={{
+        left: [startX, centerX, centerX, centerX],
+        top: [startY, centerY, centerY, centerY],
+        scale: [startScale, centerScale, centerScale, centerScale * 1.04],
+        opacity: [0, 1, 1, 0],
+      }}
+      transition={{
+        duration: TOTAL_MS / 1000,
+        times: [0, t1, t2, 1],
+        ease: ["easeOut", "linear", "easeIn"],
+      }}
+      onAnimationComplete={handleComplete}
+      style={{
+        position: "fixed",
+        width: CARD_W,
+        height: CARD_H,
+        willChange: "transform, opacity, left, top",
+      }}
+    >
+      <div className="relative w-full h-full">
+        {/* グロウ: 中央到着の瞬間カード周辺がふわっと光る */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.92 }}
+          animate={{ opacity: [0, 0.95, 0], scale: [0.92, 1.08, 1] }}
+          transition={{
+            duration: GLOW_DURATION_S,
+            delay: FLASH_DELAY_S,
+            times: [0, 0.45, 1],
+            ease: "easeOut",
+          }}
+          style={{
+            position: "absolute",
+            inset: -12,
+            borderRadius: "0.6rem",
+            boxShadow: glowShadow,
+            pointerEvents: "none",
+          }}
+        />
+        {/* カード本体 + シマー */}
+        <div className="absolute inset-0 rounded-md shadow-2xl overflow-hidden">
+          <CardView card={cardInstance} size="xl" fullWidth />
+          <motion.div
+            initial={{ x: "-110%", opacity: 0 }}
+            animate={{ x: ["-110%", "-110%", "210%"], opacity: [0, 1, 0] }}
+            transition={{
+              duration: SHIMMER_DURATION_S,
+              delay: FLASH_DELAY_S,
+              times: [0, 0.05, 1],
+              ease: "easeOut",
+            }}
+            style={{
+              position: "absolute",
+              inset: 0,
+              background:
+                "linear-gradient(115deg, transparent 35%, rgba(255,255,255,0.9) 50%, transparent 65%)",
+              pointerEvents: "none",
+              mixBlendMode: "overlay",
+            }}
+          />
+        </div>
+        {/* 「発動！」/「セット！」バッジ: カード上端に被せて配置 */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.6, y: -16 }}
+          animate={{
+            opacity: [0, 0, 1, 1, 0],
+            scale: [0.6, 0.6, 1.1, 1, 0.95],
+            y: [-16, -16, 0, 0, 0],
+          }}
+          transition={{
+            duration: TOTAL_MS / 1000,
+            times: [0, t1 * 0.85, t1, t2, 1],
+            ease: "easeOut",
+          }}
+          style={{
+            position: "absolute",
+            left: "50%",
+            top: -32,
+            transform: "translateX(-50%)",
+            pointerEvents: "none",
+          }}
+        >
+          <div
+            className={
+              isTrap
+                ? "px-5 py-1.5 rounded-full bg-purple-700 text-white text-xl font-bold tracking-wider shadow-lg border-2 border-purple-300"
+                : "px-5 py-1.5 rounded-full bg-amber-500 text-amber-950 text-xl font-bold tracking-wider shadow-lg border-2 border-amber-200"
+            }
+          >
+            {isTrap ? "セット！" : "発動！"}
+          </div>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -41,6 +41,7 @@ import { TrapSlot } from "./trap-slot";
 import { DeckPile } from "./deck-pile";
 import { CardPlayDialog, CardTargetingNotice } from "./card-play-dialog";
 import { DrawFlightCard } from "./draw-flight-card";
+import { CardPlayFlight } from "./card-play-flight";
 import { ManaFlightLayer, type ManaFlightItem } from "./mana-flight";
 import { FastMoveBadgeLayer, type FastMoveBadgeItem } from "./fast-move-badge";
 
@@ -80,6 +81,14 @@ export function CardShogiGame({
   // Issue #78: ドロー演出 (山札→中央→手札)。演出完了まで自分の手番継続・操作ロック。
   const [drawFlight, setDrawFlight] = useState<{ card: CardInstance; key: number } | null>(null);
   const isDrawAnimating = drawFlight !== null;
+  // Issue #106: カード使用/トラップセット時の中央演出 (手札→中央→フェードアウト)。
+  // ドロー演出と異なり手番をロックせず短時間 (~1.4s) で抜ける。
+  const [playFlight, setPlayFlight] = useState<{
+    card: CardInstance;
+    key: number;
+    startRect: DOMRect | null;
+    isTrap: boolean;
+  } | null>(null);
   // 演出完了直後に手札の対象カードを一瞬光らせる (Issue #78)
   const [freshlyDrawnId, setFreshlyDrawnId] = useState<string | null>(null);
   // 各レイアウトの山札・手札 DOM ref。表示中のものから矩形を取得する。
@@ -317,10 +326,19 @@ export function CardShogiGame({
         case "cardPlayEvent": {
           playSfx("card_play");
           const def = CARD_DEFS[ev.instance.defId];
+          const cached = playedCardRectRef.current;
+          const startRect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
           if (def.cost > 0) {
-            const cached = playedCardRectRef.current;
-            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
-            triggerManaFlight(-def.cost, rect);
+            triggerManaFlight(-def.cost, startRect);
+          }
+          // Issue #106: カード使用時に中央へカード本体を表示 (自分プレイヤーのみ)
+          if (ev.player === playerColor) {
+            setPlayFlight({
+              card: ev.instance,
+              key: Date.now(),
+              startRect,
+              isTrap: false,
+            });
           }
           break;
         }
@@ -351,10 +369,19 @@ export function CardShogiGame({
         case "trapSetEvent": {
           playSfx("card_play");
           const def = CARD_DEFS[ev.instance.defId];
+          const cached = playedCardRectRef.current;
+          const startRect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
           if (def.cost > 0) {
-            const cached = playedCardRectRef.current;
-            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
-            triggerManaFlight(-def.cost, rect);
+            triggerManaFlight(-def.cost, startRect);
+          }
+          // Issue #106: トラップセット時も中央へカード本体を表示
+          if (ev.player === playerColor) {
+            setPlayFlight({
+              card: { instanceId: ev.instance.instanceId, defId: ev.instance.defId },
+              key: Date.now(),
+              startRect,
+              isTrap: true,
+            });
           }
           break;
         }
@@ -406,6 +433,11 @@ export function CardShogiGame({
     if (!drawFlight) return cardState.hand[playerColor];
     return cardState.hand[playerColor].filter((c) => c.instanceId !== drawFlight.card.instanceId);
   }, [cardState.hand, playerColor, drawFlight]);
+
+  // Issue #106: カード使用演出の startRect は state からスナップショット参照する
+  const playFlightStartRect = playFlight?.startRect ?? null;
+  const getPlayFlightStartRect = useCallback(() => playFlightStartRect, [playFlightStartRect]);
+  const handlePlayFlightComplete = useCallback(() => setPlayFlight(null), []);
 
   // ドロー演出完了: currentPlayer を相手に渡し、手札の対象カードを一瞬フラッシュさせる
   const handleDrawFlightComplete = useCallback(() => {
@@ -1034,6 +1066,15 @@ export function CardShogiGame({
         deckRectGetter={getDeckRect}
         handRectGetter={getHandRect}
         onComplete={handleDrawFlightComplete}
+      />
+
+      {/* Issue #106: カード使用/トラップセット時の中央演出 (手札→中央→フェードアウト) */}
+      <CardPlayFlight
+        cardInstance={playFlight?.card ?? null}
+        flightKey={playFlight?.key ?? null}
+        startRectGetter={getPlayFlightStartRect}
+        isTrap={playFlight?.isTrap ?? false}
+        onComplete={handlePlayFlightComplete}
       />
 
       {/* Issue #77: マナ加減算の浮遊テキスト (起点 UI 付近に表示) */}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -89,6 +89,9 @@ export function CardShogiGame({
     startRect: DOMRect | null;
     isTrap: boolean;
   } | null>(null);
+  // 連続プレイ時に Date.now() が同 ms に丸まると AnimatePresence が
+  // 同一 key と判定し新 inner を mount しない。単調増加カウンタで防ぐ。
+  const playFlightKeyRef = useRef(0);
   // 演出完了直後に手札の対象カードを一瞬光らせる (Issue #78)
   const [freshlyDrawnId, setFreshlyDrawnId] = useState<string | null>(null);
   // 各レイアウトの山札・手札 DOM ref。表示中のものから矩形を取得する。
@@ -333,9 +336,10 @@ export function CardShogiGame({
           }
           // Issue #106: カード使用時に中央へカード本体を表示 (自分プレイヤーのみ)
           if (ev.player === playerColor) {
+            playFlightKeyRef.current += 1;
             setPlayFlight({
               card: ev.instance,
-              key: Date.now(),
+              key: playFlightKeyRef.current,
               startRect,
               isTrap: false,
             });
@@ -375,10 +379,12 @@ export function CardShogiGame({
             triggerManaFlight(-def.cost, startRect);
           }
           // Issue #106: トラップセット時も中央へカード本体を表示
+          // CardInstance に詰め直し (TrapInstance.owner は CardView 側で参照しないため捨てる)
           if (ev.player === playerColor) {
+            playFlightKeyRef.current += 1;
             setPlayFlight({
               card: { instanceId: ev.instance.instanceId, defId: ev.instance.defId },
-              key: Date.now(),
+              key: playFlightKeyRef.current,
               startRect,
               isTrap: true,
             });

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -305,6 +305,9 @@ export function CardShogiGame({
   const handleConfirmPlayCard = useCallback(() => {
     cachePendingCardRect();
     confirmPlayCard();
+    // Issue #106: モバイル手札ドロワーは「使用する」確定時に閉じる
+    // (キャンセル時は開いたままにし、再度カードを選び直しやすくする)
+    setDrawerOpen(false);
   }, [cachePendingCardRect, confirmPlayCard]);
 
   // カードイベント由来の SE 再生・画面演出・マナ浮遊テキストを eventLog の差分監視で発火
@@ -849,10 +852,7 @@ export function CardShogiGame({
             disabled={handDisabled}
             flashCardId={freshlyDrawnId}
             hideCardDescription
-            onCardClick={(id) => {
-              handleBeginPlayCard(id);
-              setDrawerOpen(false);
-            }}
+            onCardClick={handleBeginPlayCard}
           />
         </div>
       </div>

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -839,12 +839,16 @@ export function CardShogiGame({
           <Button size="sm" variant="ghost" onClick={() => setDrawerOpen(false)}>閉じる</Button>
         </div>
         <div className="p-3 overflow-x-auto">
+          {/* Issue #106: モバイル手札は幅が狭くトラップラベルとカード名が
+            * 被るため、効果記述は非表示。トラップ用バッジは CardView 側で
+            * カード名の下に再配置される。 */}
           <HandArea
             hand={displayedOwnHand}
             currentMana={cardState.mana[playerColor]}
             size="md"
             disabled={handDisabled}
             flashCardId={freshlyDrawnId}
+            hideCardDescription
             onCardClick={(id) => {
               handleBeginPlayCard(id);
               setDrawerOpen(false);

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -81,12 +81,11 @@ export function CardShogiGame({
   // Issue #78: ドロー演出 (山札→中央→手札)。演出完了まで自分の手番継続・操作ロック。
   const [drawFlight, setDrawFlight] = useState<{ card: CardInstance; key: number } | null>(null);
   const isDrawAnimating = drawFlight !== null;
-  // Issue #106: カード使用/トラップセット時の中央演出 (手札→中央→フェードアウト)。
-  // ドロー演出と異なり手番をロックせず短時間 (~1.4s) で抜ける。
+  // Issue #106: カード使用/トラップセット時の中央演出 (中央にパッと出現+キラッと光る)。
+  // ドロー演出と異なり手番をロックせず短時間 (~1.2s) で抜ける。
   const [playFlight, setPlayFlight] = useState<{
     card: CardInstance;
     key: number;
-    startRect: DOMRect | null;
     isTrap: boolean;
   } | null>(null);
   // 連続プレイ時に Date.now() が同 ms に丸まると AnimatePresence が
@@ -329,10 +328,10 @@ export function CardShogiGame({
         case "cardPlayEvent": {
           playSfx("card_play");
           const def = CARD_DEFS[ev.instance.defId];
-          const cached = playedCardRectRef.current;
-          const startRect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
           if (def.cost > 0) {
-            triggerManaFlight(-def.cost, startRect);
+            const cached = playedCardRectRef.current;
+            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
+            triggerManaFlight(-def.cost, rect);
           }
           // Issue #106: カード使用時に中央へカード本体を表示 (自分プレイヤーのみ)
           if (ev.player === playerColor) {
@@ -340,7 +339,6 @@ export function CardShogiGame({
             setPlayFlight({
               card: ev.instance,
               key: playFlightKeyRef.current,
-              startRect,
               isTrap: false,
             });
           }
@@ -373,10 +371,10 @@ export function CardShogiGame({
         case "trapSetEvent": {
           playSfx("card_play");
           const def = CARD_DEFS[ev.instance.defId];
-          const cached = playedCardRectRef.current;
-          const startRect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
           if (def.cost > 0) {
-            triggerManaFlight(-def.cost, startRect);
+            const cached = playedCardRectRef.current;
+            const rect = cached?.id === ev.instance.instanceId ? cached.rect : getHandRect();
+            triggerManaFlight(-def.cost, rect);
           }
           // Issue #106: トラップセット時も中央へカード本体を表示
           // CardInstance に詰め直し (TrapInstance.owner は CardView 側で参照しないため捨てる)
@@ -385,7 +383,6 @@ export function CardShogiGame({
             setPlayFlight({
               card: { instanceId: ev.instance.instanceId, defId: ev.instance.defId },
               key: playFlightKeyRef.current,
-              startRect,
               isTrap: true,
             });
           }
@@ -440,9 +437,7 @@ export function CardShogiGame({
     return cardState.hand[playerColor].filter((c) => c.instanceId !== drawFlight.card.instanceId);
   }, [cardState.hand, playerColor, drawFlight]);
 
-  // Issue #106: カード使用演出の startRect は state からスナップショット参照する
-  const playFlightStartRect = playFlight?.startRect ?? null;
-  const getPlayFlightStartRect = useCallback(() => playFlightStartRect, [playFlightStartRect]);
+  // Issue #106: カード使用演出は中央に固定出現するため startRect は不要
   const handlePlayFlightComplete = useCallback(() => setPlayFlight(null), []);
 
   // ドロー演出完了: currentPlayer を相手に渡し、手札の対象カードを一瞬フラッシュさせる
@@ -1074,11 +1069,10 @@ export function CardShogiGame({
         onComplete={handleDrawFlightComplete}
       />
 
-      {/* Issue #106: カード使用/トラップセット時の中央演出 (手札→中央→フェードアウト) */}
+      {/* Issue #106: カード使用/トラップセット時の中央演出 (中央にパッと出現+キラッと光る) */}
       <CardPlayFlight
         cardInstance={playFlight?.card ?? null}
         flightKey={playFlight?.key ?? null}
-        startRectGetter={getPlayFlightStartRect}
         isTrap={playFlight?.isTrap ?? false}
         onComplete={handlePlayFlightComplete}
       />

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -35,7 +35,11 @@ interface CardViewProps {
   card: CardInstance;
   faceDown?: boolean;
   onClick?: () => void;
+  // 物理的に使用不可 (マナ不足など): グレーアウト + クリック不可 + cursor-not-allowed
   disabled?: boolean;
+  // 文脈的に操作不可だが「使用不可ではない」(相手番・ドロー演出中など):
+  // グレーアウトせず通常表示のまま、ホバー演出だけ抑止しクリックを無効化
+  inactive?: boolean;
   size?: CardViewSize;
   selected?: boolean;
   fullWidth?: boolean;
@@ -175,6 +179,7 @@ export function CardView({
   faceDown = false,
   onClick,
   disabled = false,
+  inactive = false,
   size = "md",
   selected = false,
   fullWidth = false,
@@ -212,7 +217,9 @@ export function CardView({
   return (
     <button
       type="button"
-      onClick={onClick}
+      // inactive (相手番など) では HTML disabled を立てず onClick だけ無効化する。
+      // disabled を立てるとマナ不足と同じ grayout 表現になってしまうため。
+      onClick={inactive ? undefined : onClick}
       disabled={disabled}
       data-card-id={card.instanceId}
       data-rarity={def.rarity}
@@ -230,13 +237,14 @@ export function CardView({
         isAnimated && RARITY_BG_CLASS[def.rarity],
         // 斜め閃光 (super_rare/epic)
         isAnimated && RARITY_HAS_SHINE[def.rarity] && "card-rarity-shine",
-        // 非活性: ぱっと見で「使えない」と分かるよう、彩度をゼロにし
-        // opacity も下げてグレーアウトを強める。レア度演出 (動的グラデ・
-        // オーブの動き) は形状として残るが、彩度が落ちて主張は弱まる。
-        // 活性: card-hover-focus で暖色リング+lift のフォーカス強調を付与。
+        // disabled (マナ不足等の使用不可): 彩度ゼロ + opacity 50% で「使えない」と分かる
+        // inactive (相手番等の操作不可): 通常表示のまま、ホバー演出だけ抑止
+        // 活性: card-hover-focus で暖色リング+lift のフォーカス強調
         disabled
           ? "opacity-50 saturate-0 cursor-not-allowed"
-          : "cursor-pointer card-hover-focus",
+          : inactive
+            ? "cursor-default"
+            : "cursor-pointer card-hover-focus",
         // 選択時は ring で強調(枠のレア度色は維持)
         selected && "ring-2 ring-primary ring-offset-1 ring-offset-background",
       )}

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -308,7 +308,9 @@ export function CardView({
       <div className="relative z-10 flex-1 min-w-0 flex flex-col justify-center gap-0.5">
         <div className="flex items-center gap-1">
           <span className={cn("font-bold leading-tight truncate", NAME_TEXT_CLASS[size])}>{def.name}</span>
-          {def.kind === "trap" && (
+          {/* hideDescription 時はカード名横にバッジを置かず、下段(説明位置)に
+            * 単独で配置する (モバイル手札で名前と被って見づらくなるため)。 */}
+          {def.kind === "trap" && !hideDescription && (
             <span
               className={cn(
                 "bg-emerald-600 text-white px-1.5 rounded font-bold leading-tight shrink-0 shadow-sm",
@@ -329,6 +331,17 @@ export function CardView({
           >
             {def.description}
           </div>
+        )}
+        {/* hideDescription 時のトラップカード: 元々説明があった位置にバッジを表示 */}
+        {hideDescription && def.kind === "trap" && (
+          <span
+            className={cn(
+              "bg-emerald-600 text-white px-1.5 rounded font-bold leading-tight shadow-sm self-start",
+              TRAP_BADGE_TEXT_CLASS[size],
+            )}
+          >
+            トラップ
+          </span>
         )}
       </div>
     </button>

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -39,6 +39,9 @@ interface CardViewProps {
   size?: CardViewSize;
   selected?: boolean;
   fullWidth?: boolean;
+  // 効果説明テキストを非表示にする (Issue #106: ダイアログプレビュー等で
+  // 説明はダイアログ側に書く場合に重複を避けるため)
+  hideDescription?: boolean;
 }
 
 // "sm" はサムネイル(裏向きの相手手札用、縦長)
@@ -175,6 +178,7 @@ export function CardView({
   size = "md",
   selected = false,
   fullWidth = false,
+  hideDescription = false,
 }: CardViewProps) {
   const def = CARD_DEFS[card.defId];
 
@@ -300,15 +304,17 @@ export function CardView({
             </span>
           )}
         </div>
-        <div
-          className={cn(
-            "leading-tight line-clamp-2",
-            hasRarityBg ? "text-slate-300" : "text-muted-foreground",
-            DESC_TEXT_CLASS[size],
-          )}
-        >
-          {def.description}
-        </div>
+        {!hideDescription && (
+          <div
+            className={cn(
+              "leading-tight line-clamp-2",
+              hasRarityBg ? "text-slate-300" : "text-muted-foreground",
+              DESC_TEXT_CLASS[size],
+            )}
+          >
+            {def.description}
+          </div>
+        )}
       </div>
     </button>
   );

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -237,11 +237,13 @@ export function CardView({
         isAnimated && RARITY_BG_CLASS[def.rarity],
         // 斜め閃光 (super_rare/epic)
         isAnimated && RARITY_HAS_SHINE[def.rarity] && "card-rarity-shine",
-        // disabled (マナ不足等の使用不可): 彩度ゼロ + opacity 50% で「使えない」と分かる
+        // disabled (マナ不足等の使用不可): 彩度を 40% まで下げて opacity も落とし
+        //   「使えない」感を出す。完全モノクロにはせず、レア度の枠色や動的
+        //   グラデを薄く残すことでレア/究極レア等の判別を可能にする。
         // inactive (相手番等の操作不可): 通常表示のまま、ホバー演出だけ抑止
         // 活性: card-hover-focus で暖色リング+lift のフォーカス強調
         disabled
-          ? "opacity-50 saturate-0 cursor-not-allowed"
+          ? "opacity-55 saturate-[40%] cursor-not-allowed"
           : inactive
             ? "cursor-default"
             : "cursor-pointer card-hover-focus",

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -250,7 +250,7 @@ export function CardView({
         // 選択時は ring で強調(枠のレア度色は維持)
         selected && "ring-2 ring-primary ring-offset-1 ring-offset-background",
       )}
-      aria-label={`${def.name} (コスト${def.cost})`}
+      aria-label={`${def.name} (マナコスト ${def.cost})`}
     >
       {/* ホバーフォーカス用の薄黄色オーバーレイ。常に DOM に置き、:hover で
         * opacity をフェードイン (CSS 側 .card-hover-focus:hover .card-hover-overlay)。
@@ -282,7 +282,10 @@ export function CardView({
       >
         <span
           className={cn(
-            "rounded-full px-2 leading-tight font-bold tabular-nums",
+            "rounded-full leading-tight font-bold tabular-nums whitespace-nowrap inline-flex items-center",
+            // Issue #106: 山札のドローコスト表示と統一感を出すため 💎×N 形式に
+            // し、数値だけより「マナコスト」と直感的に分かるようにする。
+            size === "xl" ? "px-3 py-1 gap-1.5" : "px-1 gap-0.5",
             COST_TEXT_CLASS[size],
             def.kind === "trap"
               ? hasRarityBg
@@ -292,8 +295,10 @@ export function CardView({
                 ? "bg-amber-900/50 text-amber-200"
                 : "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
           )}
+          title={`マナコスト: ${def.cost}`}
         >
-          {def.cost}
+          <span aria-hidden>💎</span>
+          <span>×{def.cost}</span>
         </span>
         <span className={cn(ICON_SIZE_CLASS[size], "leading-none")} aria-hidden>
           {def.icon}

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -226,11 +226,12 @@ export function CardView({
         isAnimated && RARITY_BG_CLASS[def.rarity],
         // 斜め閃光 (super_rare/epic)
         isAnimated && RARITY_HAS_SHINE[def.rarity] && "card-rarity-shine",
-        // 非活性: 鮮やかさだけ落としてレア度演出は維持(opacity ではなく
-        // saturate を使うことで動的グラデ・オーブの形状感は残す)。
+        // 非活性: ぱっと見で「使えない」と分かるよう、彩度をゼロにし
+        // opacity も下げてグレーアウトを強める。レア度演出 (動的グラデ・
+        // オーブの動き) は形状として残るが、彩度が落ちて主張は弱まる。
         // 活性: card-hover-focus で暖色リング+lift のフォーカス強調を付与。
         disabled
-          ? "opacity-70 saturate-50 cursor-not-allowed"
+          ? "opacity-50 saturate-0 cursor-not-allowed"
           : "cursor-pointer card-hover-focus",
         // 選択時は ring で強調(枠のレア度色は維持)
         selected && "ring-2 ring-primary ring-offset-1 ring-offset-background",

--- a/src/components/game/card-shogi/deck-pile.tsx
+++ b/src/components/game/card-shogi/deck-pile.tsx
@@ -30,10 +30,17 @@ const SIZE_CLASS = {
 // ...
 // count >= STACK_MAX + 1 のとき: ズレカード STACK_MAX 枚
 const STACK_MAX = 4;
-const STACK_OFFSET = {
-  sm: 1.5,
-  md: 2,
-  lg: 2.5,
+// X (横) は極小: 隣接する TRAP との被りを避けるため最小限のはみ出しに抑える。
+// Y (縦) は少し控えめに: 視認できる程度に積み重なりを表現。
+const STACK_OFFSET_X = {
+  sm: 0.5,
+  md: 0.8,
+  lg: 1,
+};
+const STACK_OFFSET_Y = {
+  sm: 1,
+  md: 1.5,
+  lg: 2,
 };
 
 interface StackCardProps {
@@ -120,21 +127,23 @@ export function DeckPile({
 
   // 後ろに重ねる枚数: count - 1 を最大 STACK_MAX で頭打ち
   const stackCount = Math.min(Math.max(count - 1, 0), STACK_MAX);
-  const offsetUnit = STACK_OFFSET[size];
+  const offsetUnitX = STACK_OFFSET_X[size];
+  const offsetUnitY = STACK_OFFSET_Y[size];
 
   return (
     <div
       className={cn("relative shrink-0", fullWidth ? "w-full" : SIZE_CLASS[size].split(" ")[0])}
       // 後ろのズレカード分の余白を確保 (描画領域を超えてはみ出さないように)
       style={{
-        paddingRight: stackCount * offsetUnit,
-        paddingBottom: stackCount * offsetUnit,
+        paddingRight: stackCount * offsetUnitX,
+        paddingBottom: stackCount * offsetUnitY,
       }}
     >
       {/* 後ろのズレカード(N 枚)。i=0 が一番奥、i=stackCount-1 が手前。 */}
       {Array.from({ length: stackCount }).map((_, i) => {
         // 手前ほど offset 小、奥ほど offset 大
-        const offset = (stackCount - i) * offsetUnit;
+        const offsetX = (stackCount - i) * offsetUnitX;
+        const offsetY = (stackCount - i) * offsetUnitY;
         return (
           <div
             key={i}
@@ -142,9 +151,9 @@ export function DeckPile({
             style={{
               top: 0,
               left: 0,
-              right: stackCount * offsetUnit - offset,
-              bottom: stackCount * offsetUnit - offset,
-              transform: `translate(${offset}px, ${offset}px)`,
+              right: stackCount * offsetUnitX - offsetX,
+              bottom: stackCount * offsetUnitY - offsetY,
+              transform: `translate(${offsetX}px, ${offsetY}px)`,
               zIndex: i,
             }}
           >

--- a/src/components/game/card-shogi/hand-area.tsx
+++ b/src/components/game/card-shogi/hand-area.tsx
@@ -75,7 +75,11 @@ export function HandArea({
     >
       {hand.map((c) => {
         const def = CARD_DEFS[c.defId];
-        const cardDisabled = disabled || currentMana < def.cost;
+        // マナ不足: 常にグレーアウト (操作不可かどうかに関わらず)
+        // マナ十分かつ全体 disabled (相手番など): 通常表示のまま操作だけ無効化 (= inactive)
+        const unaffordable = currentMana < def.cost;
+        const cardDisabled = unaffordable;
+        const cardInactive = !unaffordable && disabled;
         const isFresh = c.instanceId === flashCardId;
         return (
           <div
@@ -86,6 +90,7 @@ export function HandArea({
               card={c}
               size={size}
               disabled={cardDisabled}
+              inactive={cardInactive}
               fullWidth={fullWidth}
               onClick={() => onCardClick?.(c.instanceId)}
             />

--- a/src/components/game/card-shogi/hand-area.tsx
+++ b/src/components/game/card-shogi/hand-area.tsx
@@ -20,6 +20,8 @@ interface HandAreaProps {
   fullWidth?: boolean;
   // Issue #78: 直前にドローしたカードを一瞬光らせる (instanceId 一致のカードに animate-hand-card-flash を付与)
   flashCardId?: string | null;
+  // Issue #106: モバイル手札等の幅が狭いコンテキストで効果説明を非表示にする
+  hideCardDescription?: boolean;
 }
 
 export function HandArea({
@@ -33,6 +35,7 @@ export function HandArea({
   disabled = false,
   fullWidth = false,
   flashCardId = null,
+  hideCardDescription = false,
 }: HandAreaProps) {
   if (hand.length === 0) {
     return <div className="text-xs text-muted-foreground py-2 px-3">{emptyLabel}</div>;
@@ -92,6 +95,7 @@ export function HandArea({
               disabled={cardDisabled}
               inactive={cardInactive}
               fullWidth={fullWidth}
+              hideDescription={hideCardDescription}
               onClick={() => onCardClick?.(c.instanceId)}
             />
           </div>

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -460,12 +460,13 @@ function reducer(
       if (!card) return state;
       const def = CARD_DEFS[card.defId];
       if (state.cardState.mana[action.player] < def.cost) return state;
-      const phase = def.targeting === "none" || def.kind === "trap" ? "confirm" : "selectTarget";
+      // Issue #106: 全カードでまず確認ポップアップ (phase="confirm") を出し、
+      // 「使用する」確定後に必要なら selectTarget へ遷移する流れに統一する。
       return {
         ...state,
         cardState: {
           ...state.cardState,
-          pendingCard: { instance: card, player: action.player, phase },
+          pendingCard: { instance: card, player: action.player, phase: "confirm" },
         },
         // 通常の駒選択状態はクリア
         selectedSquare: null,
@@ -477,13 +478,16 @@ function reducer(
     case "SELECT_CARD_TARGET": {
       const pending = state.cardState.pendingCard;
       if (!pending) return state;
-      return {
+      // Issue #106: target が確定したら即座に効果適用に進む (確認ステップは
+      // 既に手札選択直後の confirm フェーズで踏んでいる)。
+      const stateWithTarget: CardShogiGameStateInternal = {
         ...state,
         cardState: {
           ...state.cardState,
           pendingCard: { ...pending, target: action.target, phase: "confirm" },
         },
       };
+      return reducer(stateWithTarget, { type: "CONFIRM_PLAY_CARD" });
     }
 
     case "CONFIRM_PLAY_CARD": {
@@ -493,9 +497,16 @@ function reducer(
       const player = pending.player;
       const opponent: Player = player === "sente" ? "gote" : "sente";
 
-      // ターゲット必須カードでターゲット未選択 → 何もしない
+      // Issue #106: ターゲット必須カードで未選択なら、確認ポップアップから
+      // selectTarget フェーズに遷移して盤面選択に進む (効果適用はしない)。
       if (def.targeting !== "none" && def.kind !== "trap" && !pending.target) {
-        return state;
+        return {
+          ...state,
+          cardState: {
+            ...state.cardState,
+            pendingCard: { ...pending, phase: "selectTarget" },
+          },
+        };
       }
 
       // 効果適用


### PR DESCRIPTION
## Summary
- カード使用時に画面中央へカード本体を「パッと出現+キラッと光る」演出を追加 (CardPlayFlight)
- 手札カード選択ポップアップの上に選択カードプレビューを重ね、両者の重心を画面中央に配置
- 「確認ポップアップ → 対象選択」の順序に統一し、対象選択カード (歩戻し等) も使用可否を先に判断できるフローに

## メインタスク以外の細々とした UX 調整
- カード disabled スタイルを段階的に強化 (`opacity-50 saturate-0` → 最終 `opacity-55 saturate-[40%]`、レア度判別性を確保)
- CardView に `inactive` prop を追加し「グレーアウト (使用不可)」と「クリック制御 (相手番等)」を分離
- 山札のスタックオフセットを X (極小) / Y (控えめ) に分離し TRAP との被りを解消
- カードコスト表示を `💎×N` 形式に変更し山札 (DRAW_COST 表示) と統一
- モバイル手札ドロワーで効果説明を非表示にし、トラップラベルを名前の下段に再配置
- モバイル手札ドロワーをカード選択時ではなく「使用する」確定時に閉じるよう変更

## Test plan
- [ ] 通常カード使用時に中央でカードが「パッと出現+キラッと光る」演出が再生される
- [ ] トラップカードでは紫グロウ + 「セット！」バッジで識別できる
- [ ] 手札カード選択時、ポップアップの上にカード本体が重なり、両者を合わせて画面中央に見える
- [ ] 歩戻しを選択 → 確認ポップアップ → 「使用する」 → 駒選択モード の順で進む
- [ ] モバイル手札ドロワーで「キャンセル」してもドロワーが閉じない / 「使用する」で閉じる
- [ ] 相手番中も手札カードが通常表示 (マナ不足のみグレーアウト)
- [ ] グレーアウト中もレア度の枠色・動的グラデで rare/super_rare/epic を判別できる
- [ ] 山札と TRAP の被りが解消されている (lg / md / sm すべて)
- [ ] カードコスト pill が `💎×N` 形式で表示される
- [ ] モバイル手札のトラップカードでラベルとカード名が被っていない

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)