### PR TITLE
feat: カタログフィルタを複数選択化 (Issue #113)

### DIFF
--- a/src/components/cards/card-catalog-grid.tsx
+++ b/src/components/cards/card-catalog-grid.tsx
@@ -3,6 +3,11 @@
 import { useState, useMemo } from "react";
 import { CardCatalogTile } from "./card-catalog-tile";
 import { CardFilterBar, type CardFilterValue } from "./card-filter-bar";
+import {
+  KIND_OPTIONS,
+  RARITY_OPTIONS,
+  STATUS_OPTIONS,
+} from "@/lib/shogi/cards/labels";
 import type { CardDefinition } from "@/lib/shogi/cards/types";
 
 interface CardCatalogGridProps {
@@ -10,9 +15,9 @@ interface CardCatalogGridProps {
 }
 
 const INITIAL_FILTER: CardFilterValue = {
-  status: "all",
-  kind: "all",
-  rarity: "all",
+  status: new Set(STATUS_OPTIONS),
+  kind: new Set(KIND_OPTIONS),
+  rarity: new Set(RARITY_OPTIONS),
 };
 
 // フィルタ欄は親 flex の shrink-0 で上部固定、
@@ -22,9 +27,9 @@ export function CardCatalogGrid({ cards }: CardCatalogGridProps) {
 
   const filtered = useMemo(() => {
     return cards.filter((c) => {
-      if (filter.status !== "all" && c.status !== filter.status) return false;
-      if (filter.kind !== "all" && c.kind !== filter.kind) return false;
-      if (filter.rarity !== "all" && c.rarity !== filter.rarity) return false;
+      if (!filter.status.has(c.status)) return false;
+      if (!filter.kind.has(c.kind)) return false;
+      if (!filter.rarity.has(c.rarity)) return false;
       return true;
     });
   }, [cards, filter]);

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -17,9 +17,9 @@ import type {
 } from "@/lib/shogi/cards/types";
 
 export interface CardFilterValue {
-  status: CardStatus | "all";
-  kind: CardKind | "all";
-  rarity: CardRarity | "all";
+  status: ReadonlySet<CardStatus>;
+  kind: ReadonlySet<CardKind>;
+  rarity: ReadonlySet<CardRarity>;
 }
 
 interface CardFilterBarProps {
@@ -32,54 +32,99 @@ export function CardFilterBar({ value, onChange }: CardFilterBarProps) {
     <div className="flex flex-col gap-3">
       <FilterRow
         label="ステータス"
-        options={[
-          { id: "all", label: "すべて", className: "" },
-          ...STATUS_OPTIONS.map((s) => ({ id: s, label: STATUS_INFO[s].label, className: STATUS_INFO[s].className })),
-        ]}
+        options={STATUS_OPTIONS.map((s) => ({
+          id: s,
+          label: STATUS_INFO[s].label,
+          className: STATUS_INFO[s].className,
+        }))}
         selected={value.status}
-        onSelect={(id) => onChange({ ...value, status: id as CardFilterValue["status"] })}
+        allOptions={STATUS_OPTIONS}
+        onToggle={(id) => onChange({ ...value, status: toggle(value.status, id) })}
+        onSelectAll={() => onChange({ ...value, status: new Set(STATUS_OPTIONS) })}
       />
       <FilterRow
         label="種別"
-        options={[
-          { id: "all", label: "すべて", className: "" },
-          ...KIND_OPTIONS.map((k) => ({ id: k, label: KIND_INFO[k].label, className: KIND_INFO[k].className })),
-        ]}
+        options={KIND_OPTIONS.map((k) => ({
+          id: k,
+          label: KIND_INFO[k].label,
+          className: KIND_INFO[k].className,
+        }))}
         selected={value.kind}
-        onSelect={(id) => onChange({ ...value, kind: id as CardFilterValue["kind"] })}
+        allOptions={KIND_OPTIONS}
+        onToggle={(id) => onChange({ ...value, kind: toggle(value.kind, id) })}
+        onSelectAll={() => onChange({ ...value, kind: new Set(KIND_OPTIONS) })}
       />
       <FilterRow
         label="レア度"
-        options={[
-          { id: "all", label: "すべて", className: "" },
-          ...RARITY_OPTIONS.map((r) => ({ id: r, label: RARITY_INFO[r].label, className: RARITY_INFO[r].className })),
-        ]}
+        options={RARITY_OPTIONS.map((r) => ({
+          id: r,
+          label: RARITY_INFO[r].label,
+          className: RARITY_INFO[r].className,
+        }))}
         selected={value.rarity}
-        onSelect={(id) => onChange({ ...value, rarity: id as CardFilterValue["rarity"] })}
+        allOptions={RARITY_OPTIONS}
+        onToggle={(id) => onChange({ ...value, rarity: toggle(value.rarity, id) })}
+        onSelectAll={() => onChange({ ...value, rarity: new Set(RARITY_OPTIONS) })}
       />
     </div>
   );
 }
 
-interface FilterRowProps {
-  label: string;
-  options: { id: string; label: string; className: string }[];
-  selected: string;
-  onSelect: (id: string) => void;
+function toggle<T>(set: ReadonlySet<T>, id: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  return next;
 }
 
-function FilterRow({ label, options, selected, onSelect }: FilterRowProps) {
+interface FilterRowProps<T extends string> {
+  label: string;
+  options: { id: T; label: string; className: string }[];
+  selected: ReadonlySet<T>;
+  allOptions: readonly T[];
+  onToggle: (id: T) => void;
+  onSelectAll: () => void;
+}
+
+function FilterRow<T extends string>({
+  label,
+  options,
+  selected,
+  allOptions,
+  onToggle,
+  onSelectAll,
+}: FilterRowProps<T>) {
+  const allActive = allOptions.every((id) => selected.has(id));
   return (
     <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
       <span className="text-[10px] sm:text-xs font-medium text-muted-foreground w-11 sm:w-16 shrink-0">{label}</span>
       <div className="flex flex-wrap gap-1 sm:gap-1.5">
+        <button
+          type="button"
+          onClick={onSelectAll}
+          className={cn(
+            "cursor-pointer transition-all",
+            allActive ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : "opacity-60 hover:opacity-100",
+          )}
+          aria-pressed={allActive}
+        >
+          <Badge
+            variant="outline"
+            className={cn("text-[10px] sm:text-xs px-1.5 sm:px-2 py-0 sm:py-0.5 bg-card")}
+          >
+            すべて
+          </Badge>
+        </button>
         {options.map((opt) => {
-          const active = selected === opt.id;
+          const active = selected.has(opt.id);
           return (
             <button
               key={opt.id}
               type="button"
-              onClick={() => onSelect(opt.id)}
+              onClick={() => onToggle(opt.id)}
               className={cn(
                 "cursor-pointer transition-all",
                 active ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : "opacity-60 hover:opacity-100",

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -120,7 +120,7 @@ function FilterRow<T extends string>({
           className={cn(
             "cursor-pointer transition-all rounded-md",
             "hover:ring-2 hover:ring-amber-400/70 hover:ring-offset-1 hover:ring-offset-background",
-            allActive ? "" : "opacity-40 hover:opacity-100",
+            allActive ? "" : "opacity-40",
           )}
           aria-pressed={allActive}
         >
@@ -146,7 +146,7 @@ function FilterRow<T extends string>({
               className={cn(
                 "cursor-pointer transition-all rounded-md",
                 "hover:ring-2 hover:ring-amber-400/70 hover:ring-offset-1 hover:ring-offset-background",
-                active ? "" : "opacity-40 hover:opacity-100",
+                active ? "" : "opacity-40",
               )}
               aria-pressed={active}
             >

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -118,7 +118,8 @@ function FilterRow<T extends string>({
           type="button"
           onClick={onToggleAll}
           className={cn(
-            "cursor-pointer transition-all",
+            "cursor-pointer transition-all rounded-md",
+            "hover:ring-2 hover:ring-amber-400/70 hover:ring-offset-1 hover:ring-offset-background",
             allActive ? "" : "opacity-40 hover:opacity-100",
           )}
           aria-pressed={allActive}
@@ -138,7 +139,8 @@ function FilterRow<T extends string>({
               type="button"
               onClick={() => onToggle(opt.id)}
               className={cn(
-                "cursor-pointer transition-all",
+                "cursor-pointer transition-all rounded-md",
+                "hover:ring-2 hover:ring-amber-400/70 hover:ring-offset-1 hover:ring-offset-background",
                 active ? "" : "opacity-40 hover:opacity-100",
               )}
               aria-pressed={active}

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -126,7 +126,12 @@ function FilterRow<T extends string>({
         >
           <Badge
             variant="outline"
-            className={cn("text-[10px] sm:text-xs px-1.5 sm:px-2 py-0 sm:py-0.5 bg-card")}
+            className={cn(
+              "text-[10px] sm:text-xs px-1.5 sm:px-2 py-0 sm:py-0.5",
+              allActive
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-card",
+            )}
           >
             すべて
           </Badge>

--- a/src/components/cards/card-filter-bar.tsx
+++ b/src/components/cards/card-filter-bar.tsx
@@ -40,7 +40,9 @@ export function CardFilterBar({ value, onChange }: CardFilterBarProps) {
         selected={value.status}
         allOptions={STATUS_OPTIONS}
         onToggle={(id) => onChange({ ...value, status: toggle(value.status, id) })}
-        onSelectAll={() => onChange({ ...value, status: new Set(STATUS_OPTIONS) })}
+        onToggleAll={() =>
+          onChange({ ...value, status: toggleAll(value.status, STATUS_OPTIONS) })
+        }
       />
       <FilterRow
         label="種別"
@@ -52,7 +54,9 @@ export function CardFilterBar({ value, onChange }: CardFilterBarProps) {
         selected={value.kind}
         allOptions={KIND_OPTIONS}
         onToggle={(id) => onChange({ ...value, kind: toggle(value.kind, id) })}
-        onSelectAll={() => onChange({ ...value, kind: new Set(KIND_OPTIONS) })}
+        onToggleAll={() =>
+          onChange({ ...value, kind: toggleAll(value.kind, KIND_OPTIONS) })
+        }
       />
       <FilterRow
         label="レア度"
@@ -64,7 +68,9 @@ export function CardFilterBar({ value, onChange }: CardFilterBarProps) {
         selected={value.rarity}
         allOptions={RARITY_OPTIONS}
         onToggle={(id) => onChange({ ...value, rarity: toggle(value.rarity, id) })}
-        onSelectAll={() => onChange({ ...value, rarity: new Set(RARITY_OPTIONS) })}
+        onToggleAll={() =>
+          onChange({ ...value, rarity: toggleAll(value.rarity, RARITY_OPTIONS) })
+        }
       />
     </div>
   );
@@ -80,13 +86,19 @@ function toggle<T>(set: ReadonlySet<T>, id: T): Set<T> {
   return next;
 }
 
+// 全 ON のときは全 OFF へ、それ以外は全 ON へ切り替える。
+function toggleAll<T>(set: ReadonlySet<T>, all: readonly T[]): Set<T> {
+  const allActive = all.every((id) => set.has(id));
+  return allActive ? new Set<T>() : new Set(all);
+}
+
 interface FilterRowProps<T extends string> {
   label: string;
   options: { id: T; label: string; className: string }[];
   selected: ReadonlySet<T>;
   allOptions: readonly T[];
   onToggle: (id: T) => void;
-  onSelectAll: () => void;
+  onToggleAll: () => void;
 }
 
 function FilterRow<T extends string>({
@@ -95,7 +107,7 @@ function FilterRow<T extends string>({
   selected,
   allOptions,
   onToggle,
-  onSelectAll,
+  onToggleAll,
 }: FilterRowProps<T>) {
   const allActive = allOptions.every((id) => selected.has(id));
   return (
@@ -104,10 +116,10 @@ function FilterRow<T extends string>({
       <div className="flex flex-wrap gap-1 sm:gap-1.5">
         <button
           type="button"
-          onClick={onSelectAll}
+          onClick={onToggleAll}
           className={cn(
             "cursor-pointer transition-all",
-            allActive ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : "opacity-60 hover:opacity-100",
+            allActive ? "" : "opacity-40 hover:opacity-100",
           )}
           aria-pressed={allActive}
         >
@@ -127,7 +139,7 @@ function FilterRow<T extends string>({
               onClick={() => onToggle(opt.id)}
               className={cn(
                 "cursor-pointer transition-all",
-                active ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : "opacity-60 hover:opacity-100",
+                active ? "" : "opacity-40 hover:opacity-100",
               )}
               aria-pressed={active}
             >


### PR DESCRIPTION
## Summary
- マスターカタログ ([/cards](src/app/cards/page.tsx)) のフィルタ (status / kind / rarity) を **単一選択 → 複数選択 (multi-toggle)** に変更
- 「すべて」ボタンは **全 ON ⇄ 全 OFF のトグル**(全 ON 時に押下で全 OFF)
- 選択時の四角枠 (ring) は撤去し、ON/OFF は不透明度のみで表現
- 「すべて」ボタンの ON は他オプションと違い背景色を持たないため、`primary` 色を付与して視認性確保
- ホバー時は黄色 (amber-400/70) の薄い ring だけを表示。ボタン自体の不透明度は変えない

## 主な変更
- [src/components/cards/card-filter-bar.tsx](src/components/cards/card-filter-bar.tsx): \`CardFilterValue\` を \`ReadonlySet\` ベースに、UI を multi-toggle 化
- [src/components/cards/card-catalog-grid.tsx](src/components/cards/card-catalog-grid.tsx): フィルタ評価を \`Set.has()\` ベースに変更。初期値は全オプション ON

## Test plan
- [x] \`npx tsc --noEmit\` パス
- [x] Vercel プレビューで以下の挙動を確認
  - [x] status / kind / rarity いずれも複数オプションを ON にできる
  - [x] 「すべて」押下で全 ON、全 ON 時に押下で全 OFF
  - [x] 全オプション ON のとき「すべて」が primary 色で表示
  - [x] 全 OFF のとき「該当なし」表示
  - [x] ホバー時に黄色 ring が表示される

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)