### PR TITLE
refactor: #107 Step 2 React.memo 化でモバイルラグを軽減

### DIFF
--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import type { Hand, Player } from "@/lib/shogi/types";
 import { ShogiPiece } from "./shogi-piece";
@@ -29,7 +30,7 @@ export const CAPTURED_PIECES_HEIGHT = 72;
 // compact: モバイル時の縦幅縮小用 (駒は 36px、ラベル省略可)
 export const CAPTURED_PIECES_HEIGHT_COMPACT = 52;
 
-export function CapturedPieces({
+export const CapturedPieces = memo(function CapturedPieces({
   hand,
   player,
   playerColor,
@@ -104,4 +105,4 @@ export function CapturedPieces({
       </div>
     </div>
   );
-}
+});

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -74,6 +74,17 @@ function shouldPlayJumpSfx(move: Move): boolean {
   return Math.max(rowDiff, colDiff) >= 2;
 }
 
+// 子コンポーネント (CapturedPieces 等) に渡す noop。
+// インライン `() => {}` を毎レンダー新しい関数として渡すと React.memo の浅い比較が
+// 無効化されてしまうため、モジュールスコープで定義して安定化する (Step 2 / Issue #107)。
+const NOOP_PIECE_CLICK: (pieceType: string) => void = () => {};
+const NOOP_UNDO: () => void = () => {};
+
+// 空配列の共有参照。pieceFlight 等で「該当なし」のケースを useMemo に通しても
+// 毎レンダー [] を new するとメモ化が無効化されるため、フラグメンテーション回避。
+const EMPTY_POSITIONS: Position[] = [];
+const EMPTY_STRINGS: string[] = [];
+
 export function CardShogiGame({
   initialGameState,
   initialCardState,
@@ -677,17 +688,23 @@ export function CardShogiGame({
   // Issue #105: 親 div に flex-1 で残り幅を割り当てるため fullWidth で追従させる。
   const ownTrapSlotMobile = <TrapSlot trap={cardState.trap[playerColor]} size="md" fullWidth />;
 
-  // Issue #82: 駒フライト中、着地点を非表示にするための props 計算
-  const hiddenBoardSquares: Position[] =
-    pieceFlight && pieceFlight.hideTarget.kind === "board"
-      ? [{ row: pieceFlight.hideTarget.row, col: pieceFlight.hideTarget.col }]
-      : [];
-  const hiddenOwnCapturedTypes: string[] =
-    pieceFlight &&
-    pieceFlight.hideTarget.kind === "captured" &&
-    pieceFlight.hideTarget.player === playerColor
-      ? [pieceFlight.hideTarget.pieceType]
-      : [];
+  // Issue #82: 駒フライト中、着地点を非表示にするための props 計算。
+  // Step 2 (Issue #107): useMemo + 空配列の共有参照で ShogiBoard / CapturedPieces の
+  // memo を効かせる。
+  const hiddenBoardSquares = useMemo<Position[]>(() => {
+    if (!pieceFlight || pieceFlight.hideTarget.kind !== "board") return EMPTY_POSITIONS;
+    return [{ row: pieceFlight.hideTarget.row, col: pieceFlight.hideTarget.col }];
+  }, [pieceFlight]);
+  const hiddenOwnCapturedTypes = useMemo<string[]>(() => {
+    if (
+      !pieceFlight ||
+      pieceFlight.hideTarget.kind !== "captured" ||
+      pieceFlight.hideTarget.player !== playerColor
+    ) {
+      return EMPTY_STRINGS;
+    }
+    return [pieceFlight.hideTarget.pieceType];
+  }, [pieceFlight, playerColor]);
 
   // 山札からのドロー可否 (Issue #82: pendingCard 中もドロー禁止に統一)
   const canDrawCard =
@@ -954,7 +971,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
               selectedHandPiece={null}
-              onPieceClick={() => {}}
+              onPieceClick={NOOP_PIECE_CLICK}
               label={character.name}
               squareSize={squareSize}
               compact={isMobile}
@@ -1078,7 +1095,7 @@ export function CardShogiGame({
         <div className="shrink-0 ml-2 border-l pl-2">
           <GameControls
             onResign={resign}
-            onUndo={() => {}}
+            onUndo={NOOP_UNDO}
             isMuted={isMuted}
             onToggleMute={toggleMute}
             canUndo={false}
@@ -1270,7 +1287,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               isCurrentPlayer={gameState.currentPlayer === aiColor && isGameActive}
               selectedHandPiece={null}
-              onPieceClick={() => {}}
+              onPieceClick={NOOP_PIECE_CLICK}
               label={character.name}
               squareSize={squareSize}
             />

--- a/src/components/game/card-shogi/card-shogi-history.tsx
+++ b/src/components/game/card-shogi/card-shogi-history.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { moveToNotation } from "@/lib/shogi/notation";
 import type { Player, Position } from "@/lib/shogi/types";
 import type { GameEvent } from "@/lib/shogi/cards/types";
@@ -73,7 +73,7 @@ function buildEntries(eventLog: GameEvent[]): DisplayEntry[] {
   return entries;
 }
 
-export function CardShogiHistory({ eventLog }: CardShogiHistoryProps) {
+export const CardShogiHistory = memo(function CardShogiHistory({ eventLog }: CardShogiHistoryProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const entries = buildEntries(eventLog);
 
@@ -126,4 +126,4 @@ export function CardShogiHistory({ eventLog }: CardShogiHistoryProps) {
       </div>
     </div>
   );
-}
+});

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import type { CardInstance, CardRarity } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
@@ -176,7 +177,7 @@ const EPIC_ORBS_BY_SIZE: Record<CardViewSize, OrbVariant[]> = {
   ],
 };
 
-export function CardView({
+export const CardView = memo(function CardView({
   card,
   faceDown = false,
   onClick,
@@ -393,4 +394,4 @@ export function CardView({
       )}
     </button>
   );
-}
+});

--- a/src/components/game/card-shogi/deck-pile.tsx
+++ b/src/components/game/card-shogi/deck-pile.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import { DRAW_COST } from "@/lib/shogi/cards/definitions";
 import { CardBack } from "@/components/card-back/card-back";
@@ -65,7 +66,7 @@ function StackCard({ size, dimmed }: StackCardProps) {
   );
 }
 
-export function DeckPile({
+export const DeckPile = memo(function DeckPile({
   count,
   canDraw = false,
   onDraw,
@@ -249,4 +250,4 @@ export function DeckPile({
       </button>
     </div>
   );
-}
+});

--- a/src/components/game/card-shogi/hand-area.tsx
+++ b/src/components/game/card-shogi/hand-area.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import type { CardInstance } from "@/lib/shogi/cards/types";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
@@ -30,7 +31,49 @@ interface HandAreaProps {
   stackMaxVisible?: number;
 }
 
-export function HandArea({
+interface HandCardProps {
+  card: CardInstance;
+  size: "sm" | "md" | "lg";
+  cardDisabled: boolean;
+  cardInactive: boolean;
+  fullWidth: boolean;
+  hideCardDescription: boolean;
+  isFresh: boolean;
+  onCardClick?: (instanceId: string) => void;
+}
+
+// 手札の 1 枚分。React.memo + 内部 useCallback で onClick を安定化し、
+// 親の他フィールド変化 (マナ・eventLog 等) で他カードが再描画されないようにする。
+const HandCard = memo(function HandCard({
+  card,
+  size,
+  cardDisabled,
+  cardInactive,
+  fullWidth,
+  hideCardDescription,
+  isFresh,
+  onCardClick,
+}: HandCardProps) {
+  const handleClick = useCallback(() => {
+    onCardClick?.(card.instanceId);
+  }, [card.instanceId, onCardClick]);
+
+  return (
+    <div className={cn("rounded-md", isFresh && "animate-hand-card-flash")}>
+      <CardView
+        card={card}
+        size={size}
+        disabled={cardDisabled}
+        inactive={cardInactive}
+        fullWidth={fullWidth}
+        hideDescription={hideCardDescription}
+        onClick={handleClick}
+      />
+    </div>
+  );
+});
+
+export const HandArea = memo(function HandArea({
   hand,
   currentMana,
   faceDown = false,
@@ -105,22 +148,19 @@ export function HandArea({
         const cardInactive = !cardDisabled && disabled;
         const isFresh = c.instanceId === flashCardId;
         return (
-          <div
+          <HandCard
             key={c.instanceId}
-            className={cn("rounded-md", isFresh && "animate-hand-card-flash")}
-          >
-            <CardView
-              card={c}
-              size={size}
-              disabled={cardDisabled}
-              inactive={cardInactive}
-              fullWidth={fullWidth}
-              hideDescription={hideCardDescription}
-              onClick={() => onCardClick?.(c.instanceId)}
-            />
-          </div>
+            card={c}
+            size={size}
+            cardDisabled={cardDisabled}
+            cardInactive={cardInactive}
+            fullWidth={fullWidth}
+            hideCardDescription={hideCardDescription}
+            isFresh={isFresh}
+            onCardClick={onCardClick}
+          />
         );
       })}
     </div>
   );
-}
+});

--- a/src/components/game/card-shogi/mana-gauge.tsx
+++ b/src/components/game/card-shogi/mana-gauge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
@@ -21,7 +21,7 @@ interface DeltaSegment {
   kind: "plus" | "minus";
 }
 
-export function ManaGauge({ current, cap, compact = false, label }: ManaGaugeProps) {
+export const ManaGauge = memo(function ManaGauge({ current, cap, compact = false, label }: ManaGaugeProps) {
   const ratio = Math.min(1, current / cap);
   const canDraw = current >= DRAW_COST;
 
@@ -146,4 +146,4 @@ export function ManaGauge({ current, cap, compact = false, label }: ManaGaugePro
       {gaugeBar}
     </div>
   );
-}
+});

--- a/src/components/game/card-shogi/trap-slot.tsx
+++ b/src/components/game/card-shogi/trap-slot.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import type { CardInstance, TrapInstance } from "@/lib/shogi/cards/types";
 import { CardView } from "./card-view";
@@ -22,7 +23,7 @@ const SIZE_CLASS = {
   lg: "w-20 h-24 text-sm",
 };
 
-export function TrapSlot({
+export const TrapSlot = memo(function TrapSlot({
   trap,
   faceDown = false,
   size = "md",
@@ -127,4 +128,4 @@ export function TrapSlot({
       <span className="text-3xl">⚠</span>
     </div>
   );
-}
+});

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { forwardRef, useImperativeHandle, useRef } from "react";
+import { forwardRef, memo, useCallback, useImperativeHandle, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
 import { useTouchHandler } from "@/hooks/use-touch-handler";
-import type { Board, Move, Player, Position } from "@/lib/shogi/types";
+import type { Board, Move, Piece, Player, Position } from "@/lib/shogi/types";
 
 export interface ShogiBoardHandle {
   getSquareRect: (row: number, col: number) => DOMRect | null;
@@ -40,7 +40,147 @@ const RANK_LABELS_SENTE = ["一", "二", "三", "四", "五", "六", "七", "八
 const FILE_LABELS_GOTE = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 const RANK_LABELS_GOTE = ["九", "八", "七", "六", "五", "四", "三", "二", "一"];
 
-export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function ShogiBoard(
+// マスごとの ref 登録/解除を行う関数の型。親側で安定化して BoardSquare に渡す。
+type RegisterSquareRef = (row: number, col: number, el: HTMLDivElement | null) => void;
+
+interface BoardSquareProps {
+  rowIdx: number;
+  colIdx: number;
+  piece: Piece | null;
+  isSelected: boolean;
+  isLegalTarget: boolean;
+  isCardTarget: boolean;
+  isNoPromote: boolean;
+  isHidden: boolean;
+  isLastMoveSq: boolean;
+  isKingInCheck: boolean;
+  isStarPoint: boolean;
+  canHover: boolean;
+  squareSize: number;
+  dotSize: number;
+  playerColor: Player;
+  registerRef: RegisterSquareRef;
+}
+
+// 81 マスの 1 マス分。React.memo でラップし、変わっていないマスの再描画を skip する。
+// onClick 系は親 grid の pointerHandlers (useTouchHandler) で一括処理しているため、
+// BoardSquare 自身は受け取らない。
+const BoardSquare = memo(function BoardSquare({
+  rowIdx,
+  colIdx,
+  piece,
+  isSelected,
+  isLegalTarget,
+  isCardTarget,
+  isNoPromote,
+  isHidden,
+  isLastMoveSq,
+  isKingInCheck,
+  isStarPoint,
+  canHover,
+  squareSize,
+  dotSize,
+  playerColor,
+  registerRef,
+}: BoardSquareProps) {
+  // ref 登録は registerRef + (rowIdx, colIdx) で stabilize。BoardSquare が memo で
+  // 再描画 skip されると、ref callback の identity も変わらない。
+  const setRef = useCallback(
+    (el: HTMLDivElement | null) => registerRef(rowIdx, colIdx, el),
+    [rowIdx, colIdx, registerRef],
+  );
+
+  return (
+    <div
+      ref={setRef}
+      data-legal={isLegalTarget}
+      className={cn(
+        "shogi-square relative flex items-center justify-center",
+        "cursor-pointer",
+        // 通常背景
+        "bg-amber-50 dark:bg-amber-950",
+        // 直前の手（移動前・移動後）
+        isLastMoveSq && !isSelected && "bg-emerald-200 dark:bg-emerald-800/60",
+        // 王手中の王
+        isKingInCheck && "bg-red-300 dark:bg-red-800/70",
+        // 選択マス
+        isSelected && "bg-blue-200 dark:bg-blue-800/60",
+        // 合法手ハイライト
+        isLegalTarget && !piece && "bg-blue-200/70 dark:bg-blue-700/40",
+        isLegalTarget && piece && "bg-red-200/70 dark:bg-red-700/40",
+        // カード効果のターゲット候補(歩戻し等) - 既存の合法手ハイライトより優先
+        isCardTarget && "bg-amber-300/80 dark:bg-amber-500/40 ring-2 ring-inset ring-amber-500 dark:ring-amber-300 animate-pulse",
+        // プレイヤーのターンでない・AI思考中は操作不可
+        !canHover && !isCardTarget && "cursor-not-allowed",
+        // ホバー
+        canHover && "hover:bg-amber-100 dark:hover:bg-amber-800/50"
+      )}
+      style={{ width: squareSize, height: squareSize }}
+    >
+      {/* 星目（中央3×3四隅の交差点） */}
+      {isStarPoint && (
+        <div
+          className="absolute z-10 rounded-full bg-amber-900 dark:bg-amber-400 pointer-events-none"
+          style={{
+            width: Math.max(4, squareSize * 0.08),
+            height: Math.max(4, squareSize * 0.08),
+            bottom: 0,
+            right: 0,
+            transform: "translate(50%, 50%)",
+          }}
+        />
+      )}
+
+      {/* 合法手ドット（空きマス） */}
+      {isLegalTarget && !piece && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div
+            className="rounded-full bg-blue-500/50"
+            style={{ width: dotSize, height: dotSize }}
+          />
+        </div>
+      )}
+
+      {/* 駒 (Issue #82: hiddenSquares 指定時はフライト中につき非表示) */}
+      {piece && (
+        <div
+          className="absolute inset-0"
+          style={isHidden ? { opacity: 0, pointerEvents: "none" } : undefined}
+        >
+          <ShogiPiece
+            piece={piece}
+            isSelected={isSelected}
+            isInCheck={isKingInCheck}
+            playerColor={playerColor}
+            squareSize={squareSize}
+          />
+        </div>
+      )}
+
+      {/* no_promote 永続マーク (紫枠 + 🚫) */}
+      {isNoPromote && (
+        <div
+          className="absolute inset-0 pointer-events-none z-20 ring-2 ring-inset ring-purple-500 dark:ring-purple-300"
+          aria-label="成り不可"
+        >
+          <span
+            className="absolute leading-none select-none"
+            style={{
+              right: 1,
+              top: 1,
+              fontSize: Math.max(10, squareSize * 0.32),
+              filter: "drop-shadow(0 0 2px rgba(168,85,247,0.9))",
+            }}
+          >
+            🚫
+          </span>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(function ShogiBoard(
   {
     board,
     currentPlayer,
@@ -71,6 +211,15 @@ export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function
     }),
     [],
   );
+
+  // ref 登録/解除を BoardSquare に渡す。useCallback で stable 化することで
+  // BoardSquare の memo 比較を維持する (deps なし)。
+  const registerSquareRef = useCallback<RegisterSquareRef>((row, col, el) => {
+    const key = `${row}-${col}`;
+    if (el) squareRefs.current.set(key, el);
+    else squareRefs.current.delete(key);
+  }, []);
+
   const legalMoveSet = new Set(
     legalMoves.map((m) => `${m.to.row}-${m.to.col}`)
   );
@@ -93,14 +242,15 @@ export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function
     onSquareClick,
   });
 
-  const isLastMoveSquare = (row: number, col: number) => {
+  const isLastMoveSquare = (row: number, col: number): boolean => {
     if (!lastMove) return false;
     const matchTo = lastMove.to.row === row && lastMove.to.col === col;
-    const matchFrom = lastMove.from && lastMove.from.row === row && lastMove.from.col === col;
+    const matchFrom = !!lastMove.from && lastMove.from.row === row && lastMove.from.col === col;
     return matchTo || matchFrom;
   };
 
   const isPlayerTurn = currentPlayer === playerColor;
+  const canHover = isPlayerTurn && !isAiThinking;
 
   // 後手番時は行・列を逆順にして後手目線の盤面にする
   const rowIndices = isGote ? [8, 7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7, 8];
@@ -148,7 +298,6 @@ export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function
           {rowIndices.map((rowIdx, visualRow) =>
             colIndices.map((colIdx, visualCol) => {
               const piece = board[rowIdx][colIdx];
-              const pos = { row: rowIdx, col: colIdx };
               const isSelected =
                 selectedSquare?.row === rowIdx &&
                 selectedSquare?.col === colIdx;
@@ -166,97 +315,25 @@ export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function
                 (visualCol === 2 || visualCol === 5);
 
               return (
-                <div
+                <BoardSquare
                   key={`${rowIdx}-${colIdx}`}
-                  ref={(el) => {
-                    const key = `${rowIdx}-${colIdx}`;
-                    if (el) squareRefs.current.set(key, el);
-                    else squareRefs.current.delete(key);
-                  }}
-                  data-legal={isLegalTarget}
-                  className={cn(
-                    "shogi-square relative flex items-center justify-center",
-                    "cursor-pointer",
-                    // 通常背景
-                    "bg-amber-50 dark:bg-amber-950",
-                    // 直前の手（移動前・移動後）
-                    isLastMoveSq && !isSelected && "bg-emerald-200 dark:bg-emerald-800/60",
-                    // 王手中の王
-                    isKingInCheck && "bg-red-300 dark:bg-red-800/70",
-                    // 選択マス
-                    isSelected && "bg-blue-200 dark:bg-blue-800/60",
-                    // 合法手ハイライト
-                    isLegalTarget && !piece && "bg-blue-200/70 dark:bg-blue-700/40",
-                    isLegalTarget && piece && "bg-red-200/70 dark:bg-red-700/40",
-                    // カード効果のターゲット候補(歩戻し等) - 既存の合法手ハイライトより優先
-                    isCardTarget && "bg-amber-300/80 dark:bg-amber-500/40 ring-2 ring-inset ring-amber-500 dark:ring-amber-300 animate-pulse",
-                    // プレイヤーのターンでない・AI思考中は操作不可
-                    (!isPlayerTurn || isAiThinking) && !isCardTarget && "cursor-not-allowed",
-                    // ホバー
-                    isPlayerTurn && !isAiThinking && "hover:bg-amber-100 dark:hover:bg-amber-800/50"
-                  )}
-                  style={{ width: squareSize, height: squareSize }}
-                >
-                  {/* 星目（中央3×3四隅の交差点） */}
-                  {isStarPoint && (
-                    <div
-                      className="absolute z-10 rounded-full bg-amber-900 dark:bg-amber-400 pointer-events-none"
-                      style={{
-                        width: Math.max(4, squareSize * 0.08),
-                        height: Math.max(4, squareSize * 0.08),
-                        bottom: 0,
-                        right: 0,
-                        transform: "translate(50%, 50%)",
-                      }}
-                    />
-                  )}
-
-                  {/* 合法手ドット（空きマス） */}
-                  {isLegalTarget && !piece && (
-                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                      <div
-                        className="rounded-full bg-blue-500/50"
-                        style={{ width: dotSize, height: dotSize }}
-                      />
-                    </div>
-                  )}
-
-                  {/* 駒 (Issue #82: hiddenSquares 指定時はフライト中につき非表示) */}
-                  {piece && (
-                    <div
-                      className="absolute inset-0"
-                      style={isHidden ? { opacity: 0, pointerEvents: "none" } : undefined}
-                    >
-                      <ShogiPiece
-                        piece={piece}
-                        isSelected={isSelected}
-                        isInCheck={isKingInCheck}
-                        playerColor={playerColor}
-                        squareSize={squareSize}
-                      />
-                    </div>
-                  )}
-
-                  {/* no_promote 永続マーク (紫枠 + 🚫) */}
-                  {isNoPromote && (
-                    <div
-                      className="absolute inset-0 pointer-events-none z-20 ring-2 ring-inset ring-purple-500 dark:ring-purple-300"
-                      aria-label="成り不可"
-                    >
-                      <span
-                        className="absolute leading-none select-none"
-                        style={{
-                          right: 1,
-                          top: 1,
-                          fontSize: Math.max(10, squareSize * 0.32),
-                          filter: "drop-shadow(0 0 2px rgba(168,85,247,0.9))",
-                        }}
-                      >
-                        🚫
-                      </span>
-                    </div>
-                  )}
-                </div>
+                  rowIdx={rowIdx}
+                  colIdx={colIdx}
+                  piece={piece}
+                  isSelected={isSelected}
+                  isLegalTarget={isLegalTarget}
+                  isCardTarget={isCardTarget}
+                  isNoPromote={isNoPromote}
+                  isHidden={isHidden}
+                  isLastMoveSq={isLastMoveSq}
+                  isKingInCheck={isKingInCheck}
+                  isStarPoint={isStarPoint}
+                  canHover={canHover}
+                  squareSize={squareSize}
+                  dotSize={dotSize}
+                  playerColor={playerColor}
+                  registerRef={registerSquareRef}
+                />
               );
             })
           )}
@@ -277,4 +354,4 @@ export const ShogiBoard = forwardRef<ShogiBoardHandle, ShogiBoardProps>(function
       </div>
     </div>
   );
-});
+}));

--- a/src/components/game/shogi-piece.tsx
+++ b/src/components/game/shogi-piece.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import { PIECE_DEF_MAP } from "@/lib/shogi/variants/standard";
 import type { Piece, Player } from "@/lib/shogi/types";
@@ -67,7 +68,7 @@ function getPieceSizeRatio(type: string): number {
   return 1.0;
 }
 
-export function ShogiPiece({
+export const ShogiPiece = memo(function ShogiPiece({
   piece,
   isSelected = false,
   isSmall = false,
@@ -150,4 +151,4 @@ export function ShogiPiece({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
Issue #107 (カード将棋 全体リファクタ＆アセット先読み) の **Step 2**。親 useReducer の任意の state 変化で 81 マス・手札全枚・各駒が無条件に再描画される現状を断ち、**モバイル CPU 常時負荷の主要因を解消** する。

### 変更
1. **子 leaf 7 個を \`React.memo\`** でラップ ([shogi-piece.tsx](src/components/game/shogi-piece.tsx) / [card-view.tsx](src/components/game/card-shogi/card-view.tsx) / [captured-pieces.tsx](src/components/game/captured-pieces.tsx) / [deck-pile.tsx](src/components/game/card-shogi/deck-pile.tsx) / [trap-slot.tsx](src/components/game/card-shogi/trap-slot.tsx) / [mana-gauge.tsx](src/components/game/card-shogi/mana-gauge.tsx) / [card-shogi-history.tsx](src/components/game/card-shogi/card-shogi-history.tsx))。custom 比較は使わず default の浅い比較のみ
2. **\`BoardSquare\` を [shogi-board.tsx](src/components/game/shogi-board.tsx) から切り出し memo 化**。\`registerSquareRef\` (useCallback) 経由で ref 登録を安定化、\`data-legal\` 属性 + \`squareRefs\` Map (row-col キー) は維持。1 マス分の props は primitive のみ
3. **\`HandCard\` を [hand-area.tsx](src/components/game/card-shogi/hand-area.tsx) から切り出し memo 化**。内部 useCallback で onClick の instanceId バインディングを安定化 (CardView の onClick API は触らない)
4. **親 ([card-shogi-game.tsx](src/components/game/card-shogi/card-shogi-game.tsx)) で props 安定化**: inline \`() => {}\` を NOOP 定数化、\`hiddenBoardSquares\` / \`hiddenOwnCapturedTypes\` を useMemo + 空配列共有参照 (\`EMPTY_POSITIONS\` / \`EMPTY_STRINGS\`)

### 期待効果
1 手指したときの ShogiPiece 再描画が **動いた駒 + 直前の駒の 2 個程度** に収束 (従来 81 マス全て)。手札のマナ/使用条件変化があった枚のみ再描画 (従来は全枚)。**モバイルラグ★★★** の主要因解消。

### ユーザー影響
**なし** (純粋な再描画最適化、振る舞い不変)。

## Test plan
- [x] \`pnpm test:ci\` 63/63 PASS
- [x] \`pnpm lint\` 13 errors / 21 warnings (Step 1 ベースラインから 1 warning 減、新規追加なし)
- [x] \`pnpm build\` 成功
- [x] Vercel preview で対局フロー全体動作確認 (歩戻し / 駒戻し / 二歩指し の駒フライト正常、UNDO / 投了 / 王手回避ガード) — ユーザー verified
- [x] flushSync × \`setPieceFlight\` の rect 取得が新 BoardSquare 構造で正常動作 — ユーザー verified

Issue #107 (Step 2)