### PR TITLE
chore: 破壊的操作の auto-deny を解消し AGENTS.md ルール 5 のみで制御 (Issue #139)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,9 +55,7 @@
       "Bash(gh pr create:*)",
       "Bash(gh api:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh pr merge:*)"
-    ],
-    "deny": [
+      "Bash(gh pr merge:*)",
       "Bash(rm -rf:*)",
       "Bash(rm -fr:*)",
       "Bash(git push --force:*)",
@@ -67,7 +65,9 @@
       "Bash(git clean -f:*)",
       "Bash(git clean -fd:*)",
       "Bash(git branch -D:*)",
-      "Bash(git branch --delete --force:*)",
+      "Bash(git branch --delete --force:*)"
+    ],
+    "deny": [
       "Bash(git push origin main:*)",
       "Bash(git push origin master:*)",
       "Bash(gh issue close:*)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,8 @@ Issue対応は必ず専用ブランチを作成してから実装を開始する
 - 操作内容と影響範囲を明示してから確認を求める
 - ユーザー指示で明示的に許可された範囲のみ実行する
 - Claude Code の自動承認/拒否ルールは `.claude/settings.json` に集約されている。変更する際は本ファイルのルール追加・更新フローに従い、Issueを立ててPRで反映する
+- **「破壊的操作」カテゴリ (`rm -rf`、`git branch -D`、`git reset --hard`、`git push --force` 等) は `.claude/settings.json` で auto-deny を外し allow に置いている。これは「ユーザー明示指示があれば実行可」を意図した設計であり、AI 側の本ルール 5 (= 必ずユーザーに確認してから実行) が唯一の安全網となる。明示指示なしの実行は本ルール違反として扱う**
+- 一方、「公開・共有状態への影響」カテゴリ (`git push origin main`、`gh issue close`、`gh pr close`) は引き続き auto-deny を維持する (ルール 1・2 と二重化された安全網)
 
 ### 6. Vercelデプロイ確認のため専用ブランチはpushまで行う
 


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の `permissions.deny` から「破壊的操作カテゴリ」(AGENTS.md ルール 5 該当) を `allow` に移動
- 「公開・共有状態への影響」カテゴリ (`git push origin main`、`gh issue close`、`gh pr close` 等、ルール 1・2 該当) は引き続き `deny` に維持
- AGENTS.md ルール 5 の How to apply に、auto-deny 緩和後の運用方針を明記 (= AI 行動規範のみで制御、明示指示なし実行は本ルール違反として扱う)

## 背景

Issue #130 完了後、ユーザーが「ローカル `feature/#130` ブランチを削除して」と明示指示したが、settings.json の deny で auto-deny が作動し実行不可となるケースが発生。同種の安全網が AGENTS.md ルール 5 と settings.json deny で二重化されており、明示指示時の正当な実行までブロックされていた。

## 移動内容

### deny → allow (破壊的操作カテゴリ)

- `Bash(rm -rf:*)` / `Bash(rm -fr:*)`
- `Bash(git push --force:*)` / `Bash(git push -f:*)` / `Bash(git push --force-with-lease:*)`
- `Bash(git reset --hard:*)`
- `Bash(git clean -f:*)` / `Bash(git clean -fd:*)`
- `Bash(git branch -D:*)` / `Bash(git branch --delete --force:*)`

### deny に維持 (公開・共有状態カテゴリ)

- `Bash(git push origin main:*)` / `Bash(git push origin master:*)`
- `Bash(gh issue close:*)` / `Bash(gh pr close:*)`

## Test plan

- [x] `jq -e '.permissions.allow | index("Bash(git branch -D:*)")'` で allow 移動を確認
- [x] `jq '.permissions.deny | length'` が 4 (公開・共有 4 件のみ) であることを確認
- [ ] マージ後 Claude Code を再起動 or `/hooks` でリロードし、`git branch -D <branch>` がユーザー明示指示後に実行可能になることを確認
- [ ] `gh issue close` / `gh pr close` / `git push origin main` は引き続き auto-deny されることを確認

## 関連

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)