### PR TITLE
カード将棋の精密配置基盤を整備

### DIFF
--- a/docs/card-shogi-layout.md
+++ b/docs/card-shogi-layout.md
@@ -81,6 +81,7 @@ CARD_SHOGI_LAYOUT_BASE_URL=http://localhost:3000 pnpm test:layout:card-shogi
 - 主要 UI (`data-card-shogi-*`) が viewport 外へ出ていない
 - 盤面が上端カードエリア / 下端操作エリアと重ならない
 - `progress4` の進捗リングが山札 button の外縁と 1px 以内で一致する
+- browser exception / console error が発生していない
 
 ## 精密配置原則
 

--- a/docs/card-shogi-layout.md
+++ b/docs/card-shogi-layout.md
@@ -90,6 +90,7 @@ CARD_SHOGI_LAYOUT_BASE_URL=http://localhost:3000 pnpm test:layout:card-shogi
 - 「サイズが小さいほど顕著」「特定 viewport でだけ目立つ」ズレは、% 比率差や座標系の目盛り差を疑う。
 - 微調整を繰り返しても直らない場合は、座標系・スケーリング・基準点を見直す。
 - モバイル下端 UI など、safe area の影響を受ける要素は固定 px 前提にせず、表示中 DOM の実測値を CSS variable に反映する。
+- 盤マスは横幅基準値から `height = round(width * 1.08)` で縦長にし、盤面描画・タップ判定・layout metrics は同じ `board-layout` helper を参照する。
 
 ## SVG / CSS 棚卸し結果
 

--- a/docs/card-shogi-layout.md
+++ b/docs/card-shogi-layout.md
@@ -1,0 +1,101 @@
+# カード将棋 UI/UX 精密配置基盤
+
+Issue #134 の配置・検証基準。iPhone17e は所有実機で確認できる代表端末として扱うが、設計は特定端末に固定しない。viewport 実寸、DPR、safe area、DOM 実測を基準に、iPhone 15/16/17 系、Android 小型〜大型端末、PC 代表解像度で破綻しないことを目標にする。
+
+## Viewport Matrix
+
+| 種別 | Viewport | DPR | 用途 |
+|---|---:|---:|---|
+| mobile | 320x568 | 2 | 最小幅・低縦幅の下限確認 |
+| mobile | 360x640 | 3 | Android 小型相当 |
+| mobile | 360x740 | 3 | Android 標準縦長 |
+| mobile | 375x812 | 3 | iPhone 標準幅 |
+| mobile | 390x844 | 3 | iPhone 15/16 系代表 |
+| mobile | 393x852 | 3 | Android / iPhone 近似代表 |
+| mobile | 414x896 | 3 | 大きめ iPhone |
+| mobile | 430x932 | 3 | 大型 iPhone / Android |
+| desktop | 1280x800 | 1 | 小型ノート |
+| desktop | 1366x768 | 1 | 低縦幅 PC |
+| desktop | 1440x900 | 1 | 標準デスクトップ |
+| desktop | 1920x1080 | 1 | 大型デスクトップ |
+
+headless Chrome では mobile viewport に `mobile: true` と DPR を設定する。実機と完全一致するものではないため、safe area とブラウザ UI 差は下記の実機測定で補完する。
+
+## iPhone17e / 実機測定欄
+
+実測値は推測で埋めない。`/dev/card-shogi-layout?scenario=progress4` を実機で開き、Safari / Chrome / PWA それぞれ必要に応じて DevTools console で以下を記録する。
+
+```js
+JSON.stringify({
+  innerWidth: window.innerWidth,
+  innerHeight: window.innerHeight,
+  devicePixelRatio: window.devicePixelRatio,
+  visualViewport: window.visualViewport && {
+    width: window.visualViewport.width,
+    height: window.visualViewport.height,
+    offsetTop: window.visualViewport.offsetTop,
+    offsetLeft: window.visualViewport.offsetLeft,
+    scale: window.visualViewport.scale,
+  },
+  scrollWidth: document.documentElement.scrollWidth,
+  scrollHeight: document.documentElement.scrollHeight,
+  safeAreaProbe: {
+    note: "safe-area は CSS env のため、必要なら一時 probe 要素で computed style を測る",
+  },
+}, null, 2)
+```
+
+| 端末 | 表示形態 | innerWidth | innerHeight | DPR | visualViewport | safe area / 備考 |
+|---|---|---:|---:|---:|---|---|
+| iPhone17e | Safari | 未測定 | 未測定 | 未測定 | 未測定 | 実機確認後に追記 |
+| iPhone17e | Chrome | 未測定 | 未測定 | 未測定 | 未測定 | 実機確認後に追記 |
+| iPhone17e | PWA | 未測定 | 未測定 | 未測定 | 未測定 | 実機確認後に追記 |
+| その他 iPhone | Safari / Chrome | 未測定 | 未測定 | 未測定 | 未測定 | 必要に応じて追記 |
+| Android | Chrome | 未測定 | 未測定 | 未測定 | 未測定 | 必要に応じて追記 |
+
+## 検証状態
+
+`/dev/card-shogi-layout` は DB に触らない fixture でカード将棋画面を表示する。
+
+| scenario | 内容 |
+|---|---|
+| `initial` | 初期状態 |
+| `progress1` | 自動ドロー進捗 1/5 |
+| `progress4` | 自動ドロー進捗 4/5 |
+| `many-hands` | 自分 / 相手の手札が多い状態 |
+| `captured` | 持ち駒あり |
+| `trap` | トラップあり |
+| `drawer` | モバイル手札ドロワー開 |
+| `end` | 終局カード表示 |
+
+機械監査は dev server 起動後に実行する。
+
+```bash
+pnpm dev
+CARD_SHOGI_LAYOUT_BASE_URL=http://localhost:3000 pnpm test:layout:card-shogi
+```
+
+チェック内容:
+
+- `document.documentElement.scrollWidth <= window.innerWidth`
+- 主要 UI (`data-card-shogi-*`) が viewport 外へ出ていない
+- 盤面が上端カードエリア / 下端操作エリアと重ならない
+- `progress4` の進捗リングが山札 button の外縁と 1px 以内で一致する
+
+## 精密配置原則
+
+- スケーラブル座標系 (`viewBox` / `%`) と固定ピクセル量 (`non-scaling-stroke` / px border) を 1 要素内で混在させない。
+- DOM に重ねる装飾は、対象要素の実 px を `getBoundingClientRect` / `ResizeObserver` で測ってから描画する。
+- 「サイズが小さいほど顕著」「特定 viewport でだけ目立つ」ズレは、% 比率差や座標系の目盛り差を疑う。
+- 微調整を繰り返しても直らない場合は、座標系・スケーリング・基準点を見直す。
+- モバイル下端 UI など、safe area の影響を受ける要素は固定 px 前提にせず、表示中 DOM の実測値を CSS variable に反映する。
+
+## SVG / CSS 棚卸し結果
+
+| 対象 | 状態 | 対応 |
+|---|---|---|
+| 山札自動ドローリング | #130 で是正済み | button 実 px を SVG viewBox に反映 |
+| 王手崩し ghost slash | #134 で是正 | ghost rect 実 px を SVG viewBox に反映し、`non-scaling-stroke` を撤去 |
+| ShogiPiece 五角形 | 保留 | viewBox マージンで stroke 外縁を吸収。DOM 境界に重ねる装飾ではないため今回の是正対象外 |
+| CardBack 内側枠 / 四隅装飾 | 保留 | card 内部装飾で外縁整合には直結しない。将来カード裏面調整時に共通 size token 化を検討 |
+| 盤面 hint / no_promote ring | 保留 | CSS `ring-inset` で DOM box 内に収まる。機械監査で横見切れ・重なりを監視 |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "test": "vitest",
     "test:ci": "vitest run",
+    "test:layout:card-shogi": "node scripts/card-shogi-layout-audit.mjs",
     "db:seed": "npx tsx prisma/seed.ts",
     "db:push": "prisma db push",
     "db:generate": "prisma generate"

--- a/scripts/card-shogi-layout-audit.mjs
+++ b/scripts/card-shogi-layout-audit.mjs
@@ -214,6 +214,7 @@ function auditInPage({ scenario }) {
     ["root", "[data-card-shogi-root]"],
     ["play area", "[data-card-shogi-play-area]"],
     ["board", "[data-card-shogi-board]"],
+    ["board grid", "[data-shogi-board-grid]"],
     ["bottom controls", "[data-card-shogi-bottom-controls]"],
     ["opponent area", "[data-card-shogi-opponent-area]"],
     ["deck", "[data-card-shogi-deck]"],

--- a/scripts/card-shogi-layout-audit.mjs
+++ b/scripts/card-shogi-layout-audit.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+const BASE_URL = process.env.CARD_SHOGI_LAYOUT_BASE_URL ?? "http://localhost:3000";
+const SCENARIOS = ["initial", "progress1", "progress4", "many-hands", "captured", "trap", "drawer", "end"];
+const VIEWPORTS = [
+  { name: "mobile-320x568", width: 320, height: 568, deviceScaleFactor: 2, mobile: true },
+  { name: "mobile-360x640", width: 360, height: 640, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-360x740", width: 360, height: 740, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-375x812", width: 375, height: 812, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-390x844", width: 390, height: 844, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-393x852", width: 393, height: 852, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-414x896", width: 414, height: 896, deviceScaleFactor: 3, mobile: true },
+  { name: "mobile-430x932", width: 430, height: 932, deviceScaleFactor: 3, mobile: true },
+  { name: "desktop-1280x800", width: 1280, height: 800, deviceScaleFactor: 1, mobile: false },
+  { name: "desktop-1366x768", width: 1366, height: 768, deviceScaleFactor: 1, mobile: false },
+  { name: "desktop-1440x900", width: 1440, height: 900, deviceScaleFactor: 1, mobile: false },
+  { name: "desktop-1920x1080", width: 1920, height: 1080, deviceScaleFactor: 1, mobile: false },
+];
+
+if (typeof WebSocket === "undefined") {
+  console.error("This audit requires a Node.js runtime with global WebSocket support.");
+  process.exit(1);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForJson(url, timeoutMs = 10_000, init = undefined) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(url, init);
+      if (res.ok) return res.json();
+      lastError = new Error(`${res.status} ${res.statusText}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(100);
+  }
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+class CdpPage {
+  constructor(wsUrl) {
+    this.ws = new WebSocket(wsUrl);
+    this.nextId = 1;
+    this.pending = new Map();
+    this.events = new Map();
+    this.ready = new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", reject, { once: true });
+    });
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (message.id && this.pending.has(message.id)) {
+        const { resolve, reject } = this.pending.get(message.id);
+        this.pending.delete(message.id);
+        if (message.error) reject(new Error(message.error.message));
+        else resolve(message.result);
+        return;
+      }
+      if (message.method && this.events.has(message.method)) {
+        for (const resolve of this.events.get(message.method)) resolve(message.params);
+        this.events.delete(message.method);
+      }
+    });
+  }
+
+  async send(method, params = {}) {
+    await this.ready;
+    const id = this.nextId++;
+    this.ws.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+  }
+
+  waitFor(method, timeoutMs = 10_000) {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${method}`)), timeoutMs);
+      const wrapped = (params) => {
+        clearTimeout(timeout);
+        resolve(params);
+      };
+      const listeners = this.events.get(method) ?? [];
+      listeners.push(wrapped);
+      this.events.set(method, listeners);
+    });
+  }
+
+  close() {
+    this.ws.close();
+  }
+}
+
+async function createPage(port) {
+  const target = await waitForJson(`http://127.0.0.1:${port}/json/new?about:blank`, 10_000, { method: "PUT" });
+  const page = new CdpPage(target.webSocketDebuggerUrl);
+  await page.send("Page.enable");
+  await page.send("Runtime.enable");
+  return page;
+}
+
+async function runAudit(page, viewport, scenario) {
+  await page.send("Emulation.setDeviceMetricsOverride", {
+    width: viewport.width,
+    height: viewport.height,
+    deviceScaleFactor: viewport.deviceScaleFactor,
+    mobile: viewport.mobile,
+  });
+  const url = `${BASE_URL}/dev/card-shogi-layout?scenario=${scenario}`;
+  const load = page.waitFor("Page.loadEventFired");
+  await page.send("Page.navigate", { url });
+  await load;
+  await waitForLayoutReady(page);
+  const { result } = await page.send("Runtime.evaluate", {
+    returnByValue: true,
+    expression: `(${auditInPage.toString()})(${JSON.stringify({ scenario })})`,
+  });
+  return result.value;
+}
+
+async function waitForLayoutReady(page, timeoutMs = 8_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const { result } = await page.send("Runtime.evaluate", {
+      returnByValue: true,
+      expression: `Boolean(document.querySelector("[data-card-shogi-root][data-card-shogi-layout-mode]"))`,
+    });
+    if (result.value) {
+      await sleep(100);
+      return;
+    }
+    await sleep(100);
+  }
+  throw new Error("Timed out waiting for card-shogi layout measurement");
+}
+
+function auditInPage({ scenario }) {
+  const tolerance = 1.25;
+  const failures = [];
+  const rectOf = (el) => {
+    const r = el.getBoundingClientRect();
+    return { left: r.left, top: r.top, right: r.right, bottom: r.bottom, width: r.width, height: r.height };
+  };
+  const isVisible = (el) => {
+    const r = el.getBoundingClientRect();
+    const s = getComputedStyle(el);
+    return el.isConnected && r.width > 0 && r.height > 0 && s.display !== "none" && s.visibility !== "hidden";
+  };
+  const all = (selector) => Array.from(document.querySelectorAll(selector)).filter(isVisible);
+  const first = (selector) => all(selector)[0] ?? null;
+  const withinViewport = (name, el) => {
+    const r = rectOf(el);
+    if (r.left < -tolerance || r.right > window.innerWidth + tolerance) {
+      failures.push(`${name} horizontally outside viewport: ${JSON.stringify(r)}`);
+    }
+    if (r.top < -tolerance || r.bottom > window.innerHeight + tolerance) {
+      failures.push(`${name} vertically outside viewport: ${JSON.stringify(r)}`);
+    }
+  };
+  const intersects = (a, b) =>
+    a.left < b.right - tolerance &&
+    a.right > b.left + tolerance &&
+    a.top < b.bottom - tolerance &&
+    a.bottom > b.top + tolerance;
+
+  const root = first("[data-card-shogi-root]");
+  const board = first("[data-card-shogi-board]");
+  const bottom = first("[data-card-shogi-bottom-controls]");
+  const opponent = first("[data-card-shogi-opponent-area]");
+  const playArea = first("[data-card-shogi-play-area]");
+  if (!root) failures.push("missing root");
+  if (!board) failures.push("missing board");
+  if (!playArea) failures.push("missing play area");
+
+  if (document.documentElement.scrollWidth > window.innerWidth + tolerance) {
+    failures.push(`document horizontal scroll: ${document.documentElement.scrollWidth} > ${window.innerWidth}`);
+  }
+  for (const [name, selector] of [
+    ["root", "[data-card-shogi-root]"],
+    ["play area", "[data-card-shogi-play-area]"],
+    ["board", "[data-card-shogi-board]"],
+    ["bottom controls", "[data-card-shogi-bottom-controls]"],
+    ["opponent area", "[data-card-shogi-opponent-area]"],
+    ["deck", "[data-card-shogi-deck]"],
+    ["trap", "[data-card-shogi-trap]"],
+  ]) {
+    for (const el of all(selector)) withinViewport(name, el);
+  }
+
+  if (board && bottom && intersects(rectOf(board), rectOf(bottom))) {
+    failures.push("board overlaps bottom controls");
+  }
+  if (board && opponent && intersects(rectOf(board), rectOf(opponent))) {
+    failures.push("board overlaps opponent area");
+  }
+
+  if (scenario === "progress4") {
+    for (const svg of all("svg[role='progressbar']")) {
+      const button = svg.closest("button");
+      if (!button) continue;
+      const sr = rectOf(svg);
+      const br = rectOf(button);
+      const delta = Math.max(
+        Math.abs(sr.left - br.left),
+        Math.abs(sr.top - br.top),
+        Math.abs(sr.right - br.right),
+        Math.abs(sr.bottom - br.bottom),
+      );
+      if (delta > tolerance) {
+        failures.push(`progress ring differs from deck button by ${delta.toFixed(2)}px`);
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    metrics: {
+      scenario,
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      dpr: window.devicePixelRatio,
+      squareSize: root?.getAttribute("data-card-shogi-square-size") ?? null,
+      layoutMode: root?.getAttribute("data-card-shogi-layout-mode") ?? null,
+      scrollWidth: document.documentElement.scrollWidth,
+    },
+  };
+}
+
+async function main() {
+  const port = 9400 + Math.floor(Math.random() * 1000);
+  const userDataDir = await mkdtemp(join(tmpdir(), "card-shogi-layout-audit-"));
+  const chrome = spawn("google-chrome", [
+    "--headless=new",
+    "--disable-gpu",
+    "--no-sandbox",
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    "about:blank",
+  ], { stdio: "ignore" });
+
+  try {
+    await waitForJson(`http://127.0.0.1:${port}/json/version`);
+    const page = await createPage(port);
+    const failures = [];
+    for (const viewport of VIEWPORTS) {
+      for (const scenario of SCENARIOS) {
+        const result = await runAudit(page, viewport, scenario);
+        if (!result.ok) {
+          failures.push({ viewport: viewport.name, scenario, failures: result.failures, metrics: result.metrics });
+        }
+        console.log(`${result.ok ? "PASS" : "FAIL"} ${viewport.name} ${scenario} square=${result.metrics.squareSize ?? "?"}`);
+      }
+    }
+    page.close();
+    if (failures.length > 0) {
+      console.error(JSON.stringify(failures, null, 2));
+      process.exitCode = 1;
+    }
+  } finally {
+    chrome.kill("SIGTERM");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/card-shogi-layout-audit.mjs
+++ b/scripts/card-shogi-layout-audit.mjs
@@ -52,6 +52,7 @@ class CdpPage {
     this.nextId = 1;
     this.pending = new Map();
     this.events = new Map();
+    this.diagnostics = [];
     this.ready = new Promise((resolve, reject) => {
       this.ws.addEventListener("open", resolve, { once: true });
       this.ws.addEventListener("error", reject, { once: true });
@@ -64,6 +65,17 @@ class CdpPage {
         if (message.error) reject(new Error(message.error.message));
         else resolve(message.result);
         return;
+      }
+      if (message.method === "Runtime.exceptionThrown") {
+        const details = message.params?.exceptionDetails;
+        this.diagnostics.push(`browser exception: ${details?.exception?.description ?? details?.text ?? "unknown"}`);
+      }
+      if (message.method === "Runtime.consoleAPICalled" && message.params?.type === "error") {
+        const text = (message.params.args ?? [])
+          .map((arg) => arg.value ?? arg.description ?? arg.unserializableValue ?? "")
+          .filter(Boolean)
+          .join(" ");
+        this.diagnostics.push(`browser console error: ${text || "unknown"}`);
       }
       if (message.method && this.events.has(message.method)) {
         for (const resolve of this.events.get(message.method)) resolve(message.params);
@@ -97,6 +109,14 @@ class CdpPage {
   close() {
     this.ws.close();
   }
+
+  clearDiagnostics() {
+    this.diagnostics = [];
+  }
+
+  getDiagnostics() {
+    return [...this.diagnostics];
+  }
 }
 
 async function createPage(port) {
@@ -108,6 +128,7 @@ async function createPage(port) {
 }
 
 async function runAudit(page, viewport, scenario) {
+  page.clearDiagnostics();
   await page.send("Emulation.setDeviceMetricsOverride", {
     width: viewport.width,
     height: viewport.height,
@@ -123,7 +144,13 @@ async function runAudit(page, viewport, scenario) {
     returnByValue: true,
     expression: `(${auditInPage.toString()})(${JSON.stringify({ scenario })})`,
   });
-  return result.value;
+  const value = result.value;
+  const diagnostics = page.getDiagnostics();
+  if (diagnostics.length > 0) {
+    value.ok = false;
+    value.failures.push(...diagnostics);
+  }
+  return value;
 }
 
 async function waitForLayoutReady(page, timeoutMs = 8_000) {

--- a/src/app/dev/card-shogi-layout/page.tsx
+++ b/src/app/dev/card-shogi-layout/page.tsx
@@ -1,0 +1,35 @@
+import { CardShogiGame } from "@/components/game/card-shogi/card-shogi-game";
+import {
+  getCardShogiLayoutFixture,
+  normalizeCardShogiLayoutScenario,
+} from "@/lib/dev/card-shogi-layout-fixtures";
+
+interface CardShogiLayoutDevPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function CardShogiLayoutDevPage({ searchParams }: CardShogiLayoutDevPageProps) {
+  const params = await searchParams;
+  const scenario = normalizeCardShogiLayoutScenario(
+    Array.isArray(params.scenario) ? params.scenario[0] : params.scenario,
+  );
+  const fixture = getCardShogiLayoutFixture(scenario);
+
+  return (
+    <CardShogiGame
+      initialGameState={fixture.gameState}
+      initialCardState={fixture.cardState}
+      gameId={`dev-card-shogi-layout-${scenario}`}
+      gameConfig={{
+        variantId: "card-shogi",
+        difficulty: "beginner",
+        playerColor: "sente",
+        characterId: "sakura",
+        soundEnabled: false,
+        commentaryEnabled: false,
+      }}
+      debugInitialUi={fixture.debugInitialUi}
+      debugDisableServerEffects
+    />
+  );
+}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type CSSProperties } from "react";
 import { flushSync, createPortal } from "react-dom";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -72,6 +72,11 @@ interface CardShogiGameProps {
   initialCardState: CardGameState;
   gameId: string;
   gameConfig: SerializableGameConfig;
+  debugInitialUi?: {
+    drawerOpen?: boolean;
+    endCardMinimized?: boolean;
+  };
+  debugDisableServerEffects?: boolean;
 }
 
 function shouldPlayJumpSfx(move: Move): boolean {
@@ -97,14 +102,16 @@ export function CardShogiGame({
   initialCardState,
   gameId,
   gameConfig: serializableConfig,
+  debugInitialUi,
+  debugDisableServerEffects = false,
 }: CardShogiGameProps) {
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(() => Boolean(debugInitialUi?.drawerOpen));
   // Step S4 (Issue #107): モバイル/タブレットの終了カードを最小化できるように
   // する。閉じると盤面・持ち駒が見え、再度展開して「もう一局」「ホームへ」を
   // 押せる。
-  const [endCardMinimized, setEndCardMinimized] = useState(false);
+  const [endCardMinimized, setEndCardMinimized] = useState(() => Boolean(debugInitialUi?.endCardMinimized));
   // Issue #78 + #130: ドロー演出キュー (FIFO)。
   // 旧実装は単一スロット (drawFlight) で manual 直後に auto-draw が発火すると
   // setDrawFlight が上書きされ manual 演出が中断されるバグがあった (#130)。
@@ -228,7 +235,15 @@ export function CardShogiGame({
   const [forbiddenMateDialogOpen, setForbiddenMateDialogOpen] = useState(false);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const { squareSize, isMobile, viewportHeight } = useCardBoardSize();
+  const {
+    squareSize,
+    isMobile,
+    viewportHeight,
+    playAreaRef,
+    bottomControlsRef,
+    bottomControlsHeight,
+    debug: layoutDebug,
+  } = useCardBoardSize();
   // 開発者用 dev /piece-flight で保存されたフライト演出パラメータ。
   // 未保存時は animation-constants の既定値が返る。
   const flightParams = useFlightParams();
@@ -295,6 +310,8 @@ export function CardShogiGame({
     gameId,
     gameConfig,
     onComment: handleComment,
+    disableServerSync: debugDisableServerEffects,
+    disableAi: debugDisableServerEffects,
   });
 
   const playerColor = gameConfig.playerColor;
@@ -1178,15 +1195,23 @@ export function CardShogiGame({
 
   return (
     <div
+      data-card-shogi-root
+      data-card-shogi-layout-mode={layoutDebug?.mode}
+      data-card-shogi-square-size={squareSize}
       className="shogi-game-area w-full overflow-hidden flex flex-col"
-      style={{ height: viewportHeight }}
+      style={{
+        height: viewportHeight,
+        "--card-shogi-bottom-controls-height": `${bottomControlsHeight}px`,
+        "--card-shogi-square-size": `${squareSize}px`,
+      } as CSSProperties}
       onClick={handleDeselect}
     >
       {/* モバイル: ステータスバーを画面最上段に配置 (Issue #105) */}
-      <div className="md:hidden shrink-0 bg-card border-b">{statusBarContent}</div>
+      <div data-card-shogi-status className="md:hidden shrink-0 bg-card border-b">{statusBarContent}</div>
       {/* ===== 相手ゾーン ===== */}
       {/* PC タブレット相当 (md..xl-1): 詳細ゾーン */}
       <section
+        data-card-shogi-opponent-area
         className="hidden md:flex xl:hidden shrink-0 px-2 py-1.5 border-b bg-muted/40 items-center gap-2 overflow-x-auto"
         onClick={(e) => e.stopPropagation()}
       >
@@ -1200,6 +1225,7 @@ export function CardShogiGame({
         * 左: △ ラベル + マナゲージ (縦積み)
         * 右: 手札 stack (max 10) + 山札 + トラップ (sm カードデザインで横幅統一) */}
       <section
+        data-card-shogi-opponent-area
         className="md:hidden shrink-0 px-2 py-1 border-b bg-muted/40 flex items-end gap-2 text-xs"
         onClick={(e) => e.stopPropagation()}
       >
@@ -1218,7 +1244,7 @@ export function CardShogiGame({
               layout="stack"
               size="sm"
               emptyLabel=""
-              stackMaxVisible={10}
+              stackMaxVisible={5}
             />
           </div>
           <DeckPile
@@ -1233,12 +1259,16 @@ export function CardShogiGame({
 
       {/* ===== 中央: 盤面 + 持ち駒 + (PCサイドパネル) ===== xl 未満で表示 */}
       <div className="xl:hidden flex-1 min-h-0 flex flex-col lg:flex-row max-w-5xl mx-auto w-full overflow-hidden">
-        <div className="flex flex-col items-center flex-1 min-h-0 px-2 py-0.5 lg:py-2">
+        <div
+          ref={playAreaRef}
+          data-card-shogi-play-area
+          className="flex flex-col items-center flex-1 min-h-0 px-2 py-0.5 lg:py-2"
+        >
           {/* ステータスバー (タブレット用)。モバイルでは画面最上段に分離配置済 (Issue #105) */}
           <div className="hidden md:block w-full">{statusBarContent}</div>
 
           {/* 相手の持ち駒 (モバイルでは compact で縦幅を詰める) */}
-          <div className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
+          <div data-card-shogi-captured="opponent" className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
             <CapturedPieces
               hand={gameState.hand}
               player={aiColor}
@@ -1254,7 +1284,7 @@ export function CardShogiGame({
           </div>
 
           {/* 盤面 */}
-          <div className="relative shrink-0 my-0.5">
+          <div data-card-shogi-board className="relative shrink-0 my-0.5">
             <ShogiBoard
               ref={boardTabletRef}
               board={gameState.board}
@@ -1281,7 +1311,7 @@ export function CardShogiGame({
           </div>
 
           {/* 自分の持ち駒 (モバイルでは compact で縦幅を詰める) */}
-          <div className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
+          <div data-card-shogi-captured="self" className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
             <CapturedPieces
               hand={gameState.hand}
               player={playerColor}
@@ -1347,11 +1377,12 @@ export function CardShogiGame({
           上端 (≒100px + safe-area)、translate-y-full で完全に画面外へスライド。 */}
       {!isGameActive && (
         <div
+          data-card-shogi-end-card
           className={cn(
             "xl:hidden fixed left-0 right-0 z-30 transition-transform duration-300",
             endCardMinimized ? "translate-y-full" : "translate-y-0",
           )}
-          style={{ bottom: "calc(100px + env(safe-area-inset-bottom))" }}
+          style={{ bottom: "var(--card-shogi-bottom-controls-height)" }}
           aria-hidden={endCardMinimized}
           onClick={(e) => e.stopPropagation()}
         >
@@ -1388,6 +1419,8 @@ export function CardShogiGame({
       {/* ===== 自分ゾーン (xl 未満) ===== */}
       {/* PC タブレット相当 (md..xl-1): 詳細ゾーン (GameControls を統合) */}
       <section
+        ref={bottomControlsRef}
+        data-card-shogi-bottom-controls
         className="hidden md:flex xl:hidden shrink-0 px-2 py-1.5 border-t bg-muted/40 items-end gap-2 overflow-x-auto"
         style={{ paddingBottom: "max(0.375rem, env(safe-area-inset-bottom))" }}
         onClick={(e) => e.stopPropagation()}
@@ -1417,6 +1450,8 @@ export function CardShogiGame({
         * Issue #105: 段2幅を段1 (GameControls) と同じ自然幅に揃え、
         * 余った横幅は右のトラップ列が flex-1 で取り込む。 */}
       <section
+        ref={bottomControlsRef}
+        data-card-shogi-bottom-controls
         className="md:hidden xl:hidden shrink-0 border-t bg-card flex items-stretch gap-2 px-2 py-1.5 z-30"
         style={{ paddingBottom: "max(0.375rem, env(safe-area-inset-bottom))" }}
         onClick={(e) => e.stopPropagation()}
@@ -1486,12 +1521,13 @@ export function CardShogiGame({
       {/* モバイル: 手札ドロワー(下からスライドアップ) */}
       {/* bottom 値は下端 3カラムセクションの高さ (山札 md = 80px + padding) に合わせる */}
       <div
+        data-card-shogi-drawer
         className={cn(
           "md:hidden fixed left-0 right-0 z-20 bg-card border-t-2 border-primary shadow-2xl transition-transform duration-300",
           drawerOpen ? "translate-y-0" : "translate-y-full",
         )}
         style={{
-          bottom: "calc(100px + env(safe-area-inset-bottom))",
+          bottom: "var(--card-shogi-bottom-controls-height)",
           maxHeight: "55dvh",
         }}
         onClick={(e) => e.stopPropagation()}
@@ -1530,6 +1566,7 @@ export function CardShogiGame({
       {/* ===== xl 以上: 4列レイアウト ===== */}
       {/* 列幅: 自分カード 220px / 中央 1fr / キャラ・棋譜 240px / 相手カード 220px */}
       <div
+        data-card-shogi-xl-layout
         className="hidden xl:grid xl:grid-cols-[220px_1fr_240px_220px] xl:grid-rows-[auto_minmax(0,1fr)] xl:gap-2 xl:p-2 h-full"
         onClick={(e) => e.stopPropagation()}
       >
@@ -1617,8 +1654,12 @@ export function CardShogiGame({
         </aside>
 
         {/* Col 2: 中央(盤面 + 持ち駒) */}
-        <main className="flex flex-col items-center gap-1 min-h-0 overflow-hidden">
-          <div className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
+        <main
+          ref={playAreaRef}
+          data-card-shogi-play-area
+          className="flex flex-col items-center gap-1 min-h-0 overflow-hidden"
+        >
+          <div data-card-shogi-captured="opponent" className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
             <CapturedPieces
               hand={gameState.hand}
               player={aiColor}
@@ -1631,7 +1672,7 @@ export function CardShogiGame({
               hiddenPieceTypes={hiddenOpponentCapturedTypes}
             />
           </div>
-          <div className="relative shrink-0">
+          <div data-card-shogi-board className="relative shrink-0">
             <ShogiBoard
               ref={boardXlRef}
               board={gameState.board}
@@ -1656,7 +1697,7 @@ export function CardShogiGame({
               trapName={overlayEvent?.trapName}
             />
           </div>
-          <div className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
+          <div data-card-shogi-captured="self" className="w-full shrink-0" style={{ maxWidth: squareSize * 9 + 60 }}>
             <CapturedPieces
               hand={gameState.hand}
               player={playerColor}
@@ -1867,20 +1908,19 @@ export function CardShogiGame({
                     親の hit アニメーション (シェイク・スケール) と同時並行。 */}
                 {checkBreakAnim.hitActive && (
                   <svg
-                    viewBox="0 0 100 100"
+                    viewBox={`0 0 ${g.rect.width} ${g.rect.height}`}
                     preserveAspectRatio="none"
                     className="absolute inset-0 w-full h-full pointer-events-none"
                     aria-hidden
                   >
                     <line
-                      x1="100"
+                      x1={g.rect.width}
                       y1="0"
                       x2="0"
-                      y2="100"
+                      y2={g.rect.height}
                       stroke="#ef4444"
-                      strokeWidth="5"
+                      strokeWidth={Math.max(3, Math.min(5, g.rect.width * 0.12))}
                       strokeLinecap="round"
-                      vectorEffect="non-scaling-stroke"
                       className="ghost-slash-line"
                     />
                   </svg>

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -26,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { getShogiBoardCellSize } from "@/lib/shogi/board-layout";
 
 import { getCharacterById } from "@/data/characters";
 import { gameResultText } from "@/lib/shogi/notation";
@@ -247,6 +248,7 @@ export function CardShogiGame({
   // 開発者用 dev /piece-flight で保存されたフライト演出パラメータ。
   // 未保存時は animation-constants の既定値が返る。
   const flightParams = useFlightParams();
+  const boardCellSize = useMemo(() => getShogiBoardCellSize(squareSize), [squareSize]);
 
   const gameConfig: GameConfig = {
     ...serializableConfig,
@@ -1844,14 +1846,15 @@ export function CardShogiGame({
       />
 
       {/* Issue #82: 駒移動カード(歩戻し / 駒戻し / 二歩指し)の駒回転フライト演出。
-          pieceSize は盤上マスサイズ (squareSize) を渡し、フライト中の駒サイズを
+          pieceWidth / pieceHeight は盤上マス実寸を渡し、フライト中の駒サイズを
           実際の盤駒と揃える。speed/rotation/min/ease は dev /piece-flight の
           保存値 (なければ animation-constants の既定値) を反映。 */}
       <PieceFlight
         spec={pieceFlight?.spec ?? null}
         flightKey={pieceFlight?.key ?? null}
         playerColor={playerColor}
-        pieceSize={squareSize}
+        pieceWidth={boardCellSize.width}
+        pieceHeight={boardCellSize.height}
         speedPxPerSec={flightParams.speedPxPerSec}
         rotationSecPerTurn={flightParams.rotationSecPerTurn}
         minDurationMs={flightParams.minDurationMs}
@@ -1866,7 +1869,8 @@ export function CardShogiGame({
           spec={spec}
           flightKey={checkBreakAnim.flightKeyBase + idx}
           playerColor={playerColor}
-          pieceSize={squareSize}
+          pieceWidth={boardCellSize.width}
+          pieceHeight={boardCellSize.height}
           speedPxPerSec={flightParams.speedPxPerSec}
           rotationSecPerTurn={flightParams.rotationSecPerTurn}
           minDurationMs={flightParams.minDurationMs}

--- a/src/components/game/card-shogi/deck-pile.tsx
+++ b/src/components/game/card-shogi/deck-pile.tsx
@@ -174,6 +174,7 @@ export const DeckPile = memo(function DeckPile({
   if (horizontal) {
     return (
       <button
+        data-card-shogi-deck
         type="button"
         onClick={onDraw}
         disabled={!interactable}
@@ -259,6 +260,7 @@ export const DeckPile = memo(function DeckPile({
 
   return (
     <div
+      data-card-shogi-deck
       className={cn("relative shrink-0", fullWidth && "w-full")}
       style={containerStyle}
     >

--- a/src/components/game/card-shogi/piece-flight.tsx
+++ b/src/components/game/card-shogi/piece-flight.tsx
@@ -41,6 +41,8 @@ interface PieceFlightProps {
   rotationSecPerTurn?: number;
   minDurationMs?: number;
   pieceSize?: number;
+  pieceWidth?: number;
+  pieceHeight?: number;
   ease?: "linear" | "easeIn" | "easeOut" | "easeInOut" | "circIn" | "circOut" | "anticipate";
 }
 
@@ -57,6 +59,8 @@ export function PieceFlight({
   rotationSecPerTurn,
   minDurationMs,
   pieceSize,
+  pieceWidth,
+  pieceHeight,
   ease,
 }: PieceFlightProps) {
   const isClient = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
@@ -75,6 +79,8 @@ export function PieceFlight({
             rotationSecPerTurn={rotationSecPerTurn}
             minDurationMs={minDurationMs}
             pieceSize={pieceSize}
+            pieceWidth={pieceWidth}
+            pieceHeight={pieceHeight}
             ease={ease}
           />
         )}
@@ -92,6 +98,8 @@ function PieceFlightInner({
   rotationSecPerTurn,
   minDurationMs,
   pieceSize,
+  pieceWidth,
+  pieceHeight,
   ease,
 }: {
   spec: PieceFlightSpec;
@@ -101,12 +109,15 @@ function PieceFlightInner({
   rotationSecPerTurn?: number;
   minDurationMs?: number;
   pieceSize?: number;
+  pieceWidth?: number;
+  pieceHeight?: number;
   ease?: PieceFlightProps["ease"];
 }) {
   const speed = speedPxPerSec ?? SPEED_PX_PER_SEC;
   const rotPeriod = rotationSecPerTurn ?? ROTATION_SEC_PER_TURN;
   const minDur = minDurationMs ?? MIN_DURATION_MS;
-  const size = pieceSize ?? PIECE_SIZE;
+  const width = pieceWidth ?? pieceSize ?? PIECE_SIZE;
+  const height = pieceHeight ?? pieceSize ?? PIECE_SIZE;
   // 既定 easing は dev 検証で採用された easeInOut (2026-05-04)。
   // 旧実装は linear を採用していたが、最小再生時間を 600ms に伸ばしたため
   // 始終点で減速がかかる easeInOut の方が違和感が少なくなった。
@@ -143,13 +154,13 @@ function PieceFlightInner({
   return (
     <motion.div
       initial={{
-        x: spec.fromX - size / 2,
-        y: spec.fromY - size / 2,
+        x: spec.fromX - width / 2,
+        y: spec.fromY - height / 2,
         rotate: 0,
       }}
       animate={{
-        x: spec.toX - size / 2,
-        y: spec.toY - size / 2,
+        x: spec.toX - width / 2,
+        y: spec.toY - height / 2,
         rotate: rotateDeg,
       }}
       transition={{
@@ -161,8 +172,8 @@ function PieceFlightInner({
         position: "fixed",
         left: 0,
         top: 0,
-        width: size,
-        height: size,
+        width,
+        height,
         willChange: "transform",
         zIndex: 55,
       }}
@@ -170,7 +181,7 @@ function PieceFlightInner({
       <ShogiPiece
         piece={{ type: spec.pieceType, owner: spec.owner }}
         playerColor={playerColor}
-        squareSize={size}
+        squareSize={width}
       />
     </motion.div>
   );

--- a/src/components/game/card-shogi/trap-slot.tsx
+++ b/src/components/game/card-shogi/trap-slot.tsx
@@ -41,7 +41,7 @@ export const TrapSlot = memo(function TrapSlot({
     const cardInstance: CardInstance = { instanceId: trap.instanceId, defId: trap.defId };
     if (!fullWidth && !horizontal) {
       return (
-        <div className={cn("shrink-0", SIZE_CLASS[size])}>
+        <div data-card-shogi-trap className={cn("shrink-0", SIZE_CLASS[size])}>
           <CardView
             card={cardInstance}
             size={size}
@@ -55,15 +55,17 @@ export const TrapSlot = memo(function TrapSlot({
       );
     }
     return (
-      <CardView
-        card={cardInstance}
-        size={size}
-        fullWidth={fullWidth || horizontal}
-        hideDescription
-        hideTrapBadge
-        compactIconLayout
-        inactive
-      />
+      <div data-card-shogi-trap className={cn((fullWidth || horizontal) && "w-full", horizontal && "h-full")}>
+        <CardView
+          card={cardInstance}
+          size={size}
+          fullWidth={fullWidth || horizontal}
+          hideDescription
+          hideTrapBadge
+          compactIconLayout
+          inactive
+        />
+      </div>
     );
   }
 
@@ -73,6 +75,7 @@ export const TrapSlot = memo(function TrapSlot({
     if (!trap) {
       return (
         <div
+          data-card-shogi-trap
           className={cn(wrapperBase, "border-dashed border-muted-foreground/40 bg-muted/30")}
           aria-label="トラップ未セット"
         >
@@ -83,6 +86,7 @@ export const TrapSlot = memo(function TrapSlot({
     }
     return (
       <div
+        data-card-shogi-trap
         className={cn(wrapperBase, "border-purple-700 bg-gradient-to-br from-purple-700 to-purple-900 text-white/80 font-bold")}
         aria-label="トラップセット済(裏向き)"
       >
@@ -102,6 +106,7 @@ export const TrapSlot = memo(function TrapSlot({
   if (!trap) {
     return (
       <div
+        data-card-shogi-trap
         className={cn(
           "rounded-md border-2 border-dashed border-muted-foreground/40 bg-muted/30",
           "flex flex-col items-center justify-center shrink-0",
@@ -118,6 +123,7 @@ export const TrapSlot = memo(function TrapSlot({
   // ここに来るのは faceDown=true のケース (相手側のセット済みトラップ表示)
   return (
     <div
+      data-card-shogi-trap
       className={cn(
         "rounded-md border-2 border-purple-700 bg-gradient-to-br from-purple-700 to-purple-900",
         "flex items-center justify-center text-white/80 font-bold shrink-0",

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -5,6 +5,11 @@ import { forwardRef, memo, useCallback, useImperativeHandle, useRef } from "reac
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
 import { useTouchHandler } from "@/hooks/use-touch-handler";
+import {
+  SHOGI_BOARD_GAP,
+  getShogiBoardCellSize,
+  getShogiBoardLabelSize,
+} from "@/lib/shogi/board-layout";
 import type { Board, Move, Piece, Player, Position } from "@/lib/shogi/types";
 
 export interface ShogiBoardHandle {
@@ -61,7 +66,8 @@ interface BoardSquareProps {
   isKingInCheck: boolean;
   isStarPoint: boolean;
   canHover: boolean;
-  squareSize: number;
+  cellWidth: number;
+  cellHeight: number;
   dotSize: number;
   playerColor: Player;
   registerRef: RegisterSquareRef;
@@ -84,7 +90,8 @@ const BoardSquare = memo(function BoardSquare({
   isKingInCheck,
   isStarPoint,
   canHover,
-  squareSize,
+  cellWidth,
+  cellHeight,
   dotSize,
   playerColor,
   registerRef,
@@ -123,15 +130,15 @@ const BoardSquare = memo(function BoardSquare({
         // ホバー
         canHover && "hover:bg-amber-100 dark:hover:bg-amber-800/50"
       )}
-      style={{ width: squareSize, height: squareSize }}
+      style={{ width: cellWidth, height: cellHeight }}
     >
       {/* 星目（中央3×3四隅の交差点） */}
       {isStarPoint && (
         <div
           className="absolute z-10 rounded-full bg-amber-900 dark:bg-amber-400 pointer-events-none"
           style={{
-            width: Math.max(4, squareSize * 0.08),
-            height: Math.max(4, squareSize * 0.08),
+            width: Math.max(4, cellWidth * 0.08),
+            height: Math.max(4, cellWidth * 0.08),
             bottom: 0,
             right: 0,
             transform: "translate(50%, 50%)",
@@ -158,7 +165,7 @@ const BoardSquare = memo(function BoardSquare({
           <span
             className="text-red-700 dark:text-red-300 font-bold leading-none select-none"
             style={{
-              fontSize: Math.max(20, squareSize * 0.6),
+              fontSize: Math.max(20, cellWidth * 0.6),
               filter: "drop-shadow(0 0 3px rgba(255,255,255,0.8))",
             }}
           >
@@ -178,7 +185,7 @@ const BoardSquare = memo(function BoardSquare({
             isSelected={isSelected}
             isInCheck={isKingInCheck}
             playerColor={playerColor}
-            squareSize={squareSize}
+            squareSize={cellWidth}
           />
         </div>
       )}
@@ -194,7 +201,7 @@ const BoardSquare = memo(function BoardSquare({
             style={{
               right: 1,
               top: 1,
-              fontSize: Math.max(10, squareSize * 0.32),
+              fontSize: Math.max(10, cellWidth * 0.32),
               filter: "drop-shadow(0 0 2px rgba(168,85,247,0.9))",
             }}
           >
@@ -264,6 +271,7 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
   );
 
   const isGote = playerColor === "gote";
+  const cellSize = getShogiBoardCellSize(squareSize);
   // タップスナップ対象は legalMoves + forbiddenMateMoves。
   // 禁止マスもタップで反応する (UI 側で禁止理由ダイアログを表示する) ため、スナップ対象に含める。
   const tapSnapMoves = forbiddenMateSquares && forbiddenMateSquares.length > 0
@@ -278,7 +286,8 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
       ]
     : legalMoves;
   const { gridRef, pointerHandlers } = useTouchHandler({
-    squareSize,
+    cellWidth: cellSize.width,
+    cellHeight: cellSize.height,
     legalMoves: tapSnapMoves,
     selectedSquare,
     isGote,
@@ -301,8 +310,8 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
   const fileLabels = isGote ? FILE_LABELS_GOTE : FILE_LABELS_SENTE;
   const rankLabels = isGote ? RANK_LABELS_GOTE : RANK_LABELS_SENTE;
 
-  const labelSize = isMobile ? Math.max(12, squareSize * 0.3) : Math.max(16, squareSize * 0.45);
-  const dotSize = Math.max(8, squareSize * 0.22);
+  const labelSize = getShogiBoardLabelSize(squareSize, isMobile);
+  const dotSize = Math.max(8, cellSize.width * 0.22);
 
   return (
     <div className="flex flex-col items-center gap-0.5">
@@ -312,7 +321,7 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
           <div
             key={label}
             className="flex items-center justify-center text-muted-foreground"
-            style={{ width: squareSize, height: labelSize, fontSize: labelSize * 0.75 }}
+            style={{ width: cellSize.width, height: labelSize, fontSize: labelSize * 0.75 }}
           >
             {label}
           </div>
@@ -326,13 +335,14 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
         {/* 盤面グリッド */}
         <div
           ref={gridRef}
+          data-shogi-board-grid="1"
           role="grid"
           aria-label="将棋盤"
           className="grid border border-amber-800 dark:border-amber-400 bg-amber-800/60 dark:bg-amber-400/60 relative"
           style={{
-            gridTemplateColumns: `repeat(9, ${squareSize}px)`,
-            gridTemplateRows: `repeat(9, ${squareSize}px)`,
-            gap: "1px",
+            gridTemplateColumns: `repeat(9, ${cellSize.width}px)`,
+            gridTemplateRows: `repeat(9, ${cellSize.height}px)`,
+            gap: SHOGI_BOARD_GAP,
             touchAction: "none",
           }}
           onClick={(e) => e.stopPropagation()}
@@ -374,7 +384,8 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
                   isKingInCheck={isKingInCheck}
                   isStarPoint={isStarPoint}
                   canHover={canHover}
-                  squareSize={squareSize}
+                  cellWidth={cellSize.width}
+                  cellHeight={cellSize.height}
                   dotSize={dotSize}
                   playerColor={playerColor}
                   registerRef={registerSquareRef}
@@ -390,7 +401,7 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
             <div
               key={label}
               className="flex items-center justify-center text-muted-foreground"
-              style={{ height: squareSize, width: labelSize, fontSize: labelSize * 0.75 }}
+              style={{ height: cellSize.height, width: labelSize, fontSize: labelSize * 0.75 }}
             >
               {label}
             </div>

--- a/src/hooks/use-board-size.ts
+++ b/src/hooks/use-board-size.ts
@@ -2,6 +2,12 @@
 
 import { useState, useEffect, useCallback } from "react";
 
+import {
+  SHOGI_BOARD_CELLS,
+  getShogiBoardGridSize,
+  getShogiBoardLabelSize,
+} from "@/lib/shogi/board-layout";
+
 const MOBILE_BREAKPOINT = 768;
 
 interface BoardSize {
@@ -16,7 +22,7 @@ const STATUS_BAR_HEIGHT = 28;
 const CAPTURED_PIECES_HEIGHT = 72; // captured-pieces.tsx の CAPTURED_PIECES_HEIGHT と同値
 const GAME_CONTROLS_HEIGHT = 36;  // game-controls.tsx の GAME_CONTROLS_HEIGHT と同値
 const MOBILE_DRAWER_TAB_HEIGHT = 40; // mobile-drawer.tsx のタブバー高さ
-const BOARD_LABEL_HEIGHT = 16; // ファイルラベル（上）
+const BOARD_LABEL_GAP = 2; // shogi-board.tsx の flex gap-0.5 相当
 const GAPS = 20; // マージン・パディング合計
 
 const VERTICAL_RESERVED =
@@ -24,14 +30,20 @@ const VERTICAL_RESERVED =
   CAPTURED_PIECES_HEIGHT * 2 +
   GAME_CONTROLS_HEIGHT +
   MOBILE_DRAWER_TAB_HEIGHT +
-  BOARD_LABEL_HEIGHT +
   GAPS;
 
 const MIN_SQUARE_SIZE = 36;
 const MAX_SQUARE_SIZE = 64;
 const HORIZONTAL_PADDING = 40;
 const HORIZONTAL_PADDING_MOBILE = 24;
-const BOARD_CELLS = 9;
+
+function boardFits(baseSize: number, isMobile: boolean, availableWidth: number, availableHeight: number): boolean {
+  const grid = getShogiBoardGridSize(baseSize);
+  const labelSize = getShogiBoardLabelSize(baseSize, isMobile);
+  const boardWidth = grid.width + 2 + labelSize + (isMobile ? 0 : labelSize + 6);
+  const boardHeight = labelSize + BOARD_LABEL_GAP + grid.height;
+  return boardWidth <= availableWidth && boardHeight <= availableHeight;
+}
 
 function calculate(): { squareSize: number; isMobile: boolean; viewportHeight: number } {
   if (typeof window === "undefined") return { squareSize: 40, isMobile: false, viewportHeight: 800 };
@@ -45,10 +57,14 @@ function calculate(): { squareSize: number; isMobile: boolean; viewportHeight: n
   const availableWidth = vw - padding;
   const availableHeight = vh - VERTICAL_RESERVED;
 
-  const fromWidth = Math.floor(availableWidth / BOARD_CELLS);
-  const fromHeight = Math.floor(availableHeight / BOARD_CELLS);
-
-  const squareSize = Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, fromWidth, fromHeight));
+  let squareSize = MIN_SQUARE_SIZE;
+  for (let candidate = MAX_SQUARE_SIZE; candidate >= MIN_SQUARE_SIZE; candidate--) {
+    if (boardFits(candidate, isMobile, availableWidth, availableHeight)) {
+      squareSize = candidate;
+      break;
+    }
+  }
+  squareSize = Math.min(squareSize, Math.floor(availableWidth / SHOGI_BOARD_CELLS));
   return { squareSize, isMobile, viewportHeight: vh };
 }
 
@@ -66,8 +82,10 @@ export function useBoardSize(): BoardSize {
   }, []);
 
   useEffect(() => {
-    recalculate();
-    setIsReady(true);
+    const initialFrame = window.requestAnimationFrame(() => {
+      recalculate();
+      setIsReady(true);
+    });
 
     let timeoutId: ReturnType<typeof setTimeout>;
     const handleResize = () => {
@@ -79,6 +97,7 @@ export function useBoardSize(): BoardSize {
     window.addEventListener("orientationchange", handleResize);
 
     return () => {
+      window.cancelAnimationFrame(initialFrame);
       clearTimeout(timeoutId);
       window.removeEventListener("resize", handleResize);
       window.removeEventListener("orientationchange", handleResize);

--- a/src/hooks/use-card-board-size.ts
+++ b/src/hooks/use-card-board-size.ts
@@ -2,11 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
 
-import {
-  computeCardBoardSize,
-  getCardShogiLayoutMode,
-  type CardBoardSizeResult,
-} from "@/lib/card-shogi/layout-metrics";
+import { computeCardBoardSize, type CardBoardSizeResult } from "@/lib/card-shogi/layout-metrics";
 
 interface CardBoardSize {
   squareSize: number;
@@ -151,8 +147,7 @@ export function useCardBoardSize(): CardBoardSize {
     };
   }, [recalc]);
 
-  const viewport = typeof window === "undefined" ? { width: 390 } : { width: getViewportSize().width };
-  const fallbackMode = result?.mode ?? getCardShogiLayoutMode(viewport.width);
+  const fallbackMode = result?.mode ?? "mobile";
   const squareSize = result?.squareSize ?? 40;
 
   return {

--- a/src/hooks/use-card-board-size.ts
+++ b/src/hooks/use-card-board-size.ts
@@ -1,37 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState, type RefCallback } from "react";
 
-// カード将棋画面用の盤面サイズ計算フック。
-// 既存の useBoardSize はカード要素を考慮していないため、ハイブリッドUI のレイアウト
-// (モバイル / タブレット / PC大) ごとに reserved 値を切り替える。
-// 既存の useBoardSize は改変しない(影響を切る方針)。
-
-const MOBILE_BREAKPOINT = 768; // md
-const PC_LARGE_BREAKPOINT = 1280; // xl - 4列レイアウト発動
-const MIN_SQUARE_SIZE = 32;
-const MAX_SQUARE_SIZE = 64;
-const HORIZONTAL_PADDING = 40;
-const HORIZONTAL_PADDING_MOBILE = 24;
-const BOARD_CELLS = 9;
-
-// 既存 useBoardSize の VERTICAL_RESERVED と同等の基本予約値。
-// card-shogi のモバイル時は CapturedPieces compact (52*2=104) を使用するため、
-// 標準より少し小さい値で十分。
-const BASE_RESERVED = 180;
-
-// PC タブレット相当 (md..xl-1): 上下分割の上ゾーン+下ゾーン
-const PC_CARD_RESERVED = 240;
-
-// モバイル (<md): 上端細バー (≈ 50px) + 下端3カラムセクション (山札 md = 80px + padding) + safe-area
-const MOBILE_CARD_RESERVED = 150;
-
-// PC 大 (>=xl): 4列構成 = 上下ゾーンなし、ヘッダ・パディング分のみ
-const PC_LARGE_CARD_RESERVED = 40;
-
-// PC 大 (>=xl): 横方向に「自分カード + 相手カード + キャラ・棋譜」の3列が並ぶため、
-// 中央盤面に使える横幅は (vw - これら3列の合計幅 - gap)
-const PC_LARGE_HORIZONTAL_RESERVED = 680; // 220 + 240 + 220 = 680
+import {
+  computeCardBoardSize,
+  getCardShogiLayoutMode,
+  type CardBoardSizeResult,
+} from "@/lib/card-shogi/layout-metrics";
 
 interface CardBoardSize {
   squareSize: number;
@@ -39,60 +14,156 @@ interface CardBoardSize {
   isLargeDesktop: boolean;
   viewportHeight: number;
   isReady: boolean;
+  playAreaRef: RefCallback<HTMLElement>;
+  bottomControlsRef: RefCallback<HTMLElement>;
+  bottomControlsHeight: number;
+  debug: CardBoardSizeResult | null;
+}
+
+const DEFAULT_BOTTOM_CONTROLS_HEIGHT = 100;
+
+function getViewportSize(): { width: number; height: number } {
+  if (typeof window === "undefined") return { width: 390, height: 844 };
+  const visualViewport = window.visualViewport;
+  return {
+    width: Math.floor(visualViewport?.width ?? window.innerWidth),
+    height: Math.floor(visualViewport?.height ?? window.innerHeight),
+  };
+}
+
+function isVisibleElement(node: HTMLElement): boolean {
+  if (!node.isConnected) return false;
+  const rect = node.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  const style = window.getComputedStyle(node);
+  return style.display !== "none" && style.visibility !== "hidden";
+}
+
+function getContentRect(node: HTMLElement): { width: number; height: number } {
+  const rect = node.getBoundingClientRect();
+  const style = window.getComputedStyle(node);
+  const horizontalPadding = Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight);
+  const verticalPadding = Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+  return {
+    width: Math.max(0, rect.width - horizontalPadding),
+    height: Math.max(0, rect.height - verticalPadding),
+  };
+}
+
+function getLargestVisibleNode(nodes: Set<HTMLElement>): HTMLElement | null {
+  let best: HTMLElement | null = null;
+  let bestArea = 0;
+  for (const node of nodes) {
+    if (!isVisibleElement(node)) continue;
+    const rect = node.getBoundingClientRect();
+    const area = rect.width * rect.height;
+    if (area > bestArea) {
+      best = node;
+      bestArea = area;
+    }
+  }
+  return best;
 }
 
 export function useCardBoardSize(): CardBoardSize {
-  const [squareSize, setSquareSize] = useState(40);
-  const [isMobile, setIsMobile] = useState(false);
-  const [isLargeDesktop, setIsLargeDesktop] = useState(false);
-  const [viewportHeight, setViewportHeight] = useState(800);
+  const playAreaNodesRef = useRef<Set<HTMLElement>>(new Set());
+  const bottomControlsNodesRef = useRef<Set<HTMLElement>>(new Set());
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  const [result, setResult] = useState<CardBoardSizeResult | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(844);
+  const [bottomControlsHeight, setBottomControlsHeight] = useState(DEFAULT_BOTTOM_CONTROLS_HEIGHT);
   const [isReady, setIsReady] = useState(false);
 
   const recalc = useCallback(() => {
     if (typeof window === "undefined") return;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const mobile = vw < MOBILE_BREAKPOINT;
-    const largeDesktop = vw >= PC_LARGE_BREAKPOINT;
+    const viewport = getViewportSize();
+    const activePlayArea = getLargestVisibleNode(playAreaNodesRef.current);
+    const playArea = activePlayArea ? getContentRect(activePlayArea) : null;
+    const nextResult = computeCardBoardSize({
+      viewportWidth: viewport.width,
+      viewportHeight: viewport.height,
+      availableWidth: playArea?.width,
+      availableHeight: playArea?.height,
+    });
 
-    const padding = mobile ? HORIZONTAL_PADDING_MOBILE : HORIZONTAL_PADDING;
-    const cardReserved = mobile
-      ? MOBILE_CARD_RESERVED
-      : largeDesktop
-        ? PC_LARGE_CARD_RESERVED
-        : PC_CARD_RESERVED;
-    const horizontalReserved = largeDesktop
-      ? PC_LARGE_HORIZONTAL_RESERVED + padding
-      : padding;
-    const availableWidth = vw - horizontalReserved;
-    const availableHeight = vh - BASE_RESERVED - cardReserved;
-    const fromWidth = Math.floor(availableWidth / BOARD_CELLS);
-    const fromHeight = Math.floor(availableHeight / BOARD_CELLS);
-    const size = Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, fromWidth, fromHeight));
-    setSquareSize(size);
-    setIsMobile(mobile);
-    setIsLargeDesktop(largeDesktop);
-    setViewportHeight(vh);
+    const activeBottomControls = getLargestVisibleNode(bottomControlsNodesRef.current);
+    const nextBottomControlsHeight = activeBottomControls
+      ? Math.ceil(activeBottomControls.getBoundingClientRect().height)
+      : DEFAULT_BOTTOM_CONTROLS_HEIGHT;
+
+    setViewportHeight(viewport.height);
+    setResult((prev) =>
+      prev &&
+      prev.squareSize === nextResult.squareSize &&
+      prev.availableWidth === nextResult.availableWidth &&
+      prev.availableHeight === nextResult.availableHeight &&
+      prev.mode === nextResult.mode
+        ? prev
+        : nextResult,
+    );
+    setBottomControlsHeight((prev) =>
+      prev === nextBottomControlsHeight ? prev : nextBottomControlsHeight,
+    );
   }, []);
 
-  useEffect(() => {
-    // SSR-safe: window が必要なため effect 内で呼ぶ。
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  const observeNode = useCallback((node: HTMLElement | null, bucket: Set<HTMLElement>) => {
+    if (!node) return;
+    bucket.add(node);
+    resizeObserverRef.current?.observe(node);
     recalc();
-    setIsReady(true);
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const handleResize = () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(recalc, 100);
-    };
+  }, [recalc]);
+
+  const playAreaRef = useCallback<RefCallback<HTMLElement>>(
+    (node) => observeNode(node, playAreaNodesRef.current),
+    [observeNode],
+  );
+  const bottomControlsRef = useCallback<RefCallback<HTMLElement>>(
+    (node) => observeNode(node, bottomControlsNodesRef.current),
+    [observeNode],
+  );
+
+  useEffect(() => {
+    const handleResize = () => window.requestAnimationFrame(recalc);
+    const ro = new ResizeObserver(handleResize);
+    resizeObserverRef.current = ro;
+    for (const node of playAreaNodesRef.current) ro.observe(node);
+    for (const node of bottomControlsNodesRef.current) ro.observe(node);
+
+    const initialFrame = window.requestAnimationFrame(() => {
+      recalc();
+      setIsReady(true);
+    });
+
     window.addEventListener("resize", handleResize);
     window.addEventListener("orientationchange", handleResize);
+    window.visualViewport?.addEventListener("resize", handleResize);
+    window.visualViewport?.addEventListener("scroll", handleResize);
+
     return () => {
-      clearTimeout(timeoutId);
+      ro.disconnect();
+      window.cancelAnimationFrame(initialFrame);
+      resizeObserverRef.current = null;
       window.removeEventListener("resize", handleResize);
       window.removeEventListener("orientationchange", handleResize);
+      window.visualViewport?.removeEventListener("resize", handleResize);
+      window.visualViewport?.removeEventListener("scroll", handleResize);
     };
   }, [recalc]);
 
-  return { squareSize, isMobile, isLargeDesktop, viewportHeight, isReady };
+  const viewport = typeof window === "undefined" ? { width: 390 } : { width: getViewportSize().width };
+  const fallbackMode = result?.mode ?? getCardShogiLayoutMode(viewport.width);
+  const squareSize = result?.squareSize ?? 40;
+
+  return {
+    squareSize,
+    isMobile: fallbackMode === "mobile",
+    isLargeDesktop: fallbackMode === "largeDesktop",
+    viewportHeight,
+    isReady,
+    playAreaRef,
+    bottomControlsRef,
+    bottomControlsHeight,
+    debug: result,
+  };
 }

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -26,6 +26,8 @@ interface UseCardShogiGameOptions {
   gameId: string;
   gameConfig: GameConfig;
   onComment?: (event: string) => void;
+  disableServerSync?: boolean;
+  disableAi?: boolean;
 }
 
 export function useCardShogiGame({
@@ -34,6 +36,8 @@ export function useCardShogiGame({
   gameId,
   gameConfig,
   onComment,
+  disableServerSync = false,
+  disableAi = false,
 }: UseCardShogiGameOptions) {
   const [state, dispatch] = useReducer(reducer, {
     gameState: initialState,
@@ -75,6 +79,7 @@ export function useCardShogiGame({
     if (
       gameState.status !== "active" ||
       gameState.currentPlayer !== aiPlayer ||
+      disableAi ||
       state.isAiThinking ||
       state.cardState.pendingCard !== null ||
       // Issue #78: ドロー演出中は AI 思考をブロック (COMMIT_DRAW 後に再評価される)
@@ -124,6 +129,7 @@ export function useCardShogiGame({
     state.isDrawing,
     state.isPlayingCard,
     state.isCheckBreakAnimating,
+    disableAi,
   ]);
 
   // DB 保存(state 変更を監視して、最新の moveCount で保存)
@@ -133,6 +139,7 @@ export function useCardShogiGame({
     // 2手目完了で doubleMove=null になった時に通常通り save 発火する。
     // これにより 1手目分の GameMove レコードは作られず、リロード時の DB 状態は
     // カード使用前にロールバックする (二手指しキャンセル相当)。
+    if (disableServerSync) return;
     if (state.doubleMove !== null) return;
 
     const moveCount = state.gameState.moveCount;
@@ -157,7 +164,7 @@ export function useCardShogiGame({
     ).catch((e) => {
       console.error("saveCardShogiMove failed", e);
     });
-  }, [state.gameState, state.cardState, state.doubleMove, gameId]);
+  }, [state.gameState, state.cardState, state.doubleMove, gameId, disableServerSync]);
 
   // Issue #132: カード使用 / ドロー / トラップ設置直後の cardState 即時保存。
   // 駒指し以外のカード操作は moveCount を増やさないため、上の save useEffect では発火しない。
@@ -175,6 +182,7 @@ export function useCardShogiGame({
   const lastPersistedCardStateRef = useRef(state.cardState);
   useEffect(() => {
     if (state.doubleMove !== null) return;
+    if (disableServerSync) return;
     if (state.isPlayingCard || state.isDrawing || state.isCheckBreakAnimating) return;
     if (state.cardState === lastPersistedCardStateRef.current) return;
     lastPersistedCardStateRef.current = state.cardState;
@@ -189,6 +197,7 @@ export function useCardShogiGame({
     state.isDrawing,
     state.isCheckBreakAnimating,
     gameId,
+    disableServerSync,
   ]);
 
   // ----- 公開API -----
@@ -315,9 +324,10 @@ export function useCardShogiGame({
 
   const resign = useCallback(() => {
     dispatch({ type: "RESIGN" });
+    if (disableServerSync) return;
     const winner: Player = state.gameState.currentPlayer === "sente" ? "gote" : "sente";
     updateGameStatus(gameId, "resign", winner);
-  }, [state.gameState.currentPlayer, gameId]);
+  }, [state.gameState.currentPlayer, gameId, disableServerSync]);
 
   // Issue #132: 待った時に DB 側も巻き戻す。reducer dispatch は同期に state を更新しないため、
   // ref フラグを立てて next render の useEffect (後述) で post-UNDO state を確定後にサーバーアクションを呼ぶ。
@@ -340,6 +350,7 @@ export function useCardShogiGame({
     if (!pendingUndoSyncRef.current) return;
     pendingUndoSyncRef.current = false;
     lastSavedMoveCountRef.current = state.gameState.moveCount;
+    if (disableServerSync) return;
     undoCardShogiGameState(
       gameId,
       state.gameState,
@@ -348,7 +359,7 @@ export function useCardShogiGame({
     ).catch((e) => {
       console.error("undoCardShogiGameState failed", e);
     });
-  }, [state.gameState, state.cardState, gameId]);
+  }, [state.gameState, state.cardState, gameId, disableServerSync]);
 
   const deselect = useCallback(() => {
     dispatch({ type: "DESELECT" });

--- a/src/hooks/use-touch-handler.ts
+++ b/src/hooks/use-touch-handler.ts
@@ -4,7 +4,8 @@ import { useRef, useCallback } from "react";
 import type { Move, Position } from "@/lib/shogi/types";
 
 interface UseTouchHandlerOptions {
-  squareSize: number;
+  cellWidth: number;
+  cellHeight: number;
   legalMoves: Move[];
   selectedSquare: Position | null;
   isGote: boolean;
@@ -15,7 +16,8 @@ interface UseTouchHandlerOptions {
 const SNAP_THRESHOLD_RATIO = 0.4;
 
 export function useTouchHandler({
-  squareSize,
+  cellWidth,
+  cellHeight,
   legalMoves,
   selectedSquare,
   isGote,
@@ -25,22 +27,43 @@ export function useTouchHandler({
   // pointerdown時の座標を記録（スクロールとタップを区別するため）
   const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
 
+  const getGridMetrics = useCallback(() => {
+    const grid = gridRef.current;
+    if (!grid) return null;
+    const style = window.getComputedStyle(grid);
+    return {
+      rect: grid.getBoundingClientRect(),
+      borderLeft: Number.parseFloat(style.borderLeftWidth) || 0,
+      borderTop: Number.parseFloat(style.borderTopWidth) || 0,
+      borderRight: Number.parseFloat(style.borderRightWidth) || 0,
+      borderBottom: Number.parseFloat(style.borderBottomWidth) || 0,
+      columnGap: Number.parseFloat(style.columnGap) || 0,
+      rowGap: Number.parseFloat(style.rowGap) || 0,
+    };
+  }, []);
+
   const getGridPosition = useCallback(
     (clientX: number, clientY: number): Position | null => {
-      const grid = gridRef.current;
-      if (!grid) return null;
-
-      const rect = grid.getBoundingClientRect();
-      const relX = clientX - rect.left;
-      const relY = clientY - rect.top;
+      const metrics = getGridMetrics();
+      if (!metrics) return null;
+      const { rect, borderLeft, borderTop, borderRight, borderBottom, columnGap, rowGap } = metrics;
+      const relX = clientX - rect.left - borderLeft;
+      const relY = clientY - rect.top - borderTop;
+      const contentWidth = rect.width - borderLeft - borderRight;
+      const contentHeight = rect.height - borderTop - borderBottom;
 
       // グリッド外ならnull
-      if (relX < 0 || relY < 0 || relX >= rect.width || relY >= rect.height) {
+      if (relX < 0 || relY < 0 || relX >= contentWidth || relY >= contentHeight) {
         return null;
       }
 
-      const rawCol = Math.floor(relX / squareSize);
-      const rawRow = Math.floor(relY / squareSize);
+      const colPitch = cellWidth + columnGap;
+      const rowPitch = cellHeight + rowGap;
+      const rawCol = Math.floor(relX / colPitch);
+      const rawRow = Math.floor(relY / rowPitch);
+      const withinCellX = relX - rawCol * colPitch;
+      const withinCellY = relY - rawRow * rowPitch;
+      if (withinCellX >= cellWidth || withinCellY >= cellHeight) return null;
 
       // 後手時は行・列を反転（isGoteの場合rowIndices/colIndicesが逆順）
       const col = isGote ? 8 - rawCol : rawCol;
@@ -50,7 +73,7 @@ export function useTouchHandler({
 
       return { row, col };
     },
-    [squareSize, isGote]
+    [cellWidth, cellHeight, getGridMetrics, isGote]
   );
 
   const snapToLegalMove = useCallback(
@@ -67,14 +90,13 @@ export function useTouchHandler({
       );
       if (isAlreadyLegal) return rawPos;
 
-      const grid = gridRef.current;
-      if (!grid) return rawPos;
+      const metrics = getGridMetrics();
+      if (!metrics) return rawPos;
+      const { rect, borderLeft, borderTop, columnGap, rowGap } = metrics;
+      const relX = clientX - rect.left - borderLeft;
+      const relY = clientY - rect.top - borderTop;
 
-      const rect = grid.getBoundingClientRect();
-      const relX = clientX - rect.left;
-      const relY = clientY - rect.top;
-
-      const threshold = squareSize * SNAP_THRESHOLD_RATIO;
+      const threshold = Math.min(cellWidth, cellHeight) * SNAP_THRESHOLD_RATIO;
 
       let nearestTarget: Position | null = null;
       let minDistance = Infinity;
@@ -87,8 +109,8 @@ export function useTouchHandler({
         const displayCol = isGote ? 8 - targetCol : targetCol;
 
         // マスの中心座標（グリッド相対）
-        const centerX = (displayCol + 0.5) * squareSize;
-        const centerY = (displayRow + 0.5) * squareSize;
+        const centerX = displayCol * (cellWidth + columnGap) + cellWidth / 2;
+        const centerY = displayRow * (cellHeight + rowGap) + cellHeight / 2;
 
         const dist = Math.hypot(relX - centerX, relY - centerY);
         if (dist < minDistance) {
@@ -104,7 +126,7 @@ export function useTouchHandler({
 
       return rawPos;
     },
-    [selectedSquare, legalMoves, squareSize, isGote]
+    [selectedSquare, legalMoves, cellWidth, cellHeight, getGridMetrics, isGote]
   );
 
   const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {

--- a/src/lib/card-shogi/__tests__/layout-metrics.test.ts
+++ b/src/lib/card-shogi/__tests__/layout-metrics.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CARD_SHOGI_VIEWPORT_MATRIX,
+  computeCardBoardSize,
+  getShogiBoardOuterSize,
+} from "../layout-metrics";
+
+describe("card-shogi layout metrics", () => {
+  it.each(CARD_SHOGI_VIEWPORT_MATRIX)("fits the central board stack in $name", (viewport) => {
+    const result = computeCardBoardSize({
+      viewportWidth: viewport.width,
+      viewportHeight: viewport.height,
+    });
+
+    expect(result.requiredWidth).toBeLessThanOrEqual(result.availableWidth);
+    expect(result.requiredHeight).toBeLessThanOrEqual(result.availableHeight);
+    expect(result.squareSize).toBeGreaterThanOrEqual(26);
+    expect(result.squareSize).toBeLessThanOrEqual(64);
+  });
+
+  it("accounts for grid gaps, border, labels, and the desktop left spacer", () => {
+    const mobile = getShogiBoardOuterSize(32, "mobile");
+    const desktop = getShogiBoardOuterSize(32, "largeDesktop");
+
+    expect(mobile.gridWidth).toBe(32 * 9 + 8 + 2);
+    expect(mobile.width).toBeCloseTo(mobile.gridWidth + 2 + mobile.labelSize);
+    expect(desktop.width).toBeCloseTo(desktop.gridWidth + desktop.labelSize * 2 + 8);
+  });
+
+  it("uses the emergency floor only for genuinely tight viewports", () => {
+    const roomy = computeCardBoardSize({ viewportWidth: 390, viewportHeight: 844 });
+    const tight = computeCardBoardSize({
+      viewportWidth: 320,
+      viewportHeight: 420,
+      availableWidth: 300,
+      availableHeight: 320,
+    });
+
+    expect(roomy.usedEmergencyFloor).toBe(false);
+    expect(tight.squareSize).toBeLessThan(32);
+    expect(tight.usedEmergencyFloor).toBe(true);
+  });
+});

--- a/src/lib/card-shogi/__tests__/layout-metrics.test.ts
+++ b/src/lib/card-shogi/__tests__/layout-metrics.test.ts
@@ -24,6 +24,8 @@ describe("card-shogi layout metrics", () => {
     const desktop = getShogiBoardOuterSize(32, "largeDesktop");
 
     expect(mobile.gridWidth).toBe(32 * 9 + 8 + 2);
+    expect(mobile.gridHeight).toBe(mobile.cellHeight * 9 + 8 + 2);
+    expect(mobile.gridHeight).toBeGreaterThan(mobile.gridWidth);
     expect(mobile.width).toBeCloseTo(mobile.gridWidth + 2 + mobile.labelSize);
     expect(desktop.width).toBeCloseTo(desktop.gridWidth + desktop.labelSize * 2 + 8);
   });

--- a/src/lib/card-shogi/layout-metrics.ts
+++ b/src/lib/card-shogi/layout-metrics.ts
@@ -1,0 +1,163 @@
+export type CardShogiLayoutMode = "mobile" | "tablet" | "largeDesktop";
+
+export interface CardShogiViewportSpec {
+  name: string;
+  width: number;
+  height: number;
+  kind: "mobile" | "desktop";
+  deviceScaleFactor: number;
+  isMobile: boolean;
+}
+
+export interface CardBoardArea {
+  viewportWidth: number;
+  viewportHeight: number;
+  availableWidth?: number;
+  availableHeight?: number;
+  mode?: CardShogiLayoutMode;
+}
+
+export interface ShogiBoardOuterSize {
+  width: number;
+  height: number;
+  gridWidth: number;
+  gridHeight: number;
+  labelSize: number;
+}
+
+export interface CardBoardSizeResult {
+  squareSize: number;
+  mode: CardShogiLayoutMode;
+  availableWidth: number;
+  availableHeight: number;
+  board: ShogiBoardOuterSize;
+  capturedWidth: number;
+  capturedHeight: number;
+  requiredWidth: number;
+  requiredHeight: number;
+  limitingAxis: "width" | "height" | "both";
+  usedEmergencyFloor: boolean;
+}
+
+export const CARD_SHOGI_MOBILE_BREAKPOINT = 768;
+export const CARD_SHOGI_LARGE_DESKTOP_BREAKPOINT = 1280;
+
+export const CARD_SHOGI_VIEWPORT_MATRIX: CardShogiViewportSpec[] = [
+  { name: "mobile-320x568", width: 320, height: 568, kind: "mobile", deviceScaleFactor: 2, isMobile: true },
+  { name: "mobile-360x640", width: 360, height: 640, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-360x740", width: 360, height: 740, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-375x812", width: 375, height: 812, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-390x844", width: 390, height: 844, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-393x852", width: 393, height: 852, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-414x896", width: 414, height: 896, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "mobile-430x932", width: 430, height: 932, kind: "mobile", deviceScaleFactor: 3, isMobile: true },
+  { name: "desktop-1280x800", width: 1280, height: 800, kind: "desktop", deviceScaleFactor: 1, isMobile: false },
+  { name: "desktop-1366x768", width: 1366, height: 768, kind: "desktop", deviceScaleFactor: 1, isMobile: false },
+  { name: "desktop-1440x900", width: 1440, height: 900, kind: "desktop", deviceScaleFactor: 1, isMobile: false },
+  { name: "desktop-1920x1080", width: 1920, height: 1080, kind: "desktop", deviceScaleFactor: 1, isMobile: false },
+];
+
+const BOARD_CELLS = 9;
+const BOARD_GAPS = 8;
+const BOARD_BORDER = 2;
+const BOARD_TOP_LABEL_GAP = 2;
+const RANK_LABEL_GAP = 2;
+const DESKTOP_LEFT_LABEL_EXTRA = 6;
+const CAPTURED_WIDTH_EXTRA = 60;
+const CAPTURED_HEIGHT = 72;
+const CAPTURED_HEIGHT_COMPACT = 52;
+const STACK_GAP_MOBILE_TABLET = 2;
+const STACK_GAP_DESKTOP = 4;
+const TABLET_STATUS_BAR_HEIGHT = 28;
+const MIN_SQUARE_SIZE = 32;
+const EMERGENCY_MIN_SQUARE_SIZE = 26;
+const MAX_SQUARE_SIZE = 64;
+
+export function getCardShogiLayoutMode(viewportWidth: number): CardShogiLayoutMode {
+  if (viewportWidth < CARD_SHOGI_MOBILE_BREAKPOINT) return "mobile";
+  if (viewportWidth >= CARD_SHOGI_LARGE_DESKTOP_BREAKPOINT) return "largeDesktop";
+  return "tablet";
+}
+
+export function getCardShogiBoardLabelSize(squareSize: number, mode: CardShogiLayoutMode): number {
+  if (mode === "mobile") return Math.max(12, squareSize * 0.3);
+  return Math.max(16, squareSize * 0.45);
+}
+
+export function getShogiBoardOuterSize(squareSize: number, mode: CardShogiLayoutMode): ShogiBoardOuterSize {
+  const labelSize = getCardShogiBoardLabelSize(squareSize, mode);
+  const gridWidth = BOARD_CELLS * squareSize + BOARD_GAPS + BOARD_BORDER;
+  const gridHeight = gridWidth;
+  const leftSpacer = mode === "mobile" ? 0 : labelSize + DESKTOP_LEFT_LABEL_EXTRA;
+  return {
+    width: leftSpacer + gridWidth + RANK_LABEL_GAP + labelSize,
+    height: labelSize + BOARD_TOP_LABEL_GAP + gridHeight,
+    gridWidth,
+    gridHeight,
+    labelSize,
+  };
+}
+
+function getCapturedHeight(mode: CardShogiLayoutMode): number {
+  return mode === "mobile" ? CAPTURED_HEIGHT_COMPACT : CAPTURED_HEIGHT;
+}
+
+function getStackGap(mode: CardShogiLayoutMode): number {
+  return mode === "largeDesktop" ? STACK_GAP_DESKTOP : STACK_GAP_MOBILE_TABLET;
+}
+
+function getFallbackWidth(viewportWidth: number, mode: CardShogiLayoutMode): number {
+  if (mode === "largeDesktop") return Math.max(260, viewportWidth - 220 - 240 - 220 - 48);
+  return Math.max(260, Math.min(viewportWidth, 1024) - 16);
+}
+
+function getFallbackHeight(viewportHeight: number, mode: CardShogiLayoutMode): number {
+  if (mode === "largeDesktop") return Math.max(360, viewportHeight - 64);
+  if (mode === "tablet") return Math.max(360, viewportHeight - 180);
+  return Math.max(320, viewportHeight - 180);
+}
+
+function getRequiredSize(squareSize: number, mode: CardShogiLayoutMode) {
+  const board = getShogiBoardOuterSize(squareSize, mode);
+  const capturedHeight = getCapturedHeight(mode);
+  const capturedWidth = BOARD_CELLS * squareSize + CAPTURED_WIDTH_EXTRA;
+  const stackGap = getStackGap(mode);
+  const statusHeight = mode === "tablet" ? TABLET_STATUS_BAR_HEIGHT : 0;
+  const requiredWidth = Math.ceil(Math.max(board.width, capturedWidth));
+  const requiredHeight = Math.ceil(statusHeight + capturedHeight * 2 + board.height + stackGap * 2);
+  return { board, capturedHeight, capturedWidth, requiredWidth, requiredHeight };
+}
+
+export function computeCardBoardSize(area: CardBoardArea): CardBoardSizeResult {
+  const mode = area.mode ?? getCardShogiLayoutMode(area.viewportWidth);
+  const availableWidth = Math.max(0, Math.floor(area.availableWidth ?? getFallbackWidth(area.viewportWidth, mode)));
+  const availableHeight = Math.max(0, Math.floor(area.availableHeight ?? getFallbackHeight(area.viewportHeight, mode)));
+
+  let squareSize = EMERGENCY_MIN_SQUARE_SIZE;
+  for (let candidate = MAX_SQUARE_SIZE; candidate >= EMERGENCY_MIN_SQUARE_SIZE; candidate--) {
+    const required = getRequiredSize(candidate, mode);
+    if (required.requiredWidth <= availableWidth && required.requiredHeight <= availableHeight) {
+      squareSize = candidate;
+      break;
+    }
+  }
+
+  const required = getRequiredSize(squareSize, mode);
+  const widthTight = required.requiredWidth >= availableWidth - 1;
+  const heightTight = required.requiredHeight >= availableHeight - 1;
+  const limitingAxis = widthTight && heightTight ? "both" : widthTight ? "width" : "height";
+
+  return {
+    squareSize,
+    mode,
+    availableWidth,
+    availableHeight,
+    board: required.board,
+    capturedWidth: required.capturedWidth,
+    capturedHeight: required.capturedHeight,
+    requiredWidth: required.requiredWidth,
+    requiredHeight: required.requiredHeight,
+    limitingAxis,
+    usedEmergencyFloor: squareSize < MIN_SQUARE_SIZE,
+  };
+}

--- a/src/lib/card-shogi/layout-metrics.ts
+++ b/src/lib/card-shogi/layout-metrics.ts
@@ -1,3 +1,9 @@
+import {
+  SHOGI_BOARD_CELLS,
+  getShogiBoardGridSize,
+  getShogiBoardLabelSize,
+} from "@/lib/shogi/board-layout";
+
 export type CardShogiLayoutMode = "mobile" | "tablet" | "largeDesktop";
 
 export interface CardShogiViewportSpec {
@@ -22,6 +28,8 @@ export interface ShogiBoardOuterSize {
   height: number;
   gridWidth: number;
   gridHeight: number;
+  cellWidth: number;
+  cellHeight: number;
   labelSize: number;
 }
 
@@ -57,9 +65,6 @@ export const CARD_SHOGI_VIEWPORT_MATRIX: CardShogiViewportSpec[] = [
   { name: "desktop-1920x1080", width: 1920, height: 1080, kind: "desktop", deviceScaleFactor: 1, isMobile: false },
 ];
 
-const BOARD_CELLS = 9;
-const BOARD_GAPS = 8;
-const BOARD_BORDER = 2;
 const BOARD_TOP_LABEL_GAP = 2;
 const RANK_LABEL_GAP = 2;
 const DESKTOP_LEFT_LABEL_EXTRA = 6;
@@ -80,20 +85,20 @@ export function getCardShogiLayoutMode(viewportWidth: number): CardShogiLayoutMo
 }
 
 export function getCardShogiBoardLabelSize(squareSize: number, mode: CardShogiLayoutMode): number {
-  if (mode === "mobile") return Math.max(12, squareSize * 0.3);
-  return Math.max(16, squareSize * 0.45);
+  return getShogiBoardLabelSize(squareSize, mode === "mobile");
 }
 
 export function getShogiBoardOuterSize(squareSize: number, mode: CardShogiLayoutMode): ShogiBoardOuterSize {
   const labelSize = getCardShogiBoardLabelSize(squareSize, mode);
-  const gridWidth = BOARD_CELLS * squareSize + BOARD_GAPS + BOARD_BORDER;
-  const gridHeight = gridWidth;
+  const grid = getShogiBoardGridSize(squareSize);
   const leftSpacer = mode === "mobile" ? 0 : labelSize + DESKTOP_LEFT_LABEL_EXTRA;
   return {
-    width: leftSpacer + gridWidth + RANK_LABEL_GAP + labelSize,
-    height: labelSize + BOARD_TOP_LABEL_GAP + gridHeight,
-    gridWidth,
-    gridHeight,
+    width: leftSpacer + grid.width + RANK_LABEL_GAP + labelSize,
+    height: labelSize + BOARD_TOP_LABEL_GAP + grid.height,
+    gridWidth: grid.width,
+    gridHeight: grid.height,
+    cellWidth: grid.cellWidth,
+    cellHeight: grid.cellHeight,
     labelSize,
   };
 }
@@ -120,7 +125,7 @@ function getFallbackHeight(viewportHeight: number, mode: CardShogiLayoutMode): n
 function getRequiredSize(squareSize: number, mode: CardShogiLayoutMode) {
   const board = getShogiBoardOuterSize(squareSize, mode);
   const capturedHeight = getCapturedHeight(mode);
-  const capturedWidth = BOARD_CELLS * squareSize + CAPTURED_WIDTH_EXTRA;
+  const capturedWidth = SHOGI_BOARD_CELLS * squareSize + CAPTURED_WIDTH_EXTRA;
   const stackGap = getStackGap(mode);
   const statusHeight = mode === "tablet" ? TABLET_STATUS_BAR_HEIGHT : 0;
   const requiredWidth = Math.ceil(Math.max(board.width, capturedWidth));

--- a/src/lib/dev/card-shogi-layout-fixtures.ts
+++ b/src/lib/dev/card-shogi-layout-fixtures.ts
@@ -1,0 +1,138 @@
+import { createInitialGameState } from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { MANA_CAP } from "@/lib/shogi/cards/definitions";
+import type { CardGameState, CardId, CardInstance, TrapInstance } from "@/lib/shogi/cards/types";
+import type { GameState, Hand } from "@/lib/shogi/types";
+
+export type CardShogiLayoutScenario =
+  | "initial"
+  | "progress1"
+  | "progress4"
+  | "many-hands"
+  | "captured"
+  | "trap"
+  | "drawer"
+  | "end";
+
+export const CARD_SHOGI_LAYOUT_SCENARIOS: CardShogiLayoutScenario[] = [
+  "initial",
+  "progress1",
+  "progress4",
+  "many-hands",
+  "captured",
+  "trap",
+  "drawer",
+  "end",
+];
+
+interface CardShogiLayoutFixture {
+  gameState: GameState;
+  cardState: CardGameState;
+  debugInitialUi: {
+    drawerOpen?: boolean;
+    endCardMinimized?: boolean;
+  };
+}
+
+function card(instanceId: string, defId: CardId): CardInstance {
+  return { instanceId, defId };
+}
+
+function cards(prefix: string, ids: CardId[]): CardInstance[] {
+  return ids.map((id, i) => card(`${prefix}-${i + 1}-${id}`, id));
+}
+
+function makeDeck(prefix: string, count: number): CardInstance[] {
+  const ids: CardId[] = ["pawn_return", "double_pawn", "piece_return", "check_break", "double_move", "no_promote"];
+  return Array.from({ length: count }, (_, i) => card(`${prefix}-deck-${i + 1}`, ids[i % ids.length]));
+}
+
+function makeCardState(scenario: CardShogiLayoutScenario): CardGameState {
+  const manyOwnCards = cards("sente-hand", [
+    "pawn_return",
+    "double_pawn",
+    "piece_return",
+    "check_break",
+    "double_move",
+    "no_promote",
+    "pawn_return",
+    "double_pawn",
+  ]);
+  const manyOpponentCards = cards("gote-hand", [
+    "pawn_return",
+    "double_pawn",
+    "piece_return",
+    "check_break",
+    "double_move",
+    "no_promote",
+    "pawn_return",
+    "double_pawn",
+    "piece_return",
+    "check_break",
+  ]);
+  const baseHand = scenario === "many-hands" || scenario === "drawer"
+    ? { sente: manyOwnCards, gote: manyOpponentCards }
+    : {
+        sente: cards("sente-hand", ["pawn_return", "double_pawn", "piece_return"]),
+        gote: cards("gote-hand", ["check_break", "double_move", "no_promote"]),
+      };
+  const trap: TrapInstance | null = scenario === "trap"
+    ? { instanceId: "sente-trap-check-break", defId: "check_break", owner: "sente" }
+    : null;
+
+  return {
+    mana: { sente: 8, gote: 6 },
+    manaCap: MANA_CAP,
+    hand: baseHand,
+    deck: { sente: makeDeck("sente", 18), gote: makeDeck("gote", 18) },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: trap, gote: scenario === "trap" ? { instanceId: "gote-trap-no-promote", defId: "no_promote", owner: "gote" } : null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    drawProgress:
+      scenario === "progress4"
+        ? { sente: 4, gote: 4 }
+        : scenario === "progress1"
+          ? { sente: 1, gote: 1 }
+          : { sente: 0, gote: 0 },
+  };
+}
+
+function makeGameState(scenario: CardShogiLayoutScenario): GameState {
+  const state = createInitialGameState(CARD_SHOGI_VARIANT);
+  state.moveCount = scenario === "initial" ? 0 : 24;
+  state.currentPlayer = "sente";
+
+  if (scenario === "captured" || scenario === "many-hands" || scenario === "drawer") {
+    state.hand = {
+      sente: { pawn: 4, gold: 1, silver: 1, bishop: 1 },
+      gote: { pawn: 3, lance: 1, knight: 1, rook: 1 },
+    } satisfies Hand;
+  }
+
+  if (scenario === "end") {
+    state.status = "resign";
+    state.winner = "sente";
+  }
+
+  return state;
+}
+
+export function normalizeCardShogiLayoutScenario(value: unknown): CardShogiLayoutScenario {
+  if (typeof value !== "string") return "initial";
+  return CARD_SHOGI_LAYOUT_SCENARIOS.includes(value as CardShogiLayoutScenario)
+    ? (value as CardShogiLayoutScenario)
+    : "initial";
+}
+
+export function getCardShogiLayoutFixture(scenario: CardShogiLayoutScenario): CardShogiLayoutFixture {
+  return {
+    gameState: makeGameState(scenario),
+    cardState: makeCardState(scenario),
+    debugInitialUi: {
+      drawerOpen: scenario === "drawer",
+      endCardMinimized: false,
+    },
+  };
+}

--- a/src/lib/shogi/__tests__/board-layout.test.ts
+++ b/src/lib/shogi/__tests__/board-layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SHOGI_BOARD_CELLS,
+  SHOGI_BOARD_GAP,
+  getShogiBoardCellSize,
+  getShogiBoardGridSize,
+  getShogiBoardLabelSize,
+} from "../board-layout";
+
+describe("shogi board layout", () => {
+  it("keeps board cells slightly portrait while staying on integer pixels", () => {
+    expect(getShogiBoardCellSize(40)).toEqual({ width: 40, height: 43 });
+    expect(getShogiBoardCellSize(64)).toEqual({ width: 64, height: 69 });
+  });
+
+  it("derives the visible grid size from cell width, cell height, gaps, and borders", () => {
+    const grid = getShogiBoardGridSize(40);
+
+    expect(grid.width).toBe(SHOGI_BOARD_CELLS * 40 + (SHOGI_BOARD_CELLS - 1) * SHOGI_BOARD_GAP + 2);
+    expect(grid.height).toBe(SHOGI_BOARD_CELLS * 43 + (SHOGI_BOARD_CELLS - 1) * SHOGI_BOARD_GAP + 2);
+    expect(grid.height).toBeGreaterThan(grid.width);
+  });
+
+  it("uses integer label sizes to avoid sub-pixel board offsets", () => {
+    expect(getShogiBoardLabelSize(35, true)).toBe(12);
+    expect(getShogiBoardLabelSize(57, false)).toBe(26);
+  });
+});

--- a/src/lib/shogi/board-layout.ts
+++ b/src/lib/shogi/board-layout.ts
@@ -1,0 +1,42 @@
+export const SHOGI_BOARD_CELLS = 9;
+export const SHOGI_BOARD_GAP = 1;
+export const SHOGI_BOARD_BORDER = 2;
+export const SHOGI_BOARD_CELL_HEIGHT_RATIO = 1.08;
+
+export interface ShogiBoardCellSize {
+  width: number;
+  height: number;
+}
+
+export interface ShogiBoardGridSize {
+  width: number;
+  height: number;
+  cellWidth: number;
+  cellHeight: number;
+  gap: number;
+  border: number;
+}
+
+export function getShogiBoardCellSize(baseSize: number): ShogiBoardCellSize {
+  const width = Math.max(1, Math.floor(baseSize));
+  const height = Math.max(width + 1, Math.round(width * SHOGI_BOARD_CELL_HEIGHT_RATIO));
+  return { width, height };
+}
+
+export function getShogiBoardGridSize(baseSize: number): ShogiBoardGridSize {
+  const cell = getShogiBoardCellSize(baseSize);
+  const innerGaps = (SHOGI_BOARD_CELLS - 1) * SHOGI_BOARD_GAP;
+  return {
+    width: SHOGI_BOARD_CELLS * cell.width + innerGaps + SHOGI_BOARD_BORDER,
+    height: SHOGI_BOARD_CELLS * cell.height + innerGaps + SHOGI_BOARD_BORDER,
+    cellWidth: cell.width,
+    cellHeight: cell.height,
+    gap: SHOGI_BOARD_GAP,
+    border: SHOGI_BOARD_BORDER,
+  };
+}
+
+export function getShogiBoardLabelSize(baseSize: number, isMobile: boolean): number {
+  const labelSize = isMobile ? Math.max(12, baseSize * 0.3) : Math.max(16, baseSize * 0.45);
+  return Math.round(labelSize);
+}


### PR DESCRIPTION
## Summary
- Issue #134 の前提を、iPhone17e 限定ではなく基本的なモバイル端末全般と PC に耐えるカード将棋レイアウト基盤へ更新
- viewport / safe area / DOM 実測に基づく盤面サイズ計算、開発用検証ページ、headless Chrome レイアウト監査を追加
- 盤マスと駒を実際の将棋盤に寄せて少し縦長にし、描画・タップ判定・駒フライト・layout metrics を共通 helper に集約
- モバイル手札ドロワー、終局カード、SVG/CSS 境界整合、主要 DOM 監査属性を調整

## Test plan
- `pnpm exec eslint scripts/card-shogi-layout-audit.mjs src/lib/shogi/board-layout.ts src/lib/shogi/__tests__/board-layout.test.ts src/lib/card-shogi/layout-metrics.ts src/lib/card-shogi/__tests__/layout-metrics.test.ts src/components/game/shogi-board.tsx src/components/game/card-shogi/piece-flight.tsx src/components/game/card-shogi/card-shogi-game.tsx src/hooks/use-touch-handler.ts src/hooks/use-board-size.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test:ci -- src/hooks/card-shogi/__tests__/undo-policy.test.ts src/hooks/card-shogi/__tests__/reducer.test.ts src/lib/shogi/cards/__tests__/effects.test.ts src/lib/card-shogi/__tests__/layout-metrics.test.ts src/lib/shogi/__tests__/board-layout.test.ts`
- `pnpm test:layout:card-shogi`
- `pnpm build`
- 390x844 screenshot で縦長マス表示を確認

## Notes
- `pnpm lint` 全体は既存の unrelated lint error が残っているため失敗するが、今回変更ファイルの個別 lint は通過済み

Closes #134
