### PR TITLE
fix: 待った後ボタン活性残存を修正 (Issue #149)

### DIFF
--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -9,7 +9,6 @@ import { ChevronUp, ChevronDown, Volume2, VolumeX } from "lucide-react";
 import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
 import { useSound } from "@/hooks/use-sound";
 import { useCardBoardSize } from "@/hooks/use-card-board-size";
-import { getUndoScope } from "@/hooks/card-shogi/undo-policy";
 
 import { ShogiBoard, type ShogiBoardHandle } from "../shogi-board";
 import { CapturedPieces } from "../captured-pieces";
@@ -287,6 +286,7 @@ export function CardShogiGame({
     promotionPendingMove,
     cardState,
     eventLog,
+    canUndo: hookCanUndo,
     selectSquare,
     selectHandPiece,
     confirmPromotion,
@@ -1064,18 +1064,19 @@ export function CardShogiGame({
   // Issue #82 (二手指し): 二手指し中は手札・ドローも無効化 (reducer 側でも弾くが UI でも明示)
   const handDisabled = !isPlayerTurn || !isGameActive || cardState.pendingCard !== null || isDrawAnimating || isPlayingCard || isCheckBreakAnimating || doubleMove !== null;
 
-  // 待った可否 (P28): 駒指し2手以上 / 自分の手番 / AI 思考中でない / pendingCard 無し /
-  // 過去2ターンにカード操作なし。
-  // Issue #82 (二手指し): 二手指し中は通常の「待った」を不可。
-  // スコープ判定は reducer の UNDO ケースと共通化 (undo-policy.ts)。
+  // 待った可否 (Issue #149: ヘルパ集約版):
+  // - reducer 内部条件 (moveHistory >= 2 / undoSnapshots >= 2 / pendingCard なし / doubleMove なし
+  //   / getUndoScope 非 null) はフックの `hookCanUndo` (= undo-policy.canUndoFromState) に集約。
+  // - UI 固有条件 (isPlayerTurn / isAiThinking) のみここで wrap する。
+  // 旧実装は reducer 内部条件を UI 側で再実装していたが、`undoSnapshots.length >= 2` チェックが
+  // 抜けており、待った 1 回直後にボタン活性のまま無反応 (reducer 側だけ no-op) になる問題が発生。
+  // ヘルパ集約により UI/reducer の判定ズレを構造的に防ぐ。
   const canUndo = useMemo(() => {
-    if (gameState.moveHistory.length < 2) return false;
+    if (!hookCanUndo) return false;
     if (!isPlayerTurn) return false;
     if (isAiThinking) return false;
-    if (cardState.pendingCard) return false;
-    if (doubleMove) return false;
-    return getUndoScope(eventLog) !== null;
-  }, [gameState.moveHistory.length, isPlayerTurn, isAiThinking, cardState.pendingCard, doubleMove, eventLog]);
+    return true;
+  }, [hookCanUndo, isPlayerTurn, isAiThinking]);
 
   // 歩戻し等のターゲット選択時にハイライトする盤面マス
   // (Issue #132): 以前は effectId 別に手書き判定 + 末尾で王手回避フィルタを掛けていたが、

--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -639,6 +639,66 @@ describe("reducer / UNDO", () => {
     const next = reducer(state, { type: "UNDO" });
     expect(next).toBe(state);
   });
+
+  // ===== Issue #149: 連続 UNDO の構造的ブロック (UI/reducer 判定統合) =====
+
+  it("Issue #149: 1 回 UNDO 直後の連続 UNDO は no-op (snapshot ring 枯渇による)", () => {
+    // 旧バグ: 1 回 UNDO 後、eventLog は 2 ply 前の状態に復元されるため getUndoScope は依然
+    // 非 null を返す。一方 undoSnapshots は slice(0,-2) で空になる。UI 側 canUndo memo は
+    // undoSnapshots の状態を見ていなかったため「ボタン活性表示のまま、押しても reducer が
+    // no-op で何も起きない」状態が発生していた。
+    //
+    // 本テストは「1 回目の UNDO は成功し、2 回目は state 不変 (no-op)」を検証する。
+    // ヘルパ集約 (canUndoFromState) で UI/reducer の判定を統一したことで、フックから返る
+    // canUndo も 2 回目で false になり、UI/reducer 双方で挙動が一致する (= ボタン非活性 +
+    // reducer no-op が同期する) ことが構造的に保証される。
+    const senteMove = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "pawn",
+      from: { row: 6, col: 4 },
+      to: { row: 5, col: 4 },
+    };
+    const goteMove = {
+      type: "move" as const,
+      player: "gote" as const,
+      piece: "pawn",
+      from: { row: 2, col: 4 },
+      to: { row: 3, col: 4 },
+    };
+    const snap0Game = makeInitialState().gameState;
+    const snap1Game = { ...makeInitialState().gameState, moveHistory: [senteMove] };
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState(),
+      gameState: {
+        ...makeInitialState().gameState,
+        moveHistory: [senteMove, goteMove],
+      },
+      eventLog: [
+        { kind: "moveEvent", move: senteMove, at: 0 },
+        { kind: "moveEvent", move: goteMove, at: 1 },
+      ],
+      undoSnapshots: [
+        { gameState: snap0Game, cardState: makeInitialCardState(), eventLog: [] },
+        {
+          gameState: snap1Game,
+          cardState: makeInitialCardState(),
+          eventLog: [{ kind: "moveEvent", move: senteMove, at: 0 }],
+        },
+      ],
+    };
+
+    // 1 回目: 成立して snapshot[0] (= 初期局面) に復元、ring は空になる
+    const after1st = reducer(state, { type: "UNDO" });
+    expect(after1st).not.toBe(state);
+    expect(after1st.undoSnapshots).toEqual([]);
+    expect(after1st.gameState.moveHistory).toEqual([]);
+
+    // 2 回目: ring が空なので canUndoFromState で false、reducer は state 不変
+    // (= 旧バグ「ボタン活性のまま無反応」を構造的に再発させない回帰防止)
+    const after2nd = reducer(after1st, { type: "UNDO" });
+    expect(after2nd).toBe(after1st);
+  });
 });
 
 describe("reducer / RESET_TURN_TIMER", () => {

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -50,7 +50,7 @@ import {
   moveNoPromoteMark,
   hasSameKindTrapPlaced,
 } from "@/lib/shogi/cards/effects";
-import { getUndoScope } from "./undo-policy";
+import { canUndoFromState } from "./undo-policy";
 
 export type ShogiAction =
   | { type: "SELECT_SQUARE"; pos: Position }
@@ -935,34 +935,21 @@ export function reducer(
     }
 
     case "UNDO": {
-      // Issue #82 (二手指し): 二手指し中は通常の「待った」を不可。
-      // 1手目戻しは UNDO_DOUBLE_MOVE_FIRST 専用アクションを使う。
-      if (state.doubleMove) return state;
-
-      // Issue #132: 待った = スナップショット復元方式 (旧: createInitialGameState + replay)。
-      // 旧実装はカード効果 (歩戻し / 駒戻し / 二歩指し / 王手崩し / no_promote / トラップ /
-      // 手札・山札・墓地) を moveHistory から再現できないため、UNDO 時に消失していた。
-      // また getUndoScope の 2 ターンスコープ走査が cardOp に到達する前に break するケースで、
-      // cardOp guard を素通りして UNDO が許可される結果、戻したはずの駒が盤上に復活する事象も発生。
-      // スナップショット方式は state 全量を保持するため、scope-bounds の漏れに依存せず常に正しく復元する。
+      // Issue #149: 待った可否ガードを undo-policy.canUndoFromState() に集約。
+      // ガード条件 (二手指し中除外 / moveHistory >= 2 / undoSnapshots >= 2 / pendingCard なし /
+      //  getUndoScope 非 null) の単一情報源化により、UI 側の canUndo memo と
+      // reducer 側のガードが分裂してズレることを構造的に防ぐ (旧バグ: 1 回 UNDO 直後に
+      // ボタン活性のまま無反応 = reducer 側のみ undoSnapshots 不足を検知していた事象)。
       //
-      // 復元手順:
-      // 1. ring に 2 件以上の snapshot がある (= 直近 2 ply 分) こと
-      // 2. cardOp guard (getUndoScope) は引き続き保持。これは「カード操作直後はその効果を
-      //    取り消せない (= カード使用は確定アクション)」という仕様 UX を維持するため。
-      //    snapshot 自体はカード効果も保持しているので、guard を外すと「カード後の自分の手だけ
-      //    取り消し」が可能になり、cardOp 直後は「カードを残しつつ移動だけ取り消し」できてしまう。
-      //    UI の canUndo memo と整合させるため guard は維持する。
-      // 3. snapshots[0] (= 2 ply 前の状態) を gameState/cardState/eventLog に丸ごと適用
-      // 4. ring を空に戻し、UI 一時 state・演出フラグをすべてクリア
+      // Issue #132 仕様 (待った = スナップショット復元方式) は維持:
+      // - snapshots[0] (= 2 ply 前) を gameState/cardState/eventLog に丸ごと適用
+      // - ring を空に戻し、UI 一時 state・演出フラグをすべてクリア
+      // - リロード後 (undoSnapshots: []) は canUndoFromState で弾かれて待った不可
       //
-      // リロード後 (undoSnapshots: []) は条件 1 で弾かれて「待った 不可」となる。
-      // これは Issue #132 の仕様 (リロード直後はスナップショットがないため待った不可) 通り。
-      const history = state.gameState.moveHistory;
-      if (history.length < 2) return state;
-      if (state.undoSnapshots.length < 2) return state;
-      const scopeStartIndex = getUndoScope(state.eventLog);
-      if (scopeStartIndex === null) return state;
+      // cardOp guard (getUndoScope) を引き続き保持する理由は Issue #132 と同じ:
+      // 「カード使用は確定アクション。カード直後の手だけ取り消すことは UI 仕様上許可しない」
+      // ため、snapshot に カード効果が残っていても eventLog の scope 判定で block する。
+      if (!canUndoFromState(state)) return state;
 
       const target = state.undoSnapshots[state.undoSnapshots.length - 2];
       return {

--- a/src/hooks/card-shogi/undo-policy.ts
+++ b/src/hooks/card-shogi/undo-policy.ts
@@ -84,3 +84,46 @@ export function getUndoScope(eventLog: GameEvent[]): number | null {
   if (scopeStartIndex < 0) return null;
   return scopeStartIndex;
 }
+
+/**
+ * 待った可否判定に必要な reducer 内部 state の最小 shape (Issue #149)。
+ *
+ * CardShogiGameStateInternal はこの shape に structural に互換。
+ * undo-policy.ts → reducer.ts の型循環参照を避けるため、最小 structural type を
+ * ここで定義する (length / null チェックしか行わないため `object | null` で十分)。
+ */
+export interface UndoEligibilityState {
+  doubleMove: object | null;
+  gameState: { moveHistory: { length: number } };
+  undoSnapshots: { length: number };
+  cardState: { pendingCard: object | null };
+  eventLog: GameEvent[];
+}
+
+/**
+ * 待った可能か判定する共通ヘルパ (Issue #149)。
+ *
+ * 呼び出し元は reducer の UNDO ケース冒頭ガードと、UI から参照されるフック return の両方。
+ * これにより UI/reducer の判定ズレ (Issue #149 の根本原因 = `undoSnapshots.length >= 2`
+ * チェックが reducer 側にしか存在せず、UI ボタンが活性表示のまま無反応になる事象) を
+ * 構造的に防ぐ。
+ *
+ * 判定条件 (reducer 内部条件):
+ * - 二手指し中ではない (`doubleMove === null`)
+ * - 駒指し履歴が 2 ply 以上
+ * - スナップショットリングが 2 件以上 (= 直近 2 ply 分の状態が保持されている)
+ *   → 1 回 UNDO 直後はリングが空になるので、次の UNDO はここで弾かれる
+ * - カード使用 pending 中ではない
+ * - eventLog 上で getUndoScope が非 null (cardOp ブロック通過 + 過去 2 ターン分のスコープ確保)
+ *
+ * UI 固有条件 (isPlayerTurn / isAiThinking) は UI 側で別途 wrap する。
+ * これらは reducer 内部 state からは導出できない (AI 戦で playerColor を外から渡される) ため。
+ */
+export function canUndoFromState(state: UndoEligibilityState): boolean {
+  if (state.doubleMove !== null) return false;
+  if (state.gameState.moveHistory.length < 2) return false;
+  if (state.undoSnapshots.length < 2) return false;
+  if (state.cardState.pendingCard !== null) return false;
+  if (getUndoScope(state.eventLog) === null) return false;
+  return true;
+}

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -19,6 +19,7 @@ import { isValidCardTargetSquare } from "@/lib/shogi/cards/effects";
 // reducer 関数本体) は src/hooks/card-shogi/reducer.ts に分離。本ファイルは
 // useReducer + useEffect + useCallback の薄いフックとして公開 API のみを担う。
 import { reducer } from "./card-shogi/reducer";
+import { canUndoFromState } from "./card-shogi/undo-policy";
 
 interface UseCardShogiGameOptions {
   initialState: GameState;
@@ -424,6 +425,9 @@ export function useCardShogiGame({
     promotionPendingMove: state.promotionPendingMove,
     cardState: state.cardState,
     eventLog: state.eventLog,
+    // Issue #149: 待った可能か (reducer 内部条件のみ)。UI 側で isPlayerTurn / isAiThinking と
+    // 合わせて最終判定する。undoSnapshots 自体は公開せず派生値のみ公開し API を最小化。
+    canUndo: canUndoFromState(state),
     selectSquare,
     selectHandPiece,
     confirmPromotion,


### PR DESCRIPTION
## Summary

- `undo-policy.ts` に `canUndoFromState` ヘルパを追加し、待った可否判定の 5 条件 (doubleMove / moveHistory / undoSnapshots / pendingCard / getUndoScope) を単一情報源に集約
- reducer の UNDO ガードをヘルパ呼び出しに統一
- `useCardShogiGame` の return に `canUndo: canUndoFromState(state)` を追加し、undoSnapshots 自体は非公開
- UI の canUndo memo を UI 固有条件 (isPlayerTurn / isAiThinking) のみの wrap に縮小
- `reducer.test.ts` に「1 回 UNDO 直後の連続 UNDO は no-op」回帰テストを追加

## Test plan

- [x] `pnpm test:ci` 緑 (新規テスト含む)
- [x] Vercel preview で待った 1 回実行後、ボタンが非活性になることを確認 (PC / タブレット / モバイル 3 viewport)
- [x] 既存の待った・歩戻し動作に影響なし

Closes #149

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJshfG6czdiKtJ7htgxzSD)_