### PR TITLE
対局履歴時刻をJST固定にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ci": "vitest run",
     "test:layout:card-shogi": "node scripts/card-shogi-layout-audit.mjs",

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -9,6 +9,7 @@ import { getCharacterById } from "@/data/characters";
 import Link from "next/link";
 import { ArrowLeft, Inbox } from "lucide-react";
 import { AppBackground } from "@/components/layout/app-background";
+import { formatHistoryDateTime } from "@/lib/date-format";
 
 export default async function HistoryPage() {
   const games = await getGameHistory();
@@ -53,13 +54,7 @@ export default async function HistoryPage() {
                         <div>
                           <p className="font-medium text-sm">{character.name}との対局</p>
                           <p className="text-xs text-muted-foreground">
-                            {new Date(game.createdAt).toLocaleDateString("ja-JP", {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric",
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })}
+                            {formatHistoryDateTime(game.createdAt)}
                           </p>
                         </div>
                       </div>

--- a/src/lib/__tests__/date-format.test.ts
+++ b/src/lib/__tests__/date-format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { formatHistoryDateTime } from "@/lib/date-format";
+
+describe("formatHistoryDateTime", () => {
+  it("UTCの日時をJSTで表示する", () => {
+    expect(formatHistoryDateTime("2026-01-01T00:05:00.000Z")).toBe("2026年1月1日 09:05");
+  });
+
+  it("Dateオブジェクトでも実行環境のタイムゾーンに依存しない", () => {
+    expect(formatHistoryDateTime(new Date("2026-05-06T14:12:25.000Z"))).toBe(
+      "2026年5月6日 23:12"
+    );
+  });
+});

--- a/src/lib/date-format.ts
+++ b/src/lib/date-format.ts
@@ -1,0 +1,15 @@
+const JAPAN_TIME_ZONE = "Asia/Tokyo";
+
+const historyDateTimeFormatter = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: JAPAN_TIME_ZONE,
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+export function formatHistoryDateTime(value: Date | string | number): string {
+  return historyDateTimeFormatter.format(new Date(value));
+}


### PR DESCRIPTION
## Summary

- 対局履歴画面の日時表示をJST固定の共通フォーマッタ経由に変更
- サーバー環境のタイムゾーンに依存してUTC表示になる問題を防止
- UTC入力がJSTで表示される回帰テストを追加
- 必須チェック用に `npm run typecheck` スクリプトを追加

## Test plan

- `npm run lint` は既存の未変更ファイル由来のReact Hooks/Compiler系エラーで失敗
- `npm run lint -- src/app/history/page.tsx src/lib/date-format.ts src/lib/__tests__/date-format.test.ts` 成功
- `npm run typecheck` 成功
- `npm run test` 成功
- `npm run build` 成功（初回はsandboxの外部通信制限でGoogle Fonts取得失敗、許可付き再実行で成功）

Closes #156