### PR TITLE
ローディング表面の駒字をモバイルで縮小 (Issue #162)

### DIFF
--- a/src/components/game/shogi-piece.tsx
+++ b/src/components/game/shogi-piece.tsx
@@ -37,6 +37,12 @@ interface ShogiPieceProps {
   // 2 文字以上を渡すと自動で縦書き (writing-mode: vertical-rl) にし、
   // フォントサイズも自動で縮める。
   kanjiOverride?: string;
+  // Issue #162: 駒の文字 fontSize を強制指定。isLarge / isSmall / squareSize
+  // のいずれの算出よりも優先される。LoadingCardFace のように親要素のサイズが
+  // メディアクエリで動的に変わる環境で、文字サイズだけ細かく調整したい用途。
+  // 未指定時は従来の算出ロジックがそのまま走るため、対局画面・持ち駒・
+  // ダイアログには影響しない。
+  fontSizeOverride?: number;
 }
 
 // 五角形の頂点座標（viewBox 0 0 100 100 基準）
@@ -111,6 +117,7 @@ export const ShogiPiece = memo(function ShogiPiece({
   squareSize,
   colorOverride,
   kanjiOverride,
+  fontSizeOverride,
 }: ShogiPieceProps) {
   const kanji = kanjiOverride ?? getPieceKanji(piece.type);
   const isMultiChar = kanji.length > 1;
@@ -145,8 +152,9 @@ export const ShogiPiece = memo(function ShogiPiece({
 
   // フォントサイズの計算。複数文字 (例: "香車") のときは縦書きにし、
   // 1 文字目安より小さく (約 65%) して駒シルエットに収まるよう調整する。
+  // Issue #162: fontSizeOverride 指定時は他の算出を全て無視して直接採用する。
   const multiCharScale = 0.65;
-  const fontSize = isLarge
+  const fontSize = fontSizeOverride ?? (isLarge
     ? (isMultiChar ? Math.round(48 * multiCharScale) : 48)
     : isSmall
       ? (isMultiChar ? Math.round(14 * multiCharScale) : 14)
@@ -155,7 +163,7 @@ export const ShogiPiece = memo(function ShogiPiece({
             isMultiChar ? 8 : 12,
             squareSize * (isMultiChar ? 0.45 * multiCharScale : 0.45),
           )
-        : (isMultiChar ? Math.round(18 * multiCharScale) : 18);
+        : (isMultiChar ? Math.round(18 * multiCharScale) : 18));
 
   // isSmall（持ち駒・ダイアログ用）の場合は固定サイズ、盤上は駒種別サイズ
   const sizeClass = isSmall

--- a/src/components/loading/loading-card-visual.tsx
+++ b/src/components/loading/loading-card-visual.tsx
@@ -104,6 +104,29 @@ const LOADING_PIECE_COLOR_OVERRIDE = {
   ],
 } as const;
 
+// Issue #162: モバイル判定 (sm breakpoint < 640px)。
+// ShogiPiece の isLarge fontSize (multichar 31px / 1 文字 48px) はカード幅
+// 240px 想定の値で、モバイルで縮んだカード (~156px) には大きすぎる。
+// モバイル時のみ fontSizeOverride で 22px に縮める (PC は undefined のまま現状維持)。
+const MOBILE_LOADING_FONT_SIZE = 22;
+const MOBILE_BREAKPOINT_QUERY = "(max-width: 639px)";
+
+function useIsMobileViewport(): boolean {
+  // SSR では window が無いので false で初期化 (= PC 表示)。ハイドレーション後の
+  // effect で正しい値に再評価される。一瞬の差し替えはローディング表示なので許容。
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches;
+  });
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
+    const onChange = () => setIsMobile(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+  return isMobile;
+}
+
 // 表面: 裏面と同じ「金フレーム + 中央スポット + 中央駒」の世界観を保ちつつ、
 // 背景は loading-card-face-bg (完全な黒地 + 中央楕円の白スポット) で漆 (minimal)
 // とは別パターンに差別化する。中央駒は対局駒の淡いデフォルトとは分け、ローディング
@@ -114,7 +137,9 @@ const LOADING_PIECE_COLOR_OVERRIDE = {
 //   - 背景: loading-card-face-bg (globals.css の専用 class)
 //   - 中央: ランダム駒シルエット (ShogiPiece + ローディング用 colorOverride
 //     + 正式名称の縦書き)
+//   - Issue #162: モバイルでは駒字 fontSize を 22px に縮小 (PC は現状維持)
 function LoadingCardFace({ pieceType }: LoadingCardFaceProps) {
+  const isMobile = useIsMobileViewport();
   return (
     <div
       className={cn(
@@ -140,6 +165,7 @@ function LoadingCardFace({ pieceType }: LoadingCardFaceProps) {
             isLarge
             colorOverride={LOADING_PIECE_COLOR_OVERRIDE}
             kanjiOverride={LOADING_FACE_PIECE_LABEL[pieceType]}
+            fontSizeOverride={isMobile ? MOBILE_LOADING_FONT_SIZE : undefined}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Issue #155 の派生で、ローディングカード表面 (`LoadingCardFace`) の駒字
(例: 「香車」) がモバイルで相対的に大きすぎる問題に対応。

### 修正
- **`shogi-piece.tsx`**: `ShogiPieceProps` に `fontSizeOverride?: number` を
  追加。指定時は `isLarge` / `isSmall` / `squareSize` の算出を全て無視して
  直接採用する汎用機構。未指定箇所 (対局画面・持ち駒・ダイアログ・カード
  将棋フライト) は影響なし。
- **`loading/loading-card-visual.tsx`**: `useIsMobileViewport` フック追加
  (`window.matchMedia("(max-width: 639px)")` 監視、SSR 安全)。
  `LoadingCardFace` でモバイル時のみ `fontSizeOverride={22}` を渡し、PC は
  `undefined` のまま現状の 31px (multichar) を維持。

## Test plan
- [x] `npx tsc --noEmit` エラー 0 件
- [x] `npx eslint` で新規エラー 0 件
- [ ] Vercel preview deployment ビルド成功
- [ ] モバイル実機 (iPhone) でローディング表面の駒字 22px ≒ 適正サイズ確認
- [ ] PC で駒字が現状の 31px のまま変化しないこと確認
- [ ] 対局画面の駒に変化なし (`fontSizeOverride` 未指定)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
