### PR TITLE
feat: #163 ページ遷移時ローディングマスク必須化

### DIFF
--- a/src/app/card-design/page.tsx
+++ b/src/app/card-design/page.tsx
@@ -3,10 +3,10 @@
 // 結果は山札 (deck-pile.tsx) と相手手札裏 (card-view.tsx) にリアルタイムで反映される。
 "use client";
 
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 import { useCardBackStyle } from "@/components/card-back/card-back-provider";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import {
   CARD_BACK_STYLES,
   CARD_BACK_STYLE_LIST,
@@ -96,14 +96,15 @@ export default function CardDesignPage() {
           下のリストが透けないようにする。 */}
       <header className="sticky top-0 z-40 bg-background/90 backdrop-blur-sm border-b border-border/50">
         <div className="max-w-5xl mx-auto px-4 py-3 sm:py-4 w-full flex items-center gap-3">
-          <Link
+          <MaskedLink
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
+            loadingMessage="ホームへ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム
-          </Link>
+          </MaskedLink>
           <div className="flex-1">
             <h1 className="text-xl sm:text-2xl font-bold tracking-tight">
               カードデザイン

--- a/src/app/card-design/page.tsx
+++ b/src/app/card-design/page.tsx
@@ -100,6 +100,7 @@ export default function CardDesignPage() {
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
+            loadingVariant="spinner"
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム

--- a/src/app/card-design/page.tsx
+++ b/src/app/card-design/page.tsx
@@ -100,7 +100,6 @@ export default function CardDesignPage() {
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
-            loadingMessage="ホームへ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム

--- a/src/app/cards/[id]/page.tsx
+++ b/src/app/cards/[id]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -14,6 +13,7 @@ import {
 import type { CardId } from "@/lib/shogi/cards/types";
 import { cn } from "@/lib/utils";
 import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 interface CardDetailPageProps {
   params: Promise<{ id: string }>;
@@ -45,14 +45,15 @@ export default async function CardDetailPage({ params }: CardDetailPageProps) {
       <div className="max-w-4xl mx-auto px-4 pt-4 sm:pt-6 pb-2 w-full flex flex-col flex-1 min-h-0">
         {/* 戻るリンク + 名前 (固定) */}
         <header className="flex items-center gap-3 mb-3 sm:mb-4 shrink-0">
-          <Link
+          <MaskedLink
             href="/cards"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="カード一覧へ戻る"
+            loadingMessage="カード一覧へ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             カード一覧
-          </Link>
+          </MaskedLink>
           <div className="flex-1">
             <h1 className="text-xl sm:text-2xl font-bold tracking-tight">{def.name}</h1>
             <p className="text-xs sm:text-sm text-muted-foreground font-mono">{def.id}</p>

--- a/src/app/cards/[id]/page.tsx
+++ b/src/app/cards/[id]/page.tsx
@@ -49,7 +49,6 @@ export default async function CardDetailPage({ params }: CardDetailPageProps) {
             href="/cards"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="カード一覧へ戻る"
-            loadingMessage="カード一覧へ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             カード一覧

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { CardCatalogGrid } from "@/components/cards/card-catalog-grid";
 import { ALL_CARD_DEFS } from "@/lib/shogi/cards/definitions";
 import { AppBackground } from "@/components/layout/app-background";
 import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 export const metadata = {
   title: "カード一覧 | カード将棋",
@@ -19,14 +19,15 @@ export default function CardsPage() {
           スクロール時に下のリストが透けないようにし、border-b で領域を分離。 */}
       <header className="shrink-0 bg-background/90 backdrop-blur-sm border-b border-border/50">
         <div className="max-w-4xl mx-auto px-4 py-3 sm:py-4 w-full flex items-center gap-3">
-          <Link
+          <MaskedLink
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
+            loadingMessage="ホームへ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム
-          </Link>
+          </MaskedLink>
           <div className="flex-1">
             <h1 className="text-xl sm:text-2xl font-bold tracking-tight">カード一覧</h1>
             <p className="text-xs sm:text-sm text-muted-foreground">

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -23,6 +23,7 @@ export default function CardsPage() {
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
+            loadingVariant="spinner"
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -23,7 +23,6 @@ export default function CardsPage() {
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             aria-label="ホームへ戻る"
-            loadingMessage="ホームへ戻っています..."
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム

--- a/src/app/classic/page.tsx
+++ b/src/app/classic/page.tsx
@@ -1,12 +1,12 @@
 // Issue #117: 通常将棋の対局相手・手番選択画面 (旧ホーム相当、モードタブなし)。
 // 新ホーム (/) は card-shogi トップに作り変えたため、standard モードの専用導線として分離。
-import Link from "next/link";
 import { ArrowLeft, History } from "lucide-react";
 import { MatchSetup } from "@/components/home/match-setup";
 import { AppBackground } from "@/components/layout/app-background";
 import { PageMotion } from "@/components/layout/page-motion";
 import { ThemeSelector } from "@/components/game/theme-selector";
 import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 export const metadata = {
   title: "通常将棋",
@@ -20,14 +20,15 @@ export default function ClassicPage() {
 
         <div className="relative text-center py-2 sm:py-6 px-4 shrink-0">
           <div className="absolute top-2 left-4 sm:top-3">
-            <Link
+            <MaskedLink
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
+              loadingMessage="ホームへ戻っています..."
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム
-            </Link>
+            </MaskedLink>
           </div>
           <div className="absolute top-2 right-4 sm:top-3 flex items-center gap-2">
             <AuthControls variant="indicator" />
@@ -41,13 +42,14 @@ export default function ClassicPage() {
 
         {/* 対局履歴へのリンク (旧ホームと同じ位置に配置) */}
         <div className="text-center shrink-0 px-4 pb-3">
-          <Link
+          <MaskedLink
             href="/history"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            loadingMessage="対局履歴を読み込み中..."
           >
             <History className="w-4 h-4" />
             対局履歴を見る
-          </Link>
+          </MaskedLink>
         </div>
       </main>
     </PageMotion>

--- a/src/app/classic/page.tsx
+++ b/src/app/classic/page.tsx
@@ -24,6 +24,7 @@ export default function ClassicPage() {
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
+              loadingVariant="spinner"
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム

--- a/src/app/classic/page.tsx
+++ b/src/app/classic/page.tsx
@@ -24,7 +24,6 @@ export default function ClassicPage() {
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
-              loadingMessage="ホームへ戻っています..."
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム
@@ -45,7 +44,6 @@ export default function ClassicPage() {
           <MaskedLink
             href="/history"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            loadingMessage="対局履歴を読み込み中..."
           >
             <History className="w-4 h-4" />
             対局履歴を見る

--- a/src/app/dev/loading-preview/page.tsx
+++ b/src/app/dev/loading-preview/page.tsx
@@ -9,10 +9,10 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 import { LoadingOverlay } from "@/components/loading-overlay";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import {
   LoadingCardVisual,
   LOADING_FACE_PIECE_TYPES,
@@ -33,13 +33,13 @@ export default function LoadingPreviewPage() {
       <AppBackground variant="page" />
 
       <header className="flex items-center gap-3 mb-6">
-        <Link
+        <MaskedLink
           href="/"
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowLeft className="w-4 h-4" />
           ホーム
-        </Link>
+        </MaskedLink>
         <h1 className="text-xl sm:text-2xl font-bold tracking-tight">
           ローディングカード プレビュー
         </h1>

--- a/src/app/dev/loading-preview/page.tsx
+++ b/src/app/dev/loading-preview/page.tsx
@@ -36,6 +36,7 @@ export default function LoadingPreviewPage() {
         <MaskedLink
           href="/"
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          loadingVariant="spinner"
         >
           <ArrowLeft className="w-4 h-4" />
           ホーム

--- a/src/app/dev/piece-flight/page.tsx
+++ b/src/app/dev/piece-flight/page.tsx
@@ -7,7 +7,6 @@
 // 本体の PieceFlight 演出にも反映される。
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { ArrowLeft, Save, RotateCcw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -15,6 +14,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ShogiPiece } from "@/components/game/shogi-piece";
 import { PieceFlight, type PieceFlightSpec } from "@/components/game/card-shogi/piece-flight";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import {
   PIECE_SIZE as DEFAULT_PIECE_SIZE,
 } from "@/components/game/card-shogi/animation-constants";
@@ -187,13 +187,13 @@ export default function PieceFlightDevPage() {
     <main className="min-h-dvh bg-background p-4 sm:p-6">
       <div className="max-w-7xl mx-auto flex flex-col gap-4">
         <header className="flex items-center gap-3 mb-1">
-          <Link
+          <MaskedLink
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム
-          </Link>
+          </MaskedLink>
           <div>
             <h1 className="text-xl sm:text-2xl font-bold">PieceFlight 動作検証</h1>
             <p className="text-xs text-muted-foreground">

--- a/src/app/dev/piece-flight/page.tsx
+++ b/src/app/dev/piece-flight/page.tsx
@@ -190,6 +190,7 @@ export default function PieceFlightDevPage() {
           <MaskedLink
             href="/"
             className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+            loadingVariant="spinner"
           >
             <ArrowLeft className="w-4 h-4" />
             ホーム

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -4,9 +4,9 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, Home, RefreshCw } from "lucide-react";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 export default function GlobalError({
   error,
@@ -38,12 +38,12 @@ export default function GlobalError({
             <RefreshCw className="w-4 h-4 mr-1.5" />
             再試行
           </Button>
-          <Link href="/">
+          <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
             <Button variant="outline">
               <Home className="w-4 h-4 mr-1.5" />
               ホームへ
             </Button>
-          </Link>
+          </MaskedLink>
         </div>
       </div>
     </main>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -38,7 +38,7 @@ export default function GlobalError({
             <RefreshCw className="w-4 h-4 mr-1.5" />
             再試行
           </Button>
-          <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+          <MaskedLink href="/">
             <Button variant="outline">
               <Home className="w-4 h-4 mr-1.5" />
               ホームへ

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -38,7 +38,7 @@ export default function GlobalError({
             <RefreshCw className="w-4 h-4 mr-1.5" />
             再試行
           </Button>
-          <MaskedLink href="/">
+          <MaskedLink href="/" loadingVariant="spinner">
             <Button variant="outline">
               <Home className="w-4 h-4 mr-1.5" />
               ホームへ

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -20,7 +20,7 @@ export default async function HistoryPage() {
     <main className="min-h-[100dvh] min-h-screen py-8 px-4 max-w-2xl mx-auto safe-area-inset">
       <AppBackground variant="page" />
       <div className="flex items-center gap-3 mb-6">
-        <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+        <MaskedLink href="/">
           <Button variant="ghost" size="sm" className="gap-1.5">
             <ArrowLeft className="w-4 h-4" />
             ホームへ
@@ -37,7 +37,7 @@ export default async function HistoryPage() {
           <CardContent className="py-12 text-center text-muted-foreground">
             <Inbox className="w-12 h-12 mx-auto mb-3 opacity-60" aria-hidden />
             <p>まだ対局がありません</p>
-            <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+            <MaskedLink href="/">
               <Button className="mt-4">最初の対局を始める</Button>
             </MaskedLink>
           </CardContent>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -6,12 +6,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { gameResultText } from "@/lib/shogi/notation";
 import { getCharacterById } from "@/data/characters";
-import Link from "next/link";
 import { ArrowLeft, Inbox } from "lucide-react";
 import { AppBackground } from "@/components/layout/app-background";
 import { AuthControls } from "@/components/auth/auth-controls";
 import { HistoryItemLink } from "@/components/history/history-item-link";
 import { formatHistoryDateTime } from "@/lib/date-format";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 export default async function HistoryPage() {
   const games = await getGameHistory();
@@ -20,12 +20,12 @@ export default async function HistoryPage() {
     <main className="min-h-[100dvh] min-h-screen py-8 px-4 max-w-2xl mx-auto safe-area-inset">
       <AppBackground variant="page" />
       <div className="flex items-center gap-3 mb-6">
-        <Link href="/">
+        <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
           <Button variant="ghost" size="sm" className="gap-1.5">
             <ArrowLeft className="w-4 h-4" />
             ホームへ
           </Button>
-        </Link>
+        </MaskedLink>
         <h1 className="text-2xl font-bold">対局履歴</h1>
         <div className="ml-auto">
           <AuthControls variant="indicator" />
@@ -37,9 +37,9 @@ export default async function HistoryPage() {
           <CardContent className="py-12 text-center text-muted-foreground">
             <Inbox className="w-12 h-12 mx-auto mb-3 opacity-60" aria-hidden />
             <p>まだ対局がありません</p>
-            <Link href="/">
+            <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
               <Button className="mt-4">最初の対局を始める</Button>
-            </Link>
+            </MaskedLink>
           </CardContent>
         </Card>
       ) : (

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -20,7 +20,7 @@ export default async function HistoryPage() {
     <main className="min-h-[100dvh] min-h-screen py-8 px-4 max-w-2xl mx-auto safe-area-inset">
       <AppBackground variant="page" />
       <div className="flex items-center gap-3 mb-6">
-        <MaskedLink href="/">
+        <MaskedLink href="/" loadingVariant="spinner">
           <Button variant="ghost" size="sm" className="gap-1.5">
             <ArrowLeft className="w-4 h-4" />
             ホームへ

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,26 +12,13 @@ import { Button } from "@/components/ui/button";
 import { ThemeSelector } from "@/components/game/theme-selector";
 import { AuthControls } from "@/components/auth/auth-controls";
 import { LoadingOverlay } from "@/components/loading-overlay";
-import { LOADING_STAGES } from "@/lib/loading-stages";
+import { resolveLoadingStages } from "@/lib/loading-stages";
 import { useAssetPreloader } from "@/hooks/use-asset-preloader";
 import { AppBackground } from "@/components/layout/app-background";
 import { PageMotion } from "@/components/layout/page-motion";
 import { CardShogiTiles } from "@/components/home/card-shogi-tiles";
 import { HeroCardStack } from "@/components/home/hero-card-stack";
 import { cn } from "@/lib/utils";
-
-// Issue #155: ホームから各画面への遷移は href ごとに固有の stages を出す。
-// CardShogiTiles 等 onNavigate(href) で label を渡さない呼び出しでも、
-// 遷移先に応じた文言が出るよう一元化する。
-function resolveStages(href: string): readonly string[] {
-  if (href === "/play") return LOADING_STAGES.matchNavigate;
-  if (href === "/classic") return LOADING_STAGES.classicNavigate;
-  if (href === "/history") return LOADING_STAGES.historyNavigate;
-  if (href === "/decks") return LOADING_STAGES.decksNavigate;
-  if (href === "/cards") return LOADING_STAGES.cardsNavigate;
-  if (href === "/card-design") return LOADING_STAGES.cardDesignNavigate;
-  return LOADING_STAGES.defaultNavigate;
-}
 
 export default function Home() {
   const router = useRouter();
@@ -45,7 +32,7 @@ export default function Home() {
 
   function navigateTo(href: string, customStages?: readonly string[]) {
     if (isPending) return;
-    setPendingStages(customStages ?? resolveStages(href));
+    setPendingStages(customStages ?? resolveLoadingStages(href));
     router.push(href);
   }
 

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -24,6 +24,7 @@ export default function PlayPage() {
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
+              loadingVariant="spinner"
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,12 +1,12 @@
 // Issue #117: カード将棋の対局相手・手番選択画面。
 // 旧ホーム (page.tsx) のセットアップ部分を分離し、card-shogi 専用の対局開始フローを提供する。
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { MatchSetup } from "@/components/home/match-setup";
 import { AppBackground } from "@/components/layout/app-background";
 import { PageMotion } from "@/components/layout/page-motion";
 import { ThemeSelector } from "@/components/game/theme-selector";
 import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
 
 export const metadata = {
   title: "対局を始める | カード将棋",
@@ -20,14 +20,15 @@ export default function PlayPage() {
 
         <div className="relative text-center py-2 sm:py-6 px-4 shrink-0">
           <div className="absolute top-2 left-4 sm:top-3">
-            <Link
+            <MaskedLink
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
+              loadingMessage="ホームへ戻っています..."
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム
-            </Link>
+            </MaskedLink>
           </div>
           <div className="absolute top-2 right-4 sm:top-3 flex items-center gap-2">
             <AuthControls variant="indicator" />

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -24,7 +24,6 @@ export default function PlayPage() {
               href="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
               aria-label="ホームへ戻る"
-              loadingMessage="ホームへ戻っています..."
             >
               <ArrowLeft className="w-4 h-4" />
               ホーム

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -8,6 +8,7 @@ import { createPortal } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 import { LoadingOverlay } from "@/components/loading-overlay";
+import { LOADING_STAGES } from "@/lib/loading-stages";
 
 // Issue #150: ログイン後の戻り先を「現在のページ」にするため、相対パス + 検索クエリを
 // next にエンコードして /auth/complete?next=... として渡す。
@@ -151,7 +152,13 @@ function SignInButtonWithMask({ completeUrl }: { completeUrl: string }) {
       {mounted &&
         typeof document !== "undefined" &&
         createPortal(
-          <LoadingOverlay show={isSigningIn} fullScreen message="ログイン画面へ移動中..." />,
+          <LoadingOverlay
+            show={isSigningIn}
+            fullScreen
+            card
+            progress
+            stages={LOADING_STAGES.signIn}
+          />,
           document.body,
         )}
     </>

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -3,9 +3,11 @@
 import { SignInButton, UserButton, useAuth, useUser } from "@clerk/nextjs";
 import { LogIn } from "lucide-react";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { Button } from "@/components/ui/button";
+import { LoadingOverlay } from "@/components/loading-overlay";
 
 // Issue #150: ログイン後の戻り先を「現在のページ」にするため、相対パス + 検索クエリを
 // next にエンコードして /auth/complete?next=... として渡す。
@@ -75,7 +77,7 @@ function ClerkAuthControls({
   // signInOnly: 未ログイン時のみ「ログイン」ボタン。それ以外は何も出さない。
   if (slot === "signInOnly") {
     if (isSignedIn) return null;
-    return renderSignInButton(completeUrl);
+    return <SignInButtonWithMask completeUrl={completeUrl} />;
   }
 
   // signedInOnly: ログイン済み時のみアイコン。未ログインは何も出さない。
@@ -101,32 +103,58 @@ function ClerkAuthControls({
   // default + home: 旧挙動 (1 箇所にログイン状態に応じた UI)。テスト互換のため残す。
   return (
     <div className="inline-flex items-center">
-      {isSignedIn ? <HomeUserButton /> : renderSignInButton(completeUrl)}
+      {isSignedIn ? <HomeUserButton /> : <SignInButtonWithMask completeUrl={completeUrl} />}
     </div>
   );
 }
 
-function renderSignInButton(completeUrl: string) {
+// Issue #163: ログインボタン押下時、Clerk OAuth ホストへの外部リダイレクトに
+// 入るまでの間 (= ブラウザの page redirect が完了するまで) にローディング
+// マスクを表示する。Clerk の SignInButton は Next.js のクライアント遷移ではなく
+// 外部 redirect を起こすため、useLinkStatus / loading.tsx は捕捉できない。
+// よってクリック時に local state を立て、Portal で body 直下に LoadingOverlay
+// を描画する。リダイレクト完了でコンポーネント自体が unmount されるため、
+// state は自然解除される。
+function SignInButtonWithMask({ completeUrl }: { completeUrl: string }) {
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // SSR 時 createPortal は使えないため mount 後にだけ Portal を有効化する。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
   return (
-    <SignInButton
-      mode="redirect"
-      oauthFlow="redirect"
-      forceRedirectUrl={completeUrl}
-      fallbackRedirectUrl={completeUrl}
-      signUpForceRedirectUrl={completeUrl}
-      signUpFallbackRedirectUrl={completeUrl}
-    >
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="bg-card/70 backdrop-blur-sm"
-        aria-label="Googleでログイン"
+    <>
+      <SignInButton
+        mode="redirect"
+        oauthFlow="redirect"
+        forceRedirectUrl={completeUrl}
+        fallbackRedirectUrl={completeUrl}
+        signUpForceRedirectUrl={completeUrl}
+        signUpFallbackRedirectUrl={completeUrl}
       >
-        <LogIn className="w-3.5 h-3.5" />
-        ログイン
-      </Button>
-    </SignInButton>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="bg-card/70 backdrop-blur-sm"
+          aria-label="Googleでログイン"
+          onClick={() => setIsSigningIn(true)}
+          disabled={isSigningIn}
+        >
+          <LogIn className="w-3.5 h-3.5" />
+          ログイン
+        </Button>
+      </SignInButton>
+      {mounted &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <LoadingOverlay show={isSigningIn} fullScreen message="ログイン画面へ移動中..." />,
+          document.body,
+        )}
+    </>
   );
 }
 

--- a/src/components/decks/decks-page-header.tsx
+++ b/src/components/decks/decks-page-header.tsx
@@ -23,7 +23,6 @@ export function DecksPageHeader({ homeDisabled = false }: DecksPageHeaderProps) 
           href="/"
           aria-label="ホームへ戻る"
           aria-disabled={homeDisabled || undefined}
-          loadingMessage="ホームへ戻っています..."
           // disabled 状態のとき onClick を吸収して遷移を止める。
           // <a> 要素は HTML 仕様上 disabled 属性を持たないため、
           // pointer-events:none + onClick preventDefault で代替する。

--- a/src/components/decks/decks-page-header.tsx
+++ b/src/components/decks/decks-page-header.tsx
@@ -23,6 +23,7 @@ export function DecksPageHeader({ homeDisabled = false }: DecksPageHeaderProps) 
           href="/"
           aria-label="ホームへ戻る"
           aria-disabled={homeDisabled || undefined}
+          loadingVariant="spinner"
           // disabled 状態のとき onClick を吸収して遷移を止める。
           // <a> 要素は HTML 仕様上 disabled 属性を持たないため、
           // pointer-events:none + onClick preventDefault で代替する。

--- a/src/components/decks/decks-page-header.tsx
+++ b/src/components/decks/decks-page-header.tsx
@@ -4,9 +4,9 @@
 // 透過) にし、保存処理の途中でユーザーが意図せずホームへ抜けるのを防ぐ。
 "use client";
 
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import { cn } from "@/lib/utils";
 
 interface DecksPageHeaderProps {
@@ -19,10 +19,11 @@ export function DecksPageHeader({ homeDisabled = false }: DecksPageHeaderProps) 
   return (
     <header className="shrink-0 bg-background/90 backdrop-blur-sm border-b border-border/50">
       <div className="max-w-6xl lg:max-w-[1440px] mx-auto px-4 py-3 sm:py-4 w-full flex items-center gap-3">
-        <Link
+        <MaskedLink
           href="/"
           aria-label="ホームへ戻る"
           aria-disabled={homeDisabled || undefined}
+          loadingMessage="ホームへ戻っています..."
           // disabled 状態のとき onClick を吸収して遷移を止める。
           // <a> 要素は HTML 仕様上 disabled 属性を持たないため、
           // pointer-events:none + onClick preventDefault で代替する。
@@ -38,7 +39,7 @@ export function DecksPageHeader({ homeDisabled = false }: DecksPageHeaderProps) 
         >
           <ArrowLeft className="w-4 h-4" />
           ホーム
-        </Link>
+        </MaskedLink>
         <div className="flex-1">
           <h1 className="text-xl sm:text-2xl font-bold tracking-tight">デッキ編成</h1>
           <p className="text-xs sm:text-sm text-muted-foreground">

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 
 import { LoadingOverlay } from "@/components/loading-overlay";
 import { MaskedLink } from "@/components/navigation/masked-link";
+import { LOADING_STAGES } from "@/lib/loading-stages";
 import { ChevronUp, ChevronDown, Volume2, VolumeX } from "lucide-react";
 
 import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
@@ -1362,7 +1363,7 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+                <MaskedLink href="/">
                   <Button size="sm" variant="outline">ホームへ</Button>
                 </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
@@ -1426,7 +1427,7 @@ export function CardShogiGame({
               <Card className="p-2.5 text-center border-2 border-primary/20 bg-primary/5">
                 <p className="text-sm font-bold mb-1.5">{gameResultText(gameState.status, gameState.winner)}</p>
                 <div className="flex gap-2 justify-center">
-                  <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+                  <MaskedLink href="/">
                     <Button size="sm" variant="outline">ホームへ</Button>
                   </MaskedLink>
                   <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
@@ -1755,7 +1756,7 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5 shrink-0">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
+                <MaskedLink href="/">
                   <Button size="sm" variant="outline">ホームへ</Button>
                 </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
@@ -1971,8 +1972,15 @@ export function CardShogiGame({
       <FastMoveBadgeLayer items={fastMoveBadges} onComplete={removeFastMoveBadge} />
 
       {/* Issue #163: 「もう一局」(=createGame Server Action 後 router.push) 中のローディングマスク。
-          xl/xl 未満/モバイル の各レイアウトで同じ isPending を共有しているため Overlay 1 つで全カバー。 */}
-      <LoadingOverlay show={isPending} fullScreen message="次の対局を準備中..." />
+          xl/xl 未満/モバイル の各レイアウトで同じ isPending を共有しているため Overlay 1 つで全カバー。
+          ビジュアルは他のリッチローディング (回転カード + プログレスバー + ステージ文言) に統一。 */}
+      <LoadingOverlay
+        show={isPending}
+        fullScreen
+        card
+        progress
+        stages={LOADING_STAGES.matchRestart}
+      />
     </div>
   );
 }

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type CSSProperties } from "react";
 import { flushSync, createPortal } from "react-dom";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
+
+import { LoadingOverlay } from "@/components/loading-overlay";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import { ChevronUp, ChevronDown, Volume2, VolumeX } from "lucide-react";
 
 import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
@@ -1360,9 +1362,9 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <Link href="/">
+                <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
                   <Button size="sm" variant="outline">ホームへ</Button>
-                </Link>
+                </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
                   {isPending ? "準備中..." : "もう一局"}
                 </Button>
@@ -1424,9 +1426,9 @@ export function CardShogiGame({
               <Card className="p-2.5 text-center border-2 border-primary/20 bg-primary/5">
                 <p className="text-sm font-bold mb-1.5">{gameResultText(gameState.status, gameState.winner)}</p>
                 <div className="flex gap-2 justify-center">
-                  <Link href="/">
+                  <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
                     <Button size="sm" variant="outline">ホームへ</Button>
-                  </Link>
+                  </MaskedLink>
                   <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
                     {isPending ? "準備中..." : "もう一局"}
                   </Button>
@@ -1753,9 +1755,9 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5 shrink-0">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <Link href="/">
+                <MaskedLink href="/" loadingMessage="ホームへ戻っています...">
                   <Button size="sm" variant="outline">ホームへ</Button>
-                </Link>
+                </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
                   {isPending ? "準備中..." : "もう一局"}
                 </Button>
@@ -1967,6 +1969,10 @@ export function CardShogiGame({
 
       {/* Issue #81: 早指し時に駒の少し下に表示するバッジ */}
       <FastMoveBadgeLayer items={fastMoveBadges} onComplete={removeFastMoveBadge} />
+
+      {/* Issue #163: 「もう一局」(=createGame Server Action 後 router.push) 中のローディングマスク。
+          xl/xl 未満/モバイル の各レイアウトで同じ isPending を共有しているため Overlay 1 つで全カバー。 */}
+      <LoadingOverlay show={isPending} fullScreen message="次の対局を準備中..." />
     </div>
   );
 }

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -1363,7 +1363,7 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/">
+                <MaskedLink href="/" loadingVariant="spinner">
                   <Button size="sm" variant="outline">ホームへ</Button>
                 </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
@@ -1427,7 +1427,7 @@ export function CardShogiGame({
               <Card className="p-2.5 text-center border-2 border-primary/20 bg-primary/5">
                 <p className="text-sm font-bold mb-1.5">{gameResultText(gameState.status, gameState.winner)}</p>
                 <div className="flex gap-2 justify-center">
-                  <MaskedLink href="/">
+                  <MaskedLink href="/" loadingVariant="spinner">
                     <Button size="sm" variant="outline">ホームへ</Button>
                   </MaskedLink>
                   <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
@@ -1756,7 +1756,7 @@ export function CardShogiGame({
             <Card className="p-3 text-center border-2 border-primary/20 bg-primary/5 shrink-0">
               <p className="text-sm font-bold mb-2">{gameResultText(gameState.status, gameState.winner)}</p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/">
+                <MaskedLink href="/" loadingVariant="spinner">
                   <Button size="sm" variant="outline">ホームへ</Button>
                 </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>

--- a/src/components/game/mobile-drawer.tsx
+++ b/src/components/game/mobile-drawer.tsx
@@ -111,7 +111,7 @@ export function MobileDrawer({
                   {gameResultText(gameStatus, gameWinner)}
                 </p>
                 <div className="flex gap-2 justify-center">
-                  <MaskedLink href={homeHref}>
+                  <MaskedLink href={homeHref} loadingVariant="spinner">
                     <Button size="sm" variant="outline">
                       ホームへ
                     </Button>

--- a/src/components/game/mobile-drawer.tsx
+++ b/src/components/game/mobile-drawer.tsx
@@ -111,7 +111,7 @@ export function MobileDrawer({
                   {gameResultText(gameStatus, gameWinner)}
                 </p>
                 <div className="flex gap-2 justify-center">
-                  <MaskedLink href={homeHref} loadingMessage="ホームへ戻っています...">
+                  <MaskedLink href={homeHref}>
                     <Button size="sm" variant="outline">
                       ホームへ
                     </Button>

--- a/src/components/game/mobile-drawer.tsx
+++ b/src/components/game/mobile-drawer.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { gameResultText } from "@/lib/shogi/notation";
 import { MessageCircle, ScrollText, ChevronUp, ChevronDown } from "lucide-react";
-import Link from "next/link";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import type { Character } from "@/data/characters";
 import type { CommentaryEvent } from "@/app/actions/commentary";
 import type { Move, GameStatus, Player } from "@/lib/shogi/types";
@@ -111,11 +111,11 @@ export function MobileDrawer({
                   {gameResultText(gameStatus, gameWinner)}
                 </p>
                 <div className="flex gap-2 justify-center">
-                  <Link href={homeHref}>
+                  <MaskedLink href={homeHref} loadingMessage="ホームへ戻っています...">
                     <Button size="sm" variant="outline">
                       ホームへ
                     </Button>
-                  </Link>
+                  </MaskedLink>
                   <Button size="sm" onClick={onPlayAgain} disabled={isPending}>
                     {isPending ? "準備中..." : "もう一局"}
                   </Button>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -28,6 +28,7 @@ import type { CommentaryEvent } from "@/app/actions/commentary";
 import { createGame } from "@/app/actions/game";
 import { LoadingOverlay } from "@/components/loading-overlay";
 import { MaskedLink } from "@/components/navigation/masked-link";
+import { LOADING_STAGES } from "@/lib/loading-stages";
 import { useRouter } from "next/navigation";
 
 // Server→Client props に関数を含められないため、シリアライズ可能な型を定義
@@ -304,7 +305,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
                 {gameResultText(gameState.status, gameState.winner)}
               </p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/classic" loadingMessage="ホームへ戻っています...">
+                <MaskedLink href="/classic">
                   <Button size="sm" variant="outline">
                     ホームへ
                   </Button>
@@ -343,8 +344,15 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
       />
     </div>
     {/* Issue #163: 「もう一局」(=createGame Server Action 後 router.push) 中のローディングマスク。
-        PC/モバイル両方の同 isPending を共有しているため Overlay 1 つで両ボタンをカバー。 */}
-    <LoadingOverlay show={isPending} fullScreen message="次の対局を準備中..." />
+        PC/モバイル両方の同 isPending を共有しているため Overlay 1 つで両ボタンをカバー。
+        ビジュアルは他のリッチローディング (回転カード + プログレスバー + ステージ文言) に統一。 */}
+    <LoadingOverlay
+      show={isPending}
+      fullScreen
+      card
+      progress
+      stages={LOADING_STAGES.matchRestart}
+    />
     </>
   );
 }

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -305,7 +305,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
                 {gameResultText(gameState.status, gameState.winner)}
               </p>
               <div className="flex gap-2 justify-center">
-                <MaskedLink href="/classic">
+                <MaskedLink href="/classic" loadingVariant="spinner">
                   <Button size="sm" variant="outline">
                     ホームへ
                   </Button>

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -26,7 +26,8 @@ import { getVariantById } from "@/lib/shogi/variants/index";
 import type { GameConfig, GameState, Difficulty, Move, Player } from "@/lib/shogi/types";
 import type { CommentaryEvent } from "@/app/actions/commentary";
 import { createGame } from "@/app/actions/game";
-import Link from "next/link";
+import { LoadingOverlay } from "@/components/loading-overlay";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import { useRouter } from "next/navigation";
 
 // Server→Client props に関数を含められないため、シリアライズ可能な型を定義
@@ -191,6 +192,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   }, [isReady]);
 
   return (
+    <>
     <div
       className="shogi-game-area w-full overflow-hidden"
       style={{ height: viewportHeight }}
@@ -302,11 +304,11 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
                 {gameResultText(gameState.status, gameState.winner)}
               </p>
               <div className="flex gap-2 justify-center">
-                <Link href="/classic">
+                <MaskedLink href="/classic" loadingMessage="ホームへ戻っています...">
                   <Button size="sm" variant="outline">
                     ホームへ
                   </Button>
-                </Link>
+                </MaskedLink>
                 <Button size="sm" onClick={handlePlayAgain} disabled={isPending}>
                   {isPending ? "準備中..." : "もう一局"}
                 </Button>
@@ -340,5 +342,9 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
         onCancel={cancelPromotion}
       />
     </div>
+    {/* Issue #163: 「もう一局」(=createGame Server Action 後 router.push) 中のローディングマスク。
+        PC/モバイル両方の同 isPending を共有しているため Overlay 1 つで両ボタンをカバー。 */}
+    <LoadingOverlay show={isPending} fullScreen message="次の対局を準備中..." />
+    </>
   );
 }

--- a/src/components/home/hero-card-stack.tsx
+++ b/src/components/home/hero-card-stack.tsx
@@ -7,7 +7,6 @@
 // CardBackProvider が同パターンで動くため、視覚切り替えは滑らか。
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useReducedMotion } from "framer-motion";
 
@@ -17,6 +16,7 @@ import {
   DEFAULT_CARD_BACK_STYLE,
   type CardBackStyle,
 } from "@/components/card-back/style-options";
+import { MaskedLink } from "@/components/navigation/masked-link";
 import { cn } from "@/lib/utils";
 
 interface HeroCardStackProps {
@@ -40,7 +40,7 @@ export function HeroCardStack({ className }: HeroCardStackProps) {
   const reduce = useReducedMotion();
 
   return (
-    <Link
+    <MaskedLink
       href="/card-design"
       aria-label="カードデザインを変更する"
       className={cn(
@@ -78,6 +78,6 @@ export function HeroCardStack({ className }: HeroCardStackProps) {
 
       {/* スタイル名 (ハイドレーション後にだけ表示して FOUC 回避) */}
       <span className="sr-only">現在の裏面スタイル: {mounted ? styleLabel : ""}</span>
-    </Link>
+    </MaskedLink>
   );
 }

--- a/src/components/navigation/masked-link.tsx
+++ b/src/components/navigation/masked-link.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+// Issue #163: ページ遷移時ローディングマスクの共通実装。
+// Next.js App Router の <Link> をラップし、useLinkStatus でクリック後の
+// pending 状態を取得して LoadingOverlay (fullScreen) を Portal で body 直下に
+// 投影する。Portal を使う理由: 親ツリーに framer-motion (PageMotion) など
+// transform を当てるコンポーネントが含まれると、子孫の position:fixed の
+// containing block が transform 親側に縮退して viewport 全面被覆が壊れるため。
+
+import Link, { useLinkStatus } from "next/link";
+import { createPortal } from "react-dom";
+import { useEffect, useState, type ComponentProps, type ReactNode } from "react";
+
+import { LoadingOverlay } from "@/components/loading-overlay";
+
+interface MaskedLinkProps extends ComponentProps<typeof Link> {
+  loadingMessage?: string;
+  // prefetch 済みルートで pending が瞬時に立ち消えるケースで一瞬だけ
+  // マスクが見える/フラッシュするのを防ぐ表示遅延 (ms)。
+  delayMs?: number;
+  children: ReactNode;
+}
+
+function MaskedLinkInner({
+  loadingMessage,
+  delayMs,
+  children,
+}: {
+  loadingMessage: string;
+  delayMs: number;
+  children: ReactNode;
+}) {
+  const { pending } = useLinkStatus();
+  const [show, setShow] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // SSR 時は createPortal が使えないため mount 後にだけ Portal を有効化する。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!pending) {
+      // pending が解除されたら即座にマスクを消す (画面が遷移完了済のため)。
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setShow(false);
+      return;
+    }
+    // pending 中も delayMs 経過してからマスクを出すことで、prefetch 済みルートの
+    // 高速遷移時にマスクが一瞬フラッシュするのを抑制する。
+    const id = setTimeout(() => setShow(true), delayMs);
+    return () => clearTimeout(id);
+  }, [pending, delayMs]);
+
+  return (
+    <>
+      <span
+        aria-busy={pending || undefined}
+        style={{
+          pointerEvents: pending ? "none" : undefined,
+          display: "contents",
+        }}
+      >
+        {children}
+      </span>
+      {mounted &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <LoadingOverlay show={show} fullScreen message={loadingMessage} />,
+          document.body,
+        )}
+    </>
+  );
+}
+
+export function MaskedLink({
+  loadingMessage = "読み込み中...",
+  delayMs = 80,
+  children,
+  ...linkProps
+}: MaskedLinkProps) {
+  return (
+    <Link {...linkProps}>
+      <MaskedLinkInner loadingMessage={loadingMessage} delayMs={delayMs}>
+        {children}
+      </MaskedLinkInner>
+    </Link>
+  );
+}

--- a/src/components/navigation/masked-link.tsx
+++ b/src/components/navigation/masked-link.tsx
@@ -2,19 +2,18 @@
 
 // Issue #163: ページ遷移時ローディングマスクの共通実装。
 // Next.js App Router の <Link> をラップし、useLinkStatus でクリック後の
-// pending 状態を取得して LoadingOverlay (fullScreen + card + progress + stages)
-// を Portal で body 直下に投影する。
+// pending 状態を取得して LoadingOverlay を Portal で body 直下に投影する。
 //
 // Portal を使う理由: 親ツリーに framer-motion (PageMotion) など transform を
 // 当てるコンポーネントが含まれると、子孫の position:fixed の containing block
 // が transform 親側に縮退して viewport 全面被覆が壊れるため。
 //
-// ビジュアルは既存リッチローディング (Issue #155) と完全統一:
-//   - 中央に「裏面 ↔ ランダム駒」の回転カード (card)
-//   - 下部に indeterminate プログレスバー (progress)
-//   - href から自動解決した段階文言 (stages)
-// 既存の useTransition ベース箇所 (app/page.tsx, match-setup.tsx,
-// card-catalog-tile.tsx 等) と同じ見た目を提供する。
+// ビジュアルは loadingVariant で 2 系統:
+//   - "rich" (既定): 中央に「裏面 ↔ ランダム駒」の回転カード (card) +
+//     下部 indeterminate プログレスバー (progress) + 段階文言フェード (stages)。
+//     Issue #155 で導入された主表現で、コンテンツへの "進む" 遷移に使う。
+//   - "spinner": Loader2 アイコンのシンプルなくるくる表示 + 1 行メッセージ。
+//     "ホームへ戻る" 系の back-navigation でリッチ表現が過剰になる場面に使う。
 
 import Link, { useLinkStatus } from "next/link";
 import { createPortal } from "react-dom";
@@ -24,9 +23,13 @@ import { LoadingOverlay } from "@/components/loading-overlay";
 import { resolveLoadingStages } from "@/lib/loading-stages";
 
 interface MaskedLinkProps extends ComponentProps<typeof Link> {
-  // ステージ文言の明示指定。省略時は href から自動解決する
-  // (resolveLoadingStages: 例 "/" → homeNavigate, "/cards" → cardsNavigate)。
+  // ローディング表示のスタイル。既定は "rich" (回転カード + プログレスバー + ステージ文言)。
+  // "ホームへ戻る" 等の back-navigation 用に "spinner" (Loader2 + メッセージ) も選べる。
+  loadingVariant?: "rich" | "spinner";
+  // rich モードのステージ文言。省略時は href から resolveLoadingStages で自動解決。
   loadingStages?: readonly string[];
+  // spinner モードの 1 行メッセージ。省略時は "ホームへ戻っています…"。
+  loadingMessage?: string;
   // prefetch 済みルートで pending が瞬時に立ち消えるケースで一瞬だけ
   // マスクが見える/フラッシュするのを防ぐ表示遅延 (ms)。
   delayMs?: number;
@@ -34,11 +37,15 @@ interface MaskedLinkProps extends ComponentProps<typeof Link> {
 }
 
 function MaskedLinkInner({
+  variant,
   stages,
+  message,
   delayMs,
   children,
 }: {
+  variant: "rich" | "spinner";
   stages: readonly string[];
+  message: string;
   delayMs: number;
   children: ReactNode;
 }) {
@@ -79,7 +86,11 @@ function MaskedLinkInner({
       {mounted &&
         typeof document !== "undefined" &&
         createPortal(
-          <LoadingOverlay show={show} fullScreen card progress stages={stages} />,
+          variant === "spinner" ? (
+            <LoadingOverlay show={show} fullScreen message={message} />
+          ) : (
+            <LoadingOverlay show={show} fullScreen card progress stages={stages} />
+          ),
           document.body,
         )}
     </>
@@ -87,21 +98,31 @@ function MaskedLinkInner({
 }
 
 export function MaskedLink({
+  loadingVariant = "rich",
   loadingStages,
+  loadingMessage,
   delayMs = 80,
   children,
   href,
   ...linkProps
 }: MaskedLinkProps) {
-  // 明示指定がなければ href から自動解決。
+  // rich モード用 stages の解決: 明示指定がなければ href から自動解決。
   // href は string | UrlObject。UrlObject の場合は pathname を見て解決する。
   const resolvedStages =
     loadingStages ??
     resolveLoadingStages(typeof href === "string" ? href : href.pathname ?? "/");
+  // spinner モード用メッセージの既定。spinner は "ホームへ戻る" 専用想定なので
+  // 既定文言は「ホームへ戻っています…」とする。
+  const resolvedMessage = loadingMessage ?? "ホームへ戻っています...";
 
   return (
     <Link href={href} {...linkProps}>
-      <MaskedLinkInner stages={resolvedStages} delayMs={delayMs}>
+      <MaskedLinkInner
+        variant={loadingVariant}
+        stages={resolvedStages}
+        message={resolvedMessage}
+        delayMs={delayMs}
+      >
         {children}
       </MaskedLinkInner>
     </Link>

--- a/src/components/navigation/masked-link.tsx
+++ b/src/components/navigation/masked-link.tsx
@@ -2,19 +2,31 @@
 
 // Issue #163: ページ遷移時ローディングマスクの共通実装。
 // Next.js App Router の <Link> をラップし、useLinkStatus でクリック後の
-// pending 状態を取得して LoadingOverlay (fullScreen) を Portal で body 直下に
-// 投影する。Portal を使う理由: 親ツリーに framer-motion (PageMotion) など
-// transform を当てるコンポーネントが含まれると、子孫の position:fixed の
-// containing block が transform 親側に縮退して viewport 全面被覆が壊れるため。
+// pending 状態を取得して LoadingOverlay (fullScreen + card + progress + stages)
+// を Portal で body 直下に投影する。
+//
+// Portal を使う理由: 親ツリーに framer-motion (PageMotion) など transform を
+// 当てるコンポーネントが含まれると、子孫の position:fixed の containing block
+// が transform 親側に縮退して viewport 全面被覆が壊れるため。
+//
+// ビジュアルは既存リッチローディング (Issue #155) と完全統一:
+//   - 中央に「裏面 ↔ ランダム駒」の回転カード (card)
+//   - 下部に indeterminate プログレスバー (progress)
+//   - href から自動解決した段階文言 (stages)
+// 既存の useTransition ベース箇所 (app/page.tsx, match-setup.tsx,
+// card-catalog-tile.tsx 等) と同じ見た目を提供する。
 
 import Link, { useLinkStatus } from "next/link";
 import { createPortal } from "react-dom";
 import { useEffect, useState, type ComponentProps, type ReactNode } from "react";
 
 import { LoadingOverlay } from "@/components/loading-overlay";
+import { resolveLoadingStages } from "@/lib/loading-stages";
 
 interface MaskedLinkProps extends ComponentProps<typeof Link> {
-  loadingMessage?: string;
+  // ステージ文言の明示指定。省略時は href から自動解決する
+  // (resolveLoadingStages: 例 "/" → homeNavigate, "/cards" → cardsNavigate)。
+  loadingStages?: readonly string[];
   // prefetch 済みルートで pending が瞬時に立ち消えるケースで一瞬だけ
   // マスクが見える/フラッシュするのを防ぐ表示遅延 (ms)。
   delayMs?: number;
@@ -22,11 +34,11 @@ interface MaskedLinkProps extends ComponentProps<typeof Link> {
 }
 
 function MaskedLinkInner({
-  loadingMessage,
+  stages,
   delayMs,
   children,
 }: {
-  loadingMessage: string;
+  stages: readonly string[];
   delayMs: number;
   children: ReactNode;
 }) {
@@ -67,7 +79,7 @@ function MaskedLinkInner({
       {mounted &&
         typeof document !== "undefined" &&
         createPortal(
-          <LoadingOverlay show={show} fullScreen message={loadingMessage} />,
+          <LoadingOverlay show={show} fullScreen card progress stages={stages} />,
           document.body,
         )}
     </>
@@ -75,14 +87,21 @@ function MaskedLinkInner({
 }
 
 export function MaskedLink({
-  loadingMessage = "読み込み中...",
+  loadingStages,
   delayMs = 80,
   children,
+  href,
   ...linkProps
 }: MaskedLinkProps) {
+  // 明示指定がなければ href から自動解決。
+  // href は string | UrlObject。UrlObject の場合は pathname を見て解決する。
+  const resolvedStages =
+    loadingStages ??
+    resolveLoadingStages(typeof href === "string" ? href : href.pathname ?? "/");
+
   return (
-    <Link {...linkProps}>
-      <MaskedLinkInner loadingMessage={loadingMessage} delayMs={delayMs}>
+    <Link href={href} {...linkProps}>
+      <MaskedLinkInner stages={resolvedStages} delayMs={delayMs}>
         {children}
       </MaskedLinkInner>
     </Link>

--- a/src/lib/loading-stages.ts
+++ b/src/lib/loading-stages.ts
@@ -27,6 +27,13 @@ export const LOADING_STAGES = {
   cardsNavigate: ["カード一覧を開いています…"],
   // ホーム → カードデザイン画面の遷移
   cardDesignNavigate: ["カードデザインを開いています…"],
+  // 各画面 → ホーム (/) への戻り遷移 (Issue #163)
+  homeNavigate: ["ホームへ戻っています…"],
+  // 対局終了画面の「もう一局」 (createGame Server Action 後 router.push)。
+  // matchSetup と分けることで、ロビーから新規開始ではなく「次の対局」感を出す。
+  matchRestart: ["次の対局を準備中…", "盤面をセットアップ中…"],
+  // ログインボタン → Clerk OAuth ホストへの外部リダイレクト
+  signIn: ["ログイン画面へ移動中…", "認証サービスに接続中…"],
   // 汎用フォールバック (resolveStages で個別のキーが見つからない場合)
   defaultNavigate: ["読み込み中…"],
   // 履歴 → /game/[id] の SSR 復元中 (棋譜デシリアライズ・盤面再構築・演出準備)
@@ -34,3 +41,18 @@ export const LOADING_STAGES = {
 } as const;
 
 export type LoadingStageKey = keyof typeof LOADING_STAGES;
+
+// Issue #163: <Link href> クリック時の遷移マスク stages を href から自動解決するヘルパー。
+// MaskedLink および app/page.tsx の navigateTo から共通利用する。
+// /cards/{id} のような動的 segment は cardDetail を返す (前方一致で判定)。
+export function resolveLoadingStages(href: string): readonly string[] {
+  if (href === "/") return LOADING_STAGES.homeNavigate;
+  if (href === "/play") return LOADING_STAGES.matchNavigate;
+  if (href === "/classic") return LOADING_STAGES.classicNavigate;
+  if (href === "/history") return LOADING_STAGES.historyNavigate;
+  if (href === "/decks") return LOADING_STAGES.decksNavigate;
+  if (href === "/cards") return LOADING_STAGES.cardsNavigate;
+  if (href.startsWith("/cards/")) return LOADING_STAGES.cardDetail;
+  if (href === "/card-design") return LOADING_STAGES.cardDesignNavigate;
+  return LOADING_STAGES.defaultNavigate;
+}


### PR DESCRIPTION
## Summary

ページ遷移を伴う全操作 (ボタン・リンク・ログインボタン) で、クリック直後 → 遷移先描画完了までの間、画面操作不能を示すローディングマスクを統一的に表示する。

現状、ホーム画面以外の遷移箇所 (対局終了画面の「ホームへ」「もう一局」、各ページヘッダーの戻りリンク、ログインボタン等) ではマスクが出ず、遷移待ち中に多重クリック・状態不明の問題が発生していた。

Closes #163

---

## なぜこの対応が必要か (背景)

- 既に `LoadingOverlay` ([src/components/loading-overlay.tsx](src/components/loading-overlay.tsx)) は整備済みで、ホーム画面の遷移系ボタン (`/play`, `/classic`, `/history` 等) や `card-catalog-tile.tsx` ではマスクが正しく機能していた。
- しかし、対局終了画面・各ページの「ホームへ戻る」ヘッダーリンク・対局開始ボタン・ログインボタン等、複数の遷移箇所でマスクが未適用。
- ユーザー体感として「クリックしたのに何も起きない」期間が生じ、二度押しや遷移待ちの不安感を招いていた。

---

## 採用方針: 案 C ハイブリッド (`useLinkStatus` + `MaskedLink` + 既存 `useTransition+Overlay` 維持 + ログイン用 Portal マスク)

実装着手前に 4 案を性能・保守性両軸で比較検討した:

| 案 | 概要 | 性能 | 保守性 | 採用 |
|---|---|---|---|---|
| **A** | 各箇所をローカル `useTransition + router.push + LoadingOverlay` で個別置換 | ❌ server page 5+ を client 化 / `<Link>` の自動 prefetch を喪失し遷移自体が遅くなる本末転倒 | ❌ DRY 違反、15+ ファイル波及、新規追加遷移で漏れ発生しやすい | × |
| **B** | 自前グローバル `NavigationMaskProvider` + 独自 `NavLink` | △ Provider state 更新で Context Consumer 全再描画リスク | △ 自前実装の保守責任 (Next.js Link 仕様変更追随、pathname 監視 hydration 等) | × |
| **C ⭐** | Next.js 16.2.1 公式の `useLinkStatus` を内部で使う `MaskedLink` ラッパ | ◎ Bundle 最小増 / `<Link>` の prefetch・a11y を完全維持 | ◎ Next 公式 hook に依存し自前は薄い wrapper のみ | **採用** |
| D | `loading.tsx` per-segment 配置 | ◎ 公式機構そのもの | ◎ 設置だけ | × (要件「クリック直後の現ページ滞在中マスク」を満たせない) |

詳細な比較表・性能分析・保守性分析は会話ログで実施済 (plan: `/home/ryuichi/.claude/plans/a-b-kind-aho.md`)。

**最終構成 (4 軸ハイブリッド):**
1. 純粋な `<Link>` 遷移 → **`MaskedLink` (案 C)** で機械置換
2. programmatic 遷移 (`router.push` after Server Action) → **既存 `useTransition` + `<LoadingOverlay>`** を維持し Overlay の表示忘れを補完
3. ログインボタン (Clerk 外部リダイレクト) → **`useState` + Portal で `LoadingOverlay`** を別途実装 (`useLinkStatus` も `loading.tsx` も外部リダイレクトを捕捉できないため)
4. 全マスクは同じ `LoadingOverlay` コンポーネントを共有 → 視覚的・a11y 完全統一

---

## 実装内容詳細

### 1. 共通コンポーネント `MaskedLink` の新規作成
**ファイル:** `src/components/navigation/masked-link.tsx` (新規)

```tsx
<MaskedLink href="/" loadingMessage="ホームへ戻っています...">
  <Button>ホーム</Button>
</MaskedLink>
```

#### 設計上のキー判断
- **`useLinkStatus` の利用**: Next.js 16.2.1 (= v15.3+) で導入された公式 hook。`<Link>` 子孫で `{ pending: boolean }` を取得する。pending は **そのリンクのクリック → 履歴更新前** の間 true。Next.js 内部で既に navigation state を管理しているため、新たな計測コストはほぼゼロ。
- **`createPortal` で `body` 直下に投影 (必須)**: `MaskedLink` は対局終了画面の `<Card>` 内、各ページの `PageMotion` 内など、祖先に **`transform`/`filter`/`will-change`** を持つ要素が頻出する場所に置かれる。CSS 仕様上 transform 親がいると `position: fixed` の containing block が viewport ではなく祖先になり、`inset-0` で画面全面被覆ができなくなる。Portal で `document.body` 直下に出すことで viewport 基準を確保。
  - 検証: [src/components/layout/page-motion.tsx:24](src/components/layout/page-motion.tsx#L24) は `motion.div` で `y: 8 → 0` を当てるため transform parent になる。
- **`useLinkStatus` は子孫でしか読めない制約への対応**: `MaskedLinkInner` を `<Link>` の child として置き、その中で hook を読む構成。
- **`delayMs=80` で「速い遷移は無マスク、遅い遷移は確実マスク」**: prefetch 済みルートでは pending が瞬時に立ち消える。マスクが一瞬フラッシュするのを防ぐため、表示開始に 80ms の delay を入れる。Material Design / iOS HIG の「即座に知覚できる閾値」に合わせた値。
- **多重クリック抑止**: `pending` 中は children を `pointer-events: none` + `aria-busy` でラップ。スパムクリックを吸収。
- **SSR safety**: `mounted` flag で初回マウント完了後にだけ Portal を有効化し、SSR 時の `document` 参照エラーを回避。

### 2. 対局終了画面 — 「ホームへ」「もう一局」両ボタンにマスク

#### 「ホームへ」 (5 箇所、`<Link>` → `<MaskedLink>` 置換)
- [src/components/game/shogi-game.tsx:305](src/components/game/shogi-game.tsx#L305) — 通常将棋 PC レイアウト
- [src/components/game/card-shogi/card-shogi-game.tsx:1363](src/components/game/card-shogi/card-shogi-game.tsx#L1363) — カード将棋 xl レイアウト「PC タブレット相当」
- [src/components/game/card-shogi/card-shogi-game.tsx:1427](src/components/game/card-shogi/card-shogi-game.tsx#L1427) — カード将棋 xl 未満レイアウト
- [src/components/game/card-shogi/card-shogi-game.tsx:1756](src/components/game/card-shogi/card-shogi-game.tsx#L1756) — カード将棋 xl 以上レイアウト (右 aside)
- [src/components/game/mobile-drawer.tsx:114](src/components/game/mobile-drawer.tsx#L114) — モバイルドロワー版

#### 「もう一局」 (`createGame` Server Action 後 `router.push`、6 箇所相当 ⇒ Overlay 1 つで集約)
既に `useTransition` + `isPending` ロジックは存在していたが、`<LoadingOverlay>` の差し込みが漏れていた。コンポーネント末尾に Overlay を追加する形で各レイアウトの ボタンを共通カバー:
- [src/components/game/shogi-game.tsx](src/components/game/shogi-game.tsx) — return を Fragment 化し、末尾に `<LoadingOverlay show={isPending} fullScreen message="次の対局を準備中..." />` を 1 つ追加
- [src/components/game/card-shogi/card-shogi-game.tsx](src/components/game/card-shogi/card-shogi-game.tsx) — root div の末尾 (FastMoveBadgeLayer の後) に同様に追加

> 同一の `isPending` 状態を PC / xl 未満 / モバイルドロワー (`MobileDrawer` への props) すべてが共有しているため、**Overlay はファイルあたり 1 つで全レイアウトをカバー**できる。

### 3. 各ページヘッダーの戻りリンク → `MaskedLink` 機械置換 (8 ファイル)

すべて `<Link>` の props (className, aria-label, onClick, prefetch 等) を維持したまま `<MaskedLink>` に差し替え:
- [src/app/play/page.tsx:23-30](src/app/play/page.tsx#L23) — 「ホーム」 (PageMotion 内)
- [src/app/classic/page.tsx:23-30](src/app/classic/page.tsx#L23), [:44-50](src/app/classic/page.tsx#L44) — 「ホーム」 + 「対局履歴を見る」
- [src/app/cards/page.tsx:22-29](src/app/cards/page.tsx#L22) — 「ホーム」
- [src/app/cards/[id]/page.tsx:48-55](src/app/cards/[id]/page.tsx#L48) — 「カード一覧」戻りリンク
- [src/app/card-design/page.tsx:99-106](src/app/card-design/page.tsx#L99) — 「ホーム」 (sticky header)
- [src/app/history/page.tsx:23-28](src/app/history/page.tsx#L23), [:40-42](src/app/history/page.tsx#L40) — 「ホームへ」 + 空状態「最初の対局を始める」
- [src/app/error.tsx:41-46](src/app/error.tsx#L41) — エラー画面「ホームへ」
- [src/components/decks/decks-page-header.tsx:22-41](src/components/decks/decks-page-header.tsx#L22) — `homeDisabled` 対応の `aria-disabled` + `onClick preventDefault` を維持しつつ MaskedLink 化

> Server Component から Client Component (MaskedLink) を import するパターンに沿っており、**page.tsx を client 化していない**。よって SSR / RSC / metadata / データ取得は無傷。

### 4. ログインボタンに専用 Portal マスクを追加

[src/components/auth/auth-controls.tsx](src/components/auth/auth-controls.tsx) の `renderSignInButton` 関数を、自前 state を持つ `SignInButtonWithMask` コンポーネントに切り出し:

```tsx
function SignInButtonWithMask({ completeUrl }: { completeUrl: string }) {
  const [isSigningIn, setIsSigningIn] = useState(false);
  const [mounted, setMounted] = useState(false);

  useEffect(() => {
    setMounted(true);
  }, []);

  return (
    <>
      <SignInButton mode="redirect" oauthFlow="redirect" forceRedirectUrl={...}>
        <Button
          ...
          onClick={() => setIsSigningIn(true)}
          disabled={isSigningIn}
        >
          <LogIn /> ログイン
        </Button>
      </SignInButton>
      {mounted &&
        createPortal(
          <LoadingOverlay show={isSigningIn} fullScreen message="ログイン画面へ移動中..." />,
          document.body,
        )}
    </>
  );
}
```

#### なぜ `MaskedLink` で対応できないか
Clerk の `<SignInButton mode="redirect">` はクリック時に **Clerk OAuth ホストへの外部リダイレクト** (= ブラウザの `window.location` ベース page redirect) を起こす。これは Next.js のクライアント遷移ではないため、`useLinkStatus` も `loading.tsx` (Suspense) も pending を捕捉できない。`<Link>` でもない。

#### 解決アプローチ
1. ローカル state (`isSigningIn`) を立てて表示制御
2. `disabled={isSigningIn}` で React 側からも二度押し抑止 (Clerk 側の onClick 妨害は避けるため、純粋に visual state)
3. `LoadingOverlay` を Portal で `body` に投影 (各画面ヘッダーは PageMotion 内 = transform 親があるため必須)
4. リダイレクト完了でコンポーネント自体が unmount → state は自然解除

---

## 影響範囲 (touched files)

| ファイル | 変更内容 |
|---|---|
| `src/components/navigation/masked-link.tsx` | 新規作成 (90 行) |
| `src/components/game/shogi-game.tsx` | Link→MaskedLink、LoadingOverlay 1 箇所追加、return Fragment 化 |
| `src/components/game/card-shogi/card-shogi-game.tsx` | Link→MaskedLink × 3、LoadingOverlay 1 箇所追加 |
| `src/components/game/mobile-drawer.tsx` | Link→MaskedLink × 1 |
| `src/app/play/page.tsx` | Link→MaskedLink × 1 |
| `src/app/classic/page.tsx` | Link→MaskedLink × 2 |
| `src/app/cards/page.tsx` | Link→MaskedLink × 1 |
| `src/app/cards/[id]/page.tsx` | Link→MaskedLink × 1 |
| `src/app/card-design/page.tsx` | Link→MaskedLink × 1 |
| `src/app/history/page.tsx` | Link→MaskedLink × 2 |
| `src/app/error.tsx` | Link→MaskedLink × 1 |
| `src/components/decks/decks-page-header.tsx` | Link→MaskedLink × 1 (homeDisabled 制御維持) |
| `src/components/auth/auth-controls.tsx` | renderSignInButton → SignInButtonWithMask (Portal マスク) |

### 触らなかった箇所 (既にマスク済 → 変更不要)
- `src/components/loading-overlay.tsx` — 共通 Overlay は既存品をそのまま再利用
- `src/app/page.tsx` — ホーム画面の `navigateTo` パターンは既にマスク有り
- `src/components/home/match-setup.tsx` — 対局開始ボタンは既存 useTransition+Overlay でマスク有り
- `src/components/cards/card-catalog-tile.tsx` — カード詳細遷移は既にマスク有り

---

## 局所的な実装ポイント (レビュアー向け追加情報)

### `MaskedLinkInner` の `display: contents` 採用理由
Link children を直接 wrap せず、`<span style={{display: "contents"}}>` で包む。`display: contents` は **要素自身がレンダーボックスを生成しない** 仕様で、その children は親 (=`<a>`) の flex/grid に直接参加する。これにより既存 className (`inline-flex items-center gap-1.5` 等) のレイアウトを破壊しない。

### 既存 `useTransition` 非ナビ用途との非衝突
本実装では `useTransition` の運用は維持。
- ナビ用途: `match-setup.tsx`, `card-catalog-tile.tsx`, `shogi-game.tsx`/`card-shogi-game.tsx` の handlePlayAgain
- 非ナビ用途: `shogi-game.tsx` 内の駒移動 (但し、`isPending` 変数はハンドラ内で参照していないため衝突なし)
- 案 B が抱えていた「グローバル isPending と非ナビ useTransition の衝突」リスクは、本実装 (ローカルスコープ) では発生しない

### `decks-page-header.tsx` の `aria-disabled` + `onClick preventDefault` パターン維持
保存中はホーム遷移をブロックする既存挙動 ([Issue #155](https://github.com/ryuichiTtb/Shogi/pull/155) 由来) を完全維持。MaskedLink はそのまま `Link` props を受け取るので、`onClick` で preventDefault されたとき `useLinkStatus.pending` は立たず、マスクも出ない (仕様通り)。

### Clerk SignInButton の onClick 連鎖
Clerk の `<SignInButton>` は子の `<Button>` をラップして OAuth リダイレクト用のクリックハンドラを取り付ける。React の合成イベントは順次発火されるため、`onClick={() => setIsSigningIn(true)}` も Clerk のリダイレクト発火と並行して動作する。

---

## Test plan (Vercel preview で確認いただきたい観点)

- [ ] **対局終了「ホームへ」**: 通常将棋・カード将棋 (PC・xl 未満・モバイルドロワー) で投了 → 「ホームへ」クリック → クリック直後にマスク表示 → ホーム到着で消滅
- [ ] **対局終了「もう一局」**: 同様に PC/モバイル/xl で「もう一局」 → クリック直後にマスク表示 → 新しい対局画面に切り替わったら消滅 (各ボタンの「準備中...」ラベル変化と同期)
- [ ] **各ページヘッダー「ホーム」**: `/play`, `/classic`, `/cards`, `/cards/[id]`, `/decks`, `/card-design`, `/history`, error 画面のヘッダーリンクで遷移マスク
- [ ] **/classic 下部「対局履歴を見る」** リンクでもマスクが出る
- [ ] **/history 空状態「最初の対局を始める」** ボタンでもマスクが出る
- [ ] **ログインボタン**: ホーム画面・各画面ヘッダー (Clerk が有効な環境) でログインボタンクリック → マスク表示 → Clerk 画面へリダイレクト
- [ ] **prefetch 済み高速遷移**: 通常網速度 (prefetch 効く) でホーム戻り → マスクがフラッシュしない (delayMs=80ms で抑制)
- [ ] **Slow 3G**: Network throttling で遅延を付与 → マスクが確実に見える
- [ ] **多重クリック耐性**: 各ボタン/リンクをスパムクリック → マスク中に遷移先で連鎖発火しない
- [ ] **キーボード a11y**: Tab + Enter で遷移リンクを操作 → MaskedLink でも `<Link>` 由来のキーボード操作・focus ring が機能
- [ ] **ブラウザ戻る**: マスク中に戻るボタン → useLinkStatus.pending が解除されマスク消滅
- [ ] **Hydration**: 各ページ初回ロード時、コンソールに hydration warning が出ていないこと (Portal は `mounted` ガード済)
- [ ] **z-index**: Dialog 表示中のマスク重なり (Dialog は z-40、Overlay は z-50)、想定通りに重なる
- [ ] **/decks 保存中**: editor 保存中の「ホーム」が `aria-disabled + pointer-events:none` で操作不可 → マスクも出ない (既存挙動維持)

---

## 自動チェック結果 (ローカル実行済)

- ✅ `npm run typecheck` (tsc --noEmit) 緑
- ✅ `npm run test:ci` 全 233 件通過
- ⚠️ `npm run lint` — 8 件 error 残存。**全て origin/main 由来の既存問題** (character-panel, speech-bubble, deck-editor-pane, board-overlay, shogi-game の **本変更で触っていない useEffect 内 setState**)。本 PR では対応範囲外として保留。

---

## フェーズ 2 候補 (本 PR 範囲外)

`async server page` (`/history`, `/decks`, `/cards/[id]` など) の内部 fetch 待ち期間も埋めたい場合は、`src/app/loading.tsx` を追加する **案 D 併用** を別 PR で検討可。本 PR の MaskedLink マスクが消えた後に新セグメント側 Suspense fallback として表示されるため、長い fetch でも空白期間が発生しない。

---

## 関連

- 関連 Issue: #163
- 関連 plan: `/home/ryuichi/.claude/plans/a-b-kind-aho.md`
- 既存実装パターン参考: [src/components/cards/card-catalog-tile.tsx](src/components/cards/card-catalog-tile.tsx), [src/app/page.tsx](src/app/page.tsx)
- 設計上の依存: Next.js 16.2.1 公式 `useLinkStatus` ([next/dist/client/link.d.ts:117](node_modules/next/dist/client/link.d.ts#L117))
