### PR TITLE
fix: #168 ゲスト初回作成のP2028 transaction timeoutを恒久対応

### DIFF
--- a/src/lib/auth/current-user.ts
+++ b/src/lib/auth/current-user.ts
@@ -194,35 +194,43 @@ export async function getOrCreateGuestUserForToken(token: string): Promise<AppUs
   const existing = await findGuestByTokenHash(tokenHash);
   if (existing) return existing;
 
+  // Issue #168: ゲスト初回作成の interactive transaction を撤去する。Vercel Functions +
+  // Neon HTTP の cold start で Prisma の maxWait (default 2s) を踏み抜き、P2028
+  // ("Unable to start a transaction in the given time") を発生させていたため。
+  // merge.ts (#150) で確立された冪等化パターンに揃え、User と GuestSession を順次
+  // 作成する。GuestSession.tokenHash の @unique 制約で racing は P2002 として検出する。
+  // 部分失敗 (User 作成成功 → GuestSession 作成失敗) では User cleanup を試みた上で
+  // racing 経路に合流する。SIGKILL 等の突然死による User リークは merge.ts と同様の
+  // 設計トレードオフとして許容し、cleanup は別 Issue で扱う。
+  const created = await prisma.user.create({
+    data: {
+      kind: "guest",
+      name: "Guest",
+    },
+  });
+
   try {
-    // Issue #150: User と GuestSession の同時作成のみ atomic にする。
-    // ensureInitialUserData は Card マスタ全件 upsert を含み、
-    // Vercel + Neon HTTP の interactive transaction (5s timeout) に収まらないため、
-    // transaction 外で実行する。upsert ベースで冪等なので途中失敗時の再試行も安全。
-    const user = await prisma.$transaction(async (tx) => {
-      const created = await tx.user.create({
-        data: {
-          kind: "guest",
-          name: "Guest",
-        },
-      });
-      await tx.guestSession.create({
-        data: {
-          tokenHash,
-          userId: created.id,
-          expiresAt: getGuestSessionExpiresAt(),
-        },
-      });
-      return created;
+    await prisma.guestSession.create({
+      data: {
+        tokenHash,
+        userId: created.id,
+        expiresAt: getGuestSessionExpiresAt(),
+      },
     });
-    await ensureInitialUserData(prisma, user.id);
-    return toAppUser(user);
   } catch (error) {
-    if (!isUniqueConstraintError(error)) throw error;
-    const raced = await findGuestByTokenHash(tokenHash);
-    if (!raced) throw error;
-    return raced;
+    // 自分が作った User を best-effort で cleanup (cascade で関連 GuestSession も削除)。
+    // delete 自体が失敗しても racing 経路を継続する。
+    await prisma.user.delete({ where: { id: created.id } }).catch(() => {});
+    if (isUniqueConstraintError(error)) {
+      // 別 request が先に同じ tokenHash で session を作成済 → 既存 session を返す。
+      const raced = await findGuestByTokenHash(tokenHash);
+      if (raced) return raced;
+    }
+    throw error;
   }
+
+  await ensureInitialUserData(prisma, created.id);
+  return toAppUser(created);
 }
 
 export const getCurrentAppUser = cache(async (): Promise<AppUser> => {


### PR DESCRIPTION
## Summary
- モバイル初回 deployment アクセスで発生する P2028 エラー (Prisma transaction timeout) を、`getOrCreateGuestUserForToken` の interactive transaction 撤去 + try-catch + P2002 冪等化 で恒久対応
- merge.ts (#150 で確立されたパターン) と同じ冪等化に揃え、`$transaction` 利用箇所のばらつきを解消
- `current-user.ts` 1 ファイル / 33 insertions, 25 deletions

## 症状

モバイルで初回 deployment アクセス時、一定時間待った後にエラー画面が表示される。リロードすると正常表示。PC では再現しない。

```
Error [PrismaClientKnownRequestError]: Transaction API error: Unable to start a transaction in the given time.
  code: 'P2028',
  meta: {},
  clientVersion: '7.5.0',
  digest: '1805568189'
```

## 根本原因

### 容疑箇所
[src/lib/auth/current-user.ts:202-217](src/lib/auth/current-user.ts#L202-L217) (修正前) の `getOrCreateGuestUserForToken` 内 `prisma.$transaction` (interactive):

```ts
const user = await prisma.$transaction(async (tx) => {
  const created = await tx.user.create({
    data: { kind: "guest", name: "Guest" },
  });
  await tx.guestSession.create({
    data: {
      tokenHash,
      userId: created.id,
      expiresAt: getGuestSessionExpiresAt(),
    },
  });
  return created;
});
```

### Prisma transaction の timeout 仕様 (default 値)
| パラメータ | 既定値 | 意味 |
|-----------|-------|------|
| `maxWait` | **2000ms** | transaction を **開始する** までの最大待ち時間 → 超過すると **P2028** |
| `timeout` | 5000ms | transaction 内処理の最大時間 → 超過すると別エラー |

P2028 は「**transaction が始まる前** に connection 取得で時間切れ」を意味する。

### モバイル初回で踏み抜くメカニズム
ユーザーがモバイルで初めて preview を開いた時のリクエストフロー:

1. 初回 GET `/` → ブラウザにゲスト cookie (`shogi_guest_session`) 無し
2. [src/proxy.ts](src/proxy.ts) の `clerkProxy` (clerkMiddleware) が `auth().userId === null` を検知 → `ensureGuestCookie(request)` で新規ゲスト cookie 発行 (= response に `Set-Cookie`、同 request の `cookies()` API にも反映)
3. SSR 開始 → [src/app/layout.tsx](src/app/layout.tsx) の RootLayout が `getCurrentUserPreferences()` を呼出
4. `getCurrentUserPreferences` → [getCurrentAppUser](src/lib/auth/current-user.ts#L228-L241) → ゲスト経路 → `getOrCreateGuestUserForToken(token)` を呼出
5. `findGuestByTokenHash(tokenHash)` → 新規 cookie のため DB に未登録 → `null`
6. `prisma.$transaction(...)` を起動

ここで以下 3 つの cold start が累積:

| ① Vercel Functions cold start | function instance を新規起動 (~数百ms - 数秒) |
| ② Neon HTTP cold start | DB connection 確立 (~数百ms) |
| ③ Prisma engine 初期化 | Rust binary 起動 / connection pool 初期化 |

これら累積で 2 秒の `maxWait` を踏み抜き → P2028。

### モバイル特異な理由 / PC で再現しない理由 / リロードで治る理由

| 観測 | 説明 |
|------|------|
| **モバイルで一時待ってからエラー** | maxWait=2s 経過後に P2028 が return される |
| **PC で問題なし** | PC は既存ゲスト cookie 持ち → `findGuestByTokenHash` で即返却 → transaction 経路に入らない。検証作業の継続でも Vercel function はウォーム状態を維持 |
| **リロードで治る** | 1 回目のリクエストで Vercel function が起動 + Neon connection が確立。2 回目は両方ウォーム。さらに発行済 cookie で `findGuestByTokenHash` HIT → transaction 経路に入らない |
| **マージ済 #160 では未対応** | 本対応 (#160) は `force-dynamic` / `await auth()` などで認証解決の SSR タイミングを早めたが、ゲスト User の DB 作成自体は別の cold start 問題で independent |

## 過去の関連修正 (適用漏れ)

Issue #150 系列で同種の P2028 を撤去するパターンが既に確立されているが、`current-user.ts:202` だけ修正から取り残されていた:

| Commit | 対応箇所 | 内容 |
|--------|---------|------|
| `223ee3a` | (#150) | Vercel + Neon 環境で interactive transaction が 5s timeout する 500 を修正 |
| `0c32b53` | merge.ts (#150) | merge の interactive transaction を撤去し再ログイン時の 500 を解消 |

[src/lib/auth/merge.ts:217-225](src/lib/auth/merge.ts#L217-L225) のコメントに対処パターンが文書化されている:

> Issue #150: 以前は全 step を prisma.$transaction で囲んでいたが、
> Vercel + Neon HTTP 環境では interactive transaction の 5s timeout に
> 引っかかる (再ログイン時に account/guest 両方の playerCardCollection 30+ 件
> upsert で 5s 超え、P2028 でクラッシュ)。
> 各 step は冪等になるよう設計してあるため (...)、transaction 外の順次実行に変更しても
> 途中失敗時はリロード/再ログインで自然に最終状態へ収束する。

## 修正内容

### 設計方針
[src/lib/auth/merge.ts](src/lib/auth/merge.ts) の `findOrCreateAccountUserShell` / `getOrCreateAccountUser` と同じ冪等化パターンに揃える:

1. `$transaction` を撤去
2. User と GuestSession を **順次実行**
3. `GuestSession.tokenHash` の `@unique` 制約で racing を P2002 として検出
4. 部分失敗 (User 作成成功 → GuestSession 作成失敗) では User を best-effort cleanup
5. P2002 (= 別 request が先行作成) なら `findGuestByTokenHash` で既存 session を返す経路に合流

### 変更後のコード
```ts
const created = await prisma.user.create({
  data: { kind: "guest", name: "Guest" },
});

try {
  await prisma.guestSession.create({
    data: {
      tokenHash,
      userId: created.id,
      expiresAt: getGuestSessionExpiresAt(),
    },
  });
} catch (error) {
  // 自分が作った User を best-effort で cleanup (cascade で関連 GuestSession も削除)。
  // delete 自体が失敗しても racing 経路を継続する。
  await prisma.user.delete({ where: { id: created.id } }).catch(() => {});
  if (isUniqueConstraintError(error)) {
    // 別 request が先に同じ tokenHash で session を作成済 → 既存 session を返す。
    const raced = await findGuestByTokenHash(tokenHash);
    if (raced) return raced;
  }
  throw error;
}

await ensureInitialUserData(prisma, created.id);
return toAppUser(created);
```

### 既存ヘルパの再利用
- `isUniqueConstraintError(error)` ([current-user.ts:53-60](src/lib/auth/current-user.ts#L53-L60)) — Prisma P2002 エラー検出
- `findGuestByTokenHash(tokenHash)` ([current-user.ts:164-186](src/lib/auth/current-user.ts#L164-L186)) — tokenHash から既存 GuestSession を find して User を返す
- 両方とも本対応で新規追加なし

## 設計トレードオフ

### 部分失敗による User リーク
| 失敗タイミング | 挙動 | 影響 |
|-------------|------|------|
| User 作成中失敗 | 例外で抜ける | 影響なし |
| User 作成 → GuestSession 失敗 (P2002) | User cleanup → 既存 session 返却 | racing 1 件で User 1 件廃棄、リーク無し |
| User 作成 → GuestSession 失敗 (P2002 以外) | User cleanup → 例外 throw | 呼び出し元 (RootLayout) が 500 → ユーザーリトライで治る、リーク無し |
| User 作成 → GuestSession 作成中に SIGKILL | cleanup 実行されず | **User リーク** (孤立) |

最後のケース (突然死) は merge.ts も同様に許容している設計トレードオフ。発生確率は実用上極小。孤立 User は kind="guest" / GuestSession 関連無し / 5 分経過で `findGuestByTokenHash` の経路に出てこないため動作影響なし。DB スペース消費だけが残る。

→ **孤立 User の cleanup は別 Issue で扱う** (例: 24h 以上 GuestSession 紐付きが無いゲスト User を定期削除する batch 等)

### Prisma transaction によるトランザクション保証の喪失
撤去前: User と GuestSession の作成が同 transaction で原子的 (成功/失敗が連動)
撤去後: 順次実行で順次に書き込まれる (= 一時的に「User あり / GuestSession なし」の状態が観測される)

ただし:
- 他の経路 (`findGuestByTokenHash` / merge / `getOrCreateAccountUser` 等) は GuestSession 起点で User を見つけるため、孤立 User は他経路から参照されない
- 同じ token の race は P2002 で検出される (= 二重作成を作らない)

→ 機能的・整合性的に問題なし。merge.ts と同じトレードオフ。

## スコープ外 (本 PR では修正しない)

確認者からの指摘で、他にも残存 `$transaction` がある:

| 箇所 | 形式 | 起動条件 | cold start 影響 |
|------|------|---------|----------------|
| [src/app/actions/game.ts:152](src/app/actions/game.ts#L152) | interactive | 対局中の手指し | 中 (ログイン後だが、対局再開 cold start) |
| [src/app/actions/game.ts:202](src/app/actions/game.ts#L202) | interactive | undo 等 | 中 |
| [src/app/actions/game.ts:285](src/app/actions/game.ts#L285) | interactive | 投了 等 | 中 |
| [src/app/actions/deck.ts:244](src/app/actions/deck.ts#L244) | sequential (`[...]`) | デッキ操作 | 小 (sequential は maxWait なし) |
| [src/app/actions/deck.ts:271](src/app/actions/deck.ts#L271) | sequential | デッキ操作 | 小 |

これらはログイン済ユーザー操作で、初回 cold start の影響を直接受けにくく実害観測なし。本 PR では修正せず、Issue #168 本文に「点検対象 / 別途対応」として整理済み。

## Test plan

### 自動チェック
- [x] `pnpm typecheck`: 緑
- [x] `pnpm test:ci`: 236/236 passed
- [x] `pnpm lint`: 8 errors (origin/main と同一セット、本 PR の新規 error 0)

### Vercel preview 動作確認 (レビュアーにお願い)

#### ケース A (主症状の解消)
- [ ] **モバイル** で **シークレットウィンドウ** から preview にアクセス (= ゲスト cookie なしの cold start)
- [ ] P2028 エラー画面が出ず、ホーム画面が正常表示されること
- [ ] DevTools Network タブで HTML response が 200 OK を返すこと

#### ケース B (既存ゲストユーザー回帰)
- [ ] 既存ゲスト cookie 持ち (= `localStorage` 含む既存セッション) で preview にアクセス
- [ ] `findGuestByTokenHash` で即返却される経路 → 正常表示

#### ケース C (Clerk ログイン済みユーザー回帰)
- [ ] Clerk ログイン済みで preview にアクセス
- [ ] ゲスト経路に入らない → 正常表示

#### ケース D (race condition、人工的に再現できれば)
- [ ] 同じゲスト cookie の token を持って 2 タブ同時に preview にアクセス → 片方が P2002 経路に入っても正常に既存 session が返ること
  - 実用上 race は 32 バイト random token なので確率ゼロ。本ケースは挙動仕様の確認用

## 受け入れ条件 (Issue #168 から再掲)

- [x] `current-user.ts:202` から `$transaction` を撤去し try-catch + P2002 冪等化に置き換える
- [ ] モバイル初回アクセスで P2028 が発生しないこと (Vercel preview で確認、レビュアー検証)
- [x] 既存テスト緑 (`pnpm test:ci`: 236/236)
- [x] 既存の Server Action / 認証フローに回帰がないこと (typecheck / lint で確認)
- [x] 孤立 User cleanup は本対応スコープ外として残課題に明記

## 共通レビュールール

Issue #109「共通レビュールール」に従い、以下の各段階で都度 #109 を再取得してレビュー実施済み:

- [x] 実装着手前 (実装方針確認、スキーマ確認)
- [x] 実装完了後、コミット/push 前 (冗長 try-catch を簡素化、最終整合確認)
- [ ] マージ前 (Vercel preview の動作確認後、最終レビュー)

Closes #168
