### PR TITLE
fix: #170 詰み成立時に自動ドロー進捗加算・発火を抑止

### DIFF
--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -402,6 +402,11 @@ function applyTurnEndEffects(
   state: CardShogiGameStateInternal,
   player: Player,
 ): CardShogiGameStateInternal {
+  // Issue #170: 詰み・投了など対局終了後はドロー進捗加算と自動ドロー発火を行わない。
+  // 詰ます手で同時にしきい値到達した場合に詰み演出と自動ドロー演出が同時実行される
+  // のを防ぐ。終局後は進捗が動いても UI 上で意味がないため、ここで止めてよい。
+  if (state.gameState.status !== "active") return state;
+
   const current = state.cardState.drawProgress[player];
   const next = current + 1;
   const deck = state.cardState.deck[player];


### PR DESCRIPTION
## Summary

- 詰みになる手と自動ドローしきい値到達が重なった場合、詰み演出と自動ドロー演出が同時実行されていたバグの修正。
- `applyTurnEndEffects` 冒頭で `gameState.status !== "active"` のとき早期 return することで、進捗加算と自動ドロー発火を抑止。

## 設計判断

- 終局後 (詰み・投了・引き分け) はドロー進捗を加算しても UI 上で意味がないため、進捗加算ごと止める設計とした (= 進捗ゲージは終局直前の状態のまま停止)。
- 修正範囲は `applyTurnEndEffects` のみで、呼び出し側 (MAKE_MOVE / CONFIRM_PROMOTION / COMMIT_DRAW / COMMIT_PLAY_CARD) は無修正。

## Test plan

- [x] 既存 card-shogi テスト (90件) グリーン
- [x] typecheck 通過
- [ ] Vercel プレビュー: drawProgress 4 状態で詰む手を指し、自動ドロー演出が出ないこと
- [ ] Vercel プレビュー: 通常進行 (status=active) では従来通り進捗加算・自動ドロー発火すること

Closes #170