### PR TITLE
fix: #173 二歩指しで王手演出が発火しないバグ修正

### DIFF
--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -603,7 +603,24 @@ export function CardShogiGame({
                 setPlayFlight({ card: cardInstance, key: playFlightKeyRef.current, isTrap: false });
               }
             } else if (!pendingPlayFlightRef.current) {
-              // 駒フライト未発火 (= 駒移動なしカード) → 中央カード演出を即発火
+              // 駒フライト未発火 (= 駒移動なしカード or 二歩指し) → 中央カード演出を即発火
+              //
+              // Issue #173: 二歩指し (double_pawn) は moveCount を増やさないため
+              // moveCount useEffect 経由で王手 SFX/演出が発火しない。中央カード演出
+              // より前にここで発火する。
+              // 二手指し (double_move) は moveEvent と paired で moveCount が動くため
+              // moveCount useEffect 側で既に発火済み → effectId で gate して二重発火を回避。
+              if (def.effectId === "double_pawn") {
+                const opponentColor: Player =
+                  playerColor === "sente" ? "gote" : "sente";
+                if (
+                  gameState.status === "active" &&
+                  isInCheck(gameState, opponentColor, CARD_SHOGI_VARIANT)
+                ) {
+                  playSfx("check");
+                  setOverlayEvent({ event: "check", key: Date.now() });
+                }
+              }
               playFlightKeyRef.current += 1;
               setPlayFlight({ card: cardInstance, key: playFlightKeyRef.current, isTrap: false });
             }
@@ -771,12 +788,10 @@ export function CardShogiGame({
         let pieceType: string | null = null;
         let hideTarget: FlightHideTarget | null = null;
 
-        if (def.effectId === "double_pawn") {
-          fromRect = findVisibleCapturedPieceRect(playerColor, "pawn");
-          toRect = getBoardSquareRect(pos.row, pos.col);
-          pieceType = "pawn";
-          hideTarget = { kind: "board", row: pos.row, col: pos.col };
-        } else if (def.effectId === "pawn_return" || def.effectId === "piece_return") {
+        // Issue #173: 二歩指し (double_pawn) は駒フライトを行わず、通常の持駒打ちと
+        // 同じ動きにする (Framer Motion の layout アニメーション任せ)。
+        // pawn_return / piece_return は引き続きフライト演出 (盤上 → 持駒)。
+        if (def.effectId === "pawn_return" || def.effectId === "piece_return") {
           const piece = gameState.board[pos.row]?.[pos.col];
           if (piece) {
             fromRect = getBoardSquareRect(pos.row, pos.col);

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -346,7 +346,6 @@ export function CardShogiGame({
   // 安全)。詳細は shogi-game.tsx のコメント参照。
   const lastMoveCountRef = useRef(gameState.moveCount);
   const lastStatusRef = useRef(gameState.status);
-  const lastIsPlayingCardRef = useRef(isPlayingCard);
   const gameStartFiredRef = useRef(false);
 
   useEffect(() => {
@@ -366,10 +365,7 @@ export function CardShogiGame({
     } else {
       playSfx("piece_move");
     }
-    // 二手指し 2手目のように、MAKE_MOVE 完了時点で isPlayingCard=true (カード演出待ち)
-    // のケースは、ここで王手 SFX を鳴らすと下の card-commit effect と二重発火するので
-    // スキップ。COMMIT_PLAY_CARD 後 (isPlayingCard=false) のタイミングで発火させる。
-    if (displayInCheck && !isPlayingCard) {
+    if (displayInCheck) {
       playSfx("check");
       setOverlayEvent({ event: "check", key: Date.now() });
     }
@@ -379,22 +375,6 @@ export function CardShogiGame({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameState.moveCount]);
-
-  // Issue #173: 二歩指し等、moveCount を増やさず盤面を変えるカード使用で
-  // 王手になったケースの王手演出。COMMIT_PLAY_CARD 完了 (= isPlayingCard true→false)
-  // のタイミングで displayInCheck を評価し、必要なら発火する。
-  // 二手指しの 2手目で isPlayingCard が true→false 遷移するパスにも乗るが、
-  // 上の moveCount effect 側で `!isPlayingCard` ガードを入れているため二重発火しない。
-  useEffect(() => {
-    const wasPlaying = lastIsPlayingCardRef.current;
-    lastIsPlayingCardRef.current = isPlayingCard;
-    if (!wasPlaying || isPlayingCard) return;
-    if (displayInCheck) {
-      playSfx("check");
-      setOverlayEvent({ event: "check", key: Date.now() });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPlayingCard]);
 
   useEffect(() => {
     if (lastStatusRef.current === gameState.status) return;
@@ -903,8 +883,24 @@ export function CardShogiGame({
   // - cardPlayEvent エフェクト側で「駒フライト or 中央カード演出」のどちらを先に発火するか判断
   // - 駒移動を伴うカードは駒フライトのみ発火し、handlePieceFlightComplete で中央カード演出を予約発火
   // - 中央カード演出完了 (handlePlayFlightComplete) で finalize → COMMIT_PLAY_CARD
+  //
+  // Issue #173: 二歩指し等で相手玉が王手になるケースは、駒フライト完了直後・
+  // 中央カード演出開始前に王手演出を挟む。CONFIRM_PLAY_CARD 時点では
+  // currentPlayer 反転が COMMIT まで保留されるため、ここでは opponent 側を
+  // 直接判定する (gameState.currentPlayer はカード使用者本人)。
   const handlePieceFlightComplete = useCallback(() => {
     setPieceFlight(null);
+
+    const opponentColor: Player =
+      gameState.currentPlayer === "sente" ? "gote" : "sente";
+    if (
+      gameState.status === "active" &&
+      isInCheck(gameState, opponentColor, CARD_SHOGI_VARIANT)
+    ) {
+      playSfx("check");
+      setOverlayEvent({ event: "check", key: Date.now() });
+    }
+
     const pendingPlay = pendingPlayFlightRef.current;
     if (pendingPlay) {
       playFlightKeyRef.current += 1;
@@ -918,7 +914,7 @@ export function CardShogiGame({
       // 中央カード演出が予約されていない異常系: 直接 finalize
       finalizePlayCard();
     }
-  }, [finalizePlayCard]);
+  }, [finalizePlayCard, gameState, playSfx]);
 
   const handlePlayFlightComplete = useCallback(() => {
     setPlayFlight(null);

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -346,6 +346,7 @@ export function CardShogiGame({
   // 安全)。詳細は shogi-game.tsx のコメント参照。
   const lastMoveCountRef = useRef(gameState.moveCount);
   const lastStatusRef = useRef(gameState.status);
+  const lastIsPlayingCardRef = useRef(isPlayingCard);
   const gameStartFiredRef = useRef(false);
 
   useEffect(() => {
@@ -365,7 +366,10 @@ export function CardShogiGame({
     } else {
       playSfx("piece_move");
     }
-    if (displayInCheck) {
+    // 二手指し 2手目のように、MAKE_MOVE 完了時点で isPlayingCard=true (カード演出待ち)
+    // のケースは、ここで王手 SFX を鳴らすと下の card-commit effect と二重発火するので
+    // スキップ。COMMIT_PLAY_CARD 後 (isPlayingCard=false) のタイミングで発火させる。
+    if (displayInCheck && !isPlayingCard) {
       playSfx("check");
       setOverlayEvent({ event: "check", key: Date.now() });
     }
@@ -375,6 +379,22 @@ export function CardShogiGame({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameState.moveCount]);
+
+  // Issue #173: 二歩指し等、moveCount を増やさず盤面を変えるカード使用で
+  // 王手になったケースの王手演出。COMMIT_PLAY_CARD 完了 (= isPlayingCard true→false)
+  // のタイミングで displayInCheck を評価し、必要なら発火する。
+  // 二手指しの 2手目で isPlayingCard が true→false 遷移するパスにも乗るが、
+  // 上の moveCount effect 側で `!isPlayingCard` ガードを入れているため二重発火しない。
+  useEffect(() => {
+    const wasPlaying = lastIsPlayingCardRef.current;
+    lastIsPlayingCardRef.current = isPlayingCard;
+    if (!wasPlaying || isPlayingCard) return;
+    if (displayInCheck) {
+      playSfx("check");
+      setOverlayEvent({ event: "check", key: Date.now() });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPlayingCard]);
 
   useEffect(() => {
     if (lastStatusRef.current === gameState.status) return;


### PR DESCRIPTION
## Summary

- 二歩指し (double_pawn) を使って相手玉に王手をかけても、王手演出 (SFX + 中央オーバーレイ) が発火しないバグを修正。
- ユーザー要望に基づき、フィードバックを取り込んで段階的に調整した最終形として、二歩指しの駒打ちは通常の持駒打ちと同じ動きに統一し、王手演出は中央カード演出より前に発火する。

## 設計判断

- 二歩指しは reducer で `applyDoublePawn` を直接呼ぶため `moveCount` が増えず、既存の `useEffect([gameState.moveCount])` 経由の王手演出ロジックに乗っていなかった。
- 駒フライト演出は廃止し、`Framer Motion` の layout アニメによる「通常打ち」と同じ動きに統一。
- 王手演出は `cardPlayEvent` useEffect の「フライト未発火」分岐で `def.effectId === "double_pawn"` のときだけ発火させる (二手指しは moveCount 経由で既発火のため除外して二重発火を回避)。
- 派生として、`pawn_return` / `piece_return` のフライト完了時にも opponent 側の王手判定を実施する経路を追加 (これらは現実問題で起きにくいが、原理的に統一)。

## 影響範囲

- `pawn_return` / `piece_return` のフライト演出は維持。
- `double_move` のフローは無変更 (moveCount useEffect 経由)。

## Test plan

- [x] 既存 card-shogi テスト (90件) グリーン
- [x] typecheck 通過
- [ ] Vercel プレビュー: 二歩指しで相手玉直前に歩を打つ → 歩は通常打ちアニメで盤面に現れ、その後王手演出 → 中央カード演出
- [ ] Vercel プレビュー: 二歩指しで王手にならないケースは王手演出なし、中央カード演出のみ
- [ ] Vercel プレビュー: 通常の駒移動による王手 (デグレ確認) — 王手演出が出る
- [ ] Vercel プレビュー: 二手指し 2手目で王手 (デグレ確認) — 王手演出が出る (moveCount 経由)
- [ ] Vercel プレビュー: 二手指し 1手目自玉王手の transient 抑制 (デグレ確認) — 演出なし

Closes #173