### PR TITLE
feat: #174 持駒の持ち数表示を緑枠チップで視認性改善

### DIFF
--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -96,11 +96,7 @@ export const CapturedPieces = memo(function CapturedPieces({
               />
               {count > 1 && (
                 <span
-                  className="absolute bottom-0 right-0.5 text-xs font-bold text-foreground leading-none z-10"
-                  style={{
-                    textShadow:
-                      "0 0 2px rgba(255,255,255,0.95), 0 0 2px rgba(255,255,255,0.95), 0 1px 1px rgba(255,255,255,0.85)",
-                  }}
+                  className="absolute bottom-0 right-0 text-xs font-bold leading-none z-10 px-1 py-px rounded-sm border border-green-500 bg-background text-foreground"
                 >
                   {count}
                 </span>

--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -96,7 +96,7 @@ export const CapturedPieces = memo(function CapturedPieces({
               />
               {count > 1 && (
                 <span
-                  className="absolute bottom-0 right-0 text-xs font-bold leading-none z-10 px-1 py-px rounded-sm border border-green-500 bg-background text-foreground"
+                  className="absolute -bottom-1 -right-1 text-[10px] font-bold leading-none z-10 px-1 py-px rounded-sm border border-green-500 bg-background text-foreground"
                 >
                   {count}
                 </span>

--- a/src/components/game/captured-pieces.tsx
+++ b/src/components/game/captured-pieces.tsx
@@ -95,7 +95,13 @@ export const CapturedPieces = memo(function CapturedPieces({
                 playerColor={playerColor}
               />
               {count > 1 && (
-                <span className="absolute bottom-0 right-0.5 text-xs text-muted-foreground leading-none z-10">
+                <span
+                  className="absolute bottom-0 right-0.5 text-xs font-bold text-foreground leading-none z-10"
+                  style={{
+                    textShadow:
+                      "0 0 2px rgba(255,255,255,0.95), 0 0 2px rgba(255,255,255,0.95), 0 1px 1px rgba(255,255,255,0.85)",
+                  }}
+                >
                   {count}
                 </span>
               )}


### PR DESCRIPTION
## Summary

- 持駒の持ち数 (×2 等) が `text-muted-foreground` で背景・駒画像と同化していたため、緑枠線 + 背景塗りのチップ風 UI で視認性を改善。
- モバイルで駒の文字 (例: 「歩」) にチップが被って読みづらかった問題を、チップを右下角の外側に張り出させ、フォントを `text-[10px]` に縮めることで解消。

## 変更内容

`src/components/game/captured-pieces.tsx` のみ:
- `text-muted-foreground` 単色 → `border-green-500` 1px ボーダー + `bg-background` テーマ依存背景 + `text-foreground` 太字
- 位置 `bottom-0 right-0.5` → `-bottom-1 -right-1` (ボタン右下角外側 4px)
- フォント `text-xs` → `text-[10px]`
- 旧 textShadow 削除

## 設計判断

- 当初は textShadow による白縁取りで対応したが、木目盤上では依然視認しづらかったためチップ化に切替。
- 緑枠は確認用カラーで、感触次第で別色に変更可能 (本 PR は緑のままマージし、必要に応じて続編で調整想定)。
- `-bottom-1 -right-1` は隣の持駒ボタンとの `gap-1=4px` を超えない範囲に収め、レイアウト破綻を防ぐ。

## Test plan

- [x] typecheck 通過
- [x] 既存テストグリーン
- [ ] Vercel プレビュー (PC): 持ち数チップが駒の文字に被らないこと
- [ ] Vercel プレビュー (モバイル): 同上
- [ ] 暗テーマ・明テーマ双方でチップ可読性確認

Closes #174