### PR TITLE
feat: #183 デッキ編成カード長押し PC 対応 + ダイアログ拡大

### DIFF
--- a/src/components/decks/card-detail-dialog.tsx
+++ b/src/components/decks/card-detail-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -35,6 +35,13 @@ function computeDialogInnerWidth(vw: number): number {
 
 // 本文スクロール領域のため詳細カードはヘッダに固定。縦幅を抑えるための係数。
 const CARD_HEIGHT_FACTOR = 0.85;
+
+// Issue #183: 長押し → ダイアログ open → ユーザーが指/マウスを離した瞬間、
+// 押下位置が overlay 上だった場合に Base UI Dialog の outside-press 検出が
+// 反応してダイアログが即閉じてしまう。これを防ぐため、open 直後はこの時間内
+// の outside-press 由来 close を無視する。close ボタン / Escape / focus-out
+// は通常通り即閉じる (理由を区別して cancel するため)。
+const OUTSIDE_DISMISS_GRACE_MS = 500;
 
 // xl カード (576×352) を Dialog 内側幅に合わせて transform: scale で縮小する。
 // container 測定 (clientWidth) は grid auto-track の挙動でうまく行かない
@@ -95,25 +102,49 @@ export function CardDetailDialog({ cardId, onClose }: CardDetailDialogProps) {
   // 長押し終端で指が dialog 内テキスト上にあると、ブラウザの「単語選択」が
   // 走ってしまうため。300ms 後に解除して通常のテキスト選択 / コピーは可。
   const [selectable, setSelectable] = useState(false);
+  // Issue #183: open 直後 OUTSIDE_DISMISS_GRACE_MS 中の outside-press 由来
+  // close を無視するためのフラグ。state ではなく ref にしているのは
+  // onOpenChange callback が closure で古い値を掴むのを避けるため。
+  const dismissAllowedRef = useRef(false);
+
   useEffect(() => {
     if (cardId === null) {
       setSelectable(false);
+      dismissAllowedRef.current = false;
       return;
     }
     setSelectable(false);
+    dismissAllowedRef.current = false;
     // open 起点の意図しない範囲選択をクリア
     if (typeof window !== "undefined") {
       window.getSelection()?.removeAllRanges();
     }
-    const t = window.setTimeout(() => setSelectable(true), 300);
-    return () => window.clearTimeout(t);
+    const tSel = window.setTimeout(() => setSelectable(true), 300);
+    const tDismiss = window.setTimeout(() => {
+      dismissAllowedRef.current = true;
+    }, OUTSIDE_DISMISS_GRACE_MS);
+    return () => {
+      window.clearTimeout(tSel);
+      window.clearTimeout(tDismiss);
+    };
   }, [cardId]);
 
   return (
     <Dialog
       open={cardId !== null}
-      onOpenChange={(o) => {
-        if (!o) onClose();
+      onOpenChange={(o, details) => {
+        if (o) return;
+        // 長押し終端で発生する outside-press のみ grace 中は無視する。
+        // close ボタン (close-press) / Escape (escape-key) / focus-out
+        // 等は通常通り即閉じる。
+        if (
+          details.reason === "outside-press" &&
+          !dismissAllowedRef.current
+        ) {
+          details.cancel();
+          return;
+        }
+        onClose();
       }}
     >
       <DialogContent

--- a/src/components/decks/card-detail-dialog.tsx
+++ b/src/components/decks/card-detail-dialog.tsx
@@ -18,14 +18,19 @@ const XL_W = 576;
 const XL_H = 352;
 
 // Dialog の固定パラメータ (CardDetailDialog 側の className と一致)
-// - mobile (< sm 640px): w = min(vw - 32, max-w-md=448), padding = p-4 (32 total)
-// - sm+:                 w = sm:max-w-sm=384, padding = p-4 (32 total)
+// Issue #183: PC で詳細をより広く表示するため、sm/lg で段階拡大する設計に変更。
+// - mobile (< sm 640px):  w = min(vw - 32, max-w-md=448),  padding = p-4 (32 total)
+// - sm/md (640-1023px):   w = min(vw - 32, max-w-xl=576),  padding = p-4 (32 total)
+// - lg+   (≥1024px):      w = min(vw - 32, max-w-2xl=672), padding = p-4 (32 total)
+// w-[calc(100%-2rem)] により vw - 32 を越えないクランプが効く。
 function computeDialogInnerWidth(vw: number): number {
   if (vw < 640) {
-    const dialogW = Math.min(vw - 32, 448);
-    return dialogW - 32;
+    return Math.min(vw - 32, 448) - 32;
   }
-  return 384 - 32;
+  if (vw < 1024) {
+    return Math.min(vw - 32, 576) - 32;
+  }
+  return Math.min(vw - 32, 672) - 32;
 }
 
 // 本文スクロール領域のため詳細カードはヘッダに固定。縦幅を抑えるための係数。
@@ -113,7 +118,9 @@ export function CardDetailDialog({ cardId, onClose }: CardDetailDialogProps) {
     >
       <DialogContent
         className={cn(
-          "max-w-md w-[calc(100%-2rem)] max-h-[85vh]",
+          // Issue #183: PC でも詳細をしっかり読めるよう sm/lg で段階拡大。
+          // computeDialogInnerWidth と数値を一致させること。
+          "max-w-md sm:max-w-xl lg:max-w-2xl w-[calc(100%-2rem)] max-h-[85vh]",
           // grid + p-4 + gap-4 を上書きし、自前で flex-col + 内側 padding。
           "flex flex-col gap-0 overflow-hidden p-0",
           !selectable && "select-none",

--- a/src/components/decks/deck-card-tile.tsx
+++ b/src/components/decks/deck-card-tile.tsx
@@ -155,31 +155,34 @@ export function DeckCardTile({
       data-card-id={cardId}
       data-instance-key={instanceKey ?? "single"}
       title={title}
+      // Issue #183: PC でもクリック長押しで詳細を表示できるよう、pointer event を
+      // 親 motion.div で一元的に listen する。pointer event は子 (mobile button /
+      // desktop CardView) から bubble するため、ブレークポイント別 (lg:hidden /
+      // hidden lg:block) の表示切替に関わらず両方で同じ長押しロジックが効く。
+      // user-select / callout 抑止も親で吸収して mobile / desktop 共通に適用。
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={cancelLongPress}
+      onPointerLeave={cancelLongPress}
+      onPointerCancel={cancelLongPress}
+      onContextMenu={(e) => e.preventDefault()}
+      style={{
+        WebkitUserSelect: "none",
+        WebkitTouchCallout: "none",
+        userSelect: "none",
+      }}
     >
       {/* モバイル: コンパクトタイル (cost + icon + name) + 長押し詳細
           注意: 0 枚カードでも長押しで詳細を見せたいので HTML disabled は
           付けず aria-disabled + 見た目だけ無効にする。click は handleClick
-          側で disabled 早期 return。pointerDown (long-press) は受け付ける。 */}
+          側で disabled 早期 return。長押し検出は親 motion.div 側に集約。 */}
       <button
         type="button"
         onClick={handleClick}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={cancelLongPress}
-        onPointerLeave={cancelLongPress}
-        onPointerCancel={cancelLongPress}
-        // 長押し時の text 選択 / iOS Safari の callout (コピー / 共有メニュー) /
-        // Android Chrome の context menu を抑止。
-        onContextMenu={(e) => e.preventDefault()}
         aria-disabled={disabled}
-        style={{
-          WebkitUserSelect: "none",
-          WebkitTouchCallout: "none",
-          userSelect: "none",
-        }}
         className={cn(
           "lg:hidden relative overflow-hidden w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md border-2",
-          "transition-all touch-manipulation select-none",
+          "transition-all touch-manipulation",
           // shine / 動的グラデ背景は relative overflow-hidden が前提。
           COMPACT_RARITY_CLASS[def.rarity],
           !disabled && "cursor-pointer active:scale-95",

--- a/src/components/decks/deck-card-tile.tsx
+++ b/src/components/decks/deck-card-tile.tsx
@@ -43,9 +43,9 @@ interface DeckCardTileProps {
   ghosted?: boolean;
 }
 
-// Issue #183: PC でも長押しで詳細を出す方針に伴い、450ms → 300ms へ短縮。
-// 通常タップ (50〜200ms) と十分に区別でき、PC マウス操作でも待ち感が少ない値。
-const LONG_PRESS_MS = 300;
+// Issue #183: PC でも長押しで詳細を出す方針に伴い、450ms → 250ms へ短縮。
+// 通常タップ (50〜200ms) との交絡を避けつつ、PC マウス操作での待ち感を最小化。
+const LONG_PRESS_MS = 250;
 // pointer がこの px だけ動いたら長押しはキャンセル (スクロール意図とみなす)。
 // 一度キャンセルされたら、指を離すまで再開しない。
 const LONG_PRESS_MOVE_THRESHOLD_PX = 10;

--- a/src/components/decks/deck-card-tile.tsx
+++ b/src/components/decks/deck-card-tile.tsx
@@ -43,7 +43,9 @@ interface DeckCardTileProps {
   ghosted?: boolean;
 }
 
-const LONG_PRESS_MS = 450;
+// Issue #183: PC でも長押しで詳細を出す方針に伴い、450ms → 300ms へ短縮。
+// 通常タップ (50〜200ms) と十分に区別でき、PC マウス操作でも待ち感が少ない値。
+const LONG_PRESS_MS = 300;
 // pointer がこの px だけ動いたら長押しはキャンセル (スクロール意図とみなす)。
 // 一度キャンセルされたら、指を離すまで再開しない。
 const LONG_PRESS_MOVE_THRESHOLD_PX = 10;


### PR DESCRIPTION
## Summary
- PC 版でもクリック長押し (250ms) でカード詳細ダイアログを表示できるように
- 長押し発火時間を 450ms → 250ms へ短縮 (タップ 50〜200ms との交絡なし)
- カード詳細ダイアログを画面サイズで段階拡大 (mobile=md / sm-md=xl / lg+=2xl)
- 長押し直後の outside-press による意図しない close を grace period (500ms) で防止 (Base UI の `eventDetails.reason` で `outside-press` のみ cancel。close-press / escape-key は通常通り即閉じる)

Closes #183

## Test plan
- [x] PC 上のブラウザでデッキ編成画面のカードを 250ms 程度クリック長押し → 詳細ダイアログが表示される
- [x] mobile 端末で従来通り長押しで詳細表示できる (回帰なし)
- [x] 長押し → 直後にマウスを離してもダイアログが閉じない (outside-press grace)
- [x] 詳細ダイアログ open 後 500ms 経過後はオーバーレイクリックで閉じる
- [x] X ボタン / Escape は grace 中でも即閉じる
- [x] sm/md タブレットで詳細ダイアログが従来より広く表示される
- [x] lg+ デスクトップで詳細ダイアログが従来より広く表示される
- [x] mobile (< sm 640px) では従来と同じ幅 (回帰なし)