### PR TITLE
feat: #187 デッキ編成 カード長押し詳細 SFX 追加

### DIFF
--- a/src/components/decks/deck-editor-pane.tsx
+++ b/src/components/decks/deck-editor-pane.tsx
@@ -75,6 +75,8 @@ export function DeckEditorPane({
   // 長押しで開くカード詳細 dialog。null=非表示。
   const [detailCardId, setDetailCardId] = useState<CardId | null>(null);
   const handleLongPressDetail = useCallback((cardId: CardId) => {
+    // Issue #187: デッキ編成 カード長押し詳細表示 SFX (default = カードをめくる)
+    playSfxOnce("deck_card_detail_open");
     setDetailCardId(cardId);
   }, []);
 

--- a/src/lib/audio/manifest.ts
+++ b/src/lib/audio/manifest.ts
@@ -62,6 +62,8 @@ export const SFX_FILES: Record<string, string> = {
   nav_forward: "/sounds/piece-move.mp3",
   // 画面遷移 戻るボタン → ナイフを投げる音
   nav_back: "/sounds/音源/振る/ナイフを投げる.mp3",
+  // ★ Issue #187: デッキ編成 カード長押しでカード詳細ダイアログ open
+  deck_card_detail_open: "/sounds/音源/カードをめくる.mp3",
 };
 
 // BGM (画面/状態別ループ再生される長尺素材)。

--- a/src/lib/dev/__tests__/sound-overrides.test.ts
+++ b/src/lib/dev/__tests__/sound-overrides.test.ts
@@ -92,6 +92,7 @@ describe("sound-overrides parseStored (SFX)", () => {
       card_use_confirm: "/sounds/piece-capture.mp3",
       card_use_animation: "/sounds/jump.mp3",
       deck_card_move: "/sounds/piece-capture.mp3",
+      deck_card_detail_open: "/sounds/piece-promote.mp3",
       deck_save: "/sounds/piece-promote.mp3",
       nav_forward: "/sounds/piece-move.mp3",
       nav_back: "/sounds/jump.mp3",
@@ -150,8 +151,8 @@ describe("isAllowedSoundPath", () => {
 });
 
 describe("SFX_EVENT_KEYS / BGM_EVENT_KEYS integrity", () => {
-  it("has 28 SFX events (26 base + deck_save + nav_back)", () => {
-    expect(SFX_EVENT_KEYS.length).toBe(28);
+  it("has 29 SFX events (28 base + deck_card_detail_open)", () => {
+    expect(SFX_EVENT_KEYS.length).toBe(29);
   });
 
   it("has 4 BGM events", () => {

--- a/src/lib/dev/sound-overrides.ts
+++ b/src/lib/dev/sound-overrides.ts
@@ -49,7 +49,9 @@ export type SfxEventKey =
   | "deck_card_move"
   | "deck_save"
   | "nav_forward"
-  | "nav_back";
+  | "nav_back"
+  // ★ Issue #187: デッキ編成 カード長押しで詳細ダイアログ open
+  | "deck_card_detail_open";
 
 export const SFX_EVENT_KEYS: readonly SfxEventKey[] = [
   // 駒系
@@ -81,6 +83,7 @@ export const SFX_EVENT_KEYS: readonly SfxEventKey[] = [
   "trap_trigger",
   // UI 系 (デッキ編成 / 画面遷移)
   "deck_card_move",
+  "deck_card_detail_open",
   "deck_save",
   "nav_forward",
   "nav_back",
@@ -113,6 +116,7 @@ export const SFX_EVENT_LABELS: Record<SfxEventKey, string> = {
   card_use_confirm: "カード使用確定 (使用ボタン押下)",
   card_use_animation: "カード使用演出 (中央演出開始)",
   deck_card_move: "デッキ編成 カード移動",
+  deck_card_detail_open: "デッキ編成 カード詳細表示 (長押し)",
   deck_save: "デッキ編成 保存ボタン",
   nav_forward: "画面遷移 (戻る以外のボタン)",
   nav_back: "画面遷移 (戻る系ボタン)",


### PR DESCRIPTION
## Summary
- 新規 SFX event \`deck_card_detail_open\` 追加 (label: 「デッキ編成 カード詳細表示 (長押し)」)
- default: \`/sounds/音源/カードをめくる.mp3\`
- 発火: \`deck-editor-pane.tsx\` の \`handleLongPressDetail\` (カード長押しで詳細ダイアログ open)
- 合計 SFX event 数: 28 → 29

## Test plan
- [x] \`npx tsc --noEmit\` 緑
- [x] \`pnpm test:ci\` 261/261 pass
- [x] \`pnpm build\` 成功
- [ ] Vercel Preview でデッキ編成画面のカード長押しで SFX が鳴る

Closes #187