### PR TITLE
fix: #198 モバイル BGM 二重再生 / 音量バランス / 無音バグを Hybrid 化で解消

### DIFF
--- a/src/hooks/__tests__/use-bgm-visibility.test.ts
+++ b/src/hooks/__tests__/use-bgm-visibility.test.ts
@@ -407,4 +407,23 @@ describe("use-bgm: GainNode 経由の音量制御 (Issue #198)", () => {
     // 最新の GainNode は gain=0 で初期化 (= 無音状態で unlock)
     expect(createdGainNode!.gain.value).toBe(0);
   });
+
+  it("startBgm の play() 成功時に AudioContext.resume() が呼ばれる (Issue #198)", async () => {
+    const engine = await import("@/lib/audio/audio-engine");
+    // ensureCtx を呼んで AudioContext を初期化させる + resume の spy 取得
+    engine.getAudioCtx();
+    const ctx = engine.__forTest.getCtx();
+    expect(ctx).not.toBeNull();
+    // ctx は最初 suspended → unlock で running になる mock
+    // suspended state を再現するためにテスト前に明示的に suspended にする
+    (ctx as unknown as { state: string }).state = "suspended";
+    const resumeSpy = ctx!.resume as unknown as ReturnType<typeof vi.fn>;
+    resumeSpy.mockClear();
+
+    __forTest.startBgm("bgm_home", "/sounds/test.mp3");
+    await vi.runOnlyPendingTimersAsync();
+
+    // play() 成功 → unlockAudio() → ctx.resume() が呼ばれる
+    expect(resumeSpy).toHaveBeenCalled();
+  });
 });

--- a/src/hooks/__tests__/use-bgm-visibility.test.ts
+++ b/src/hooks/__tests__/use-bgm-visibility.test.ts
@@ -293,3 +293,118 @@ describe("use-bgm: prepareBgmForNavigation の prepared audio フロー", () => 
     expect(prepared!.muted).toBe(false);
   });
 });
+
+// =====================
+// Issue #198: GainNode 経由の音量制御 (Web Audio Hybrid)
+// =====================
+//
+// AudioContext + createMediaElementSource を mock し、BGM の volume 操作が
+// HTMLAudioElement.volume ではなく GainNode.gain.value 経由で行われることを
+// 検証する。jsdom には AudioContext 実装がないため自前で mock する。
+
+describe("use-bgm: GainNode 経由の音量制御 (Issue #198)", () => {
+  // audio-engine の AudioContext singleton を試験用に reset する
+  let createdGainNode: { gain: { value: number }; connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } | null = null;
+  let createSourceMock: ReturnType<typeof vi.fn>;
+  let createGainMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    createdGainNode = null;
+    createSourceMock = vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+    createGainMock = vi.fn(() => {
+      const gain = {
+        gain: { value: 1 },
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      createdGainNode = gain;
+      return gain;
+    });
+    // class で mock コンストラクタ (audio-engine.test.ts と同じパターン)
+    class MockAudioContext {
+      state = "running" as const;
+      destination = { type: "destination" };
+      createMediaElementSource = createSourceMock;
+      createGain = createGainMock;
+      decodeAudioData = vi.fn();
+      resume = vi.fn().mockResolvedValue(undefined);
+      close = vi.fn().mockResolvedValue(undefined);
+      addEventListener = vi.fn();
+    }
+    (globalThis as unknown as { AudioContext: unknown }).AudioContext =
+      MockAudioContext;
+    (globalThis as unknown as { webkitAudioContext: unknown }).webkitAudioContext =
+      MockAudioContext;
+
+    // audio-engine の singleton を reset (= AudioContext 再生成のため)
+    const engine = await import("@/lib/audio/audio-engine");
+    engine.__forTest.reset();
+  });
+
+  afterEach(async () => {
+    delete (globalThis as unknown as { AudioContext?: unknown }).AudioContext;
+    delete (globalThis as unknown as { webkitAudioContext?: unknown })
+      .webkitAudioContext;
+    const engine = await import("@/lib/audio/audio-engine");
+    engine.__forTest.reset();
+  });
+
+  it("startBgm で audio.volume ではなく GainNode.gain.value で音量制御される", async () => {
+    __forTest.startBgm("bgm_home", "/sounds/test.mp3");
+    await vi.runOnlyPendingTimersAsync();
+    // fade-in (500ms) 完了まで進める
+    vi.advanceTimersByTime(600);
+
+    // BGM 用 GainNode が createMediaElementSource 経由で作られている
+    // (audio-engine 側で masterGain が別途作られるため createGain は複数回呼ばれる)
+    expect(createSourceMock).toHaveBeenCalledTimes(1);
+    expect(createdGainNode).not.toBeNull();
+    // fade-in が完了し BGM_VOLUME (0.3) に達している
+    expect(createdGainNode!.gain.value).toBeCloseTo(0.3, 5);
+  });
+
+  it("setBgmMuted で GainNode.gain.value が 0 / BGM_VOLUME に切替", async () => {
+    __forTest.startBgm("bgm_home", "/sounds/test.mp3");
+    await vi.runOnlyPendingTimersAsync();
+    // play() resolve 後の fade-in は rAF 経由のため、ここで現在値を確認する
+    // 代わりに mute 切替で GainNode 値が即時に変わることを検証
+    setBgmMuted(true);
+    expect(createdGainNode!.gain.value).toBe(0);
+    setBgmMuted(false);
+    // BGM_VOLUME = 0.3
+    expect(createdGainNode!.gain.value).toBe(0.3);
+  });
+
+  it("destroyAudio で GainNode が disconnect される (リーク防止)", async () => {
+    const matchPath = BGM_FILES.bgm_match_setup!;
+    const gamePath = BGM_FILES.bgm_game!;
+    __forTest.startBgm("bgm_match_setup", matchPath);
+    await vi.runOnlyPendingTimersAsync();
+    const firstGain = createdGainNode!;
+    expect(firstGain).not.toBeNull();
+
+    // 違う path の BGM へ切替 → 旧 audio destroy → GainNode disconnect
+    __forTest.startBgm("bgm_game", gamePath);
+    // destroyAudio は setTimeout 経由 (FADE_DURATION_MS + 50)
+    vi.advanceTimersByTime(700);
+    expect(firstGain.disconnect).toHaveBeenCalled();
+  });
+
+  it("prepareBgmForNavigation でも GainNode が attach される", async () => {
+    const matchPath = BGM_FILES.bgm_match_setup!;
+    __forTest.startBgm("bgm_match_setup", matchPath);
+    await vi.runOnlyPendingTimersAsync();
+    const callsBeforePrepare = createSourceMock.mock.calls.length;
+
+    prepareBgmForNavigation("/game/abc");
+    await vi.runOnlyPendingTimersAsync();
+
+    // prepared audio に対しても createMediaElementSource が呼ばれる
+    expect(createSourceMock.mock.calls.length).toBe(callsBeforePrepare + 1);
+    // 最新の GainNode は gain=0 で初期化 (= 無音状態で unlock)
+    expect(createdGainNode!.gain.value).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/use-bgm-visibility.test.ts
+++ b/src/hooks/__tests__/use-bgm-visibility.test.ts
@@ -245,7 +245,7 @@ describe("use-bgm: prepareBgmForNavigation の prepared audio フロー", () => 
     expect(playMock).toHaveBeenCalledTimes(playCallsBefore);
   });
 
-  it("違う path への遷移準備で prepared audio が作られ、currentAudio は変化しない", async () => {
+  it("違う path への遷移準備で prepared audio が muted=true で作られ、currentAudio は変化しない", async () => {
     const matchPath = BGM_FILES.bgm_match_setup!;
     const gamePath = BGM_FILES.bgm_game!;
     __forTest.startBgm("bgm_match_setup", matchPath);
@@ -258,13 +258,17 @@ describe("use-bgm: prepareBgmForNavigation の prepared audio フロー", () => 
     // ローディング中は currentAudio (= bgm_match_setup) を維持
     expect(__forTest.getCurrentAudio()).toBe(before);
     // 裏で prepared audio が unlock 済み状態で作られている
-    expect(__forTest.getPreparedAudio()).not.toBeNull();
+    const prepared = __forTest.getPreparedAudio();
+    expect(prepared).not.toBeNull();
     expect(__forTest.getPreparedPath()).toBe(gamePath);
     // prepared audio は play() 後に pause されている
     expect(pauseMock).toHaveBeenCalled();
+    // Issue #198: iOS Safari で volume プロパティが無効なため、無音再生は
+    // muted=true でなければ実現できない。prepared 状態では muted=true で保持。
+    expect(prepared!.muted).toBe(true);
   });
 
-  it("画面遷移後の startBgm 呼出で prepared audio が再利用される", async () => {
+  it("画面遷移後の startBgm で prepared audio が再利用され、muted が解除される", async () => {
     const matchPath = BGM_FILES.bgm_match_setup!;
     const gamePath = BGM_FILES.bgm_game!;
     __forTest.startBgm("bgm_match_setup", matchPath);
@@ -274,6 +278,7 @@ describe("use-bgm: prepareBgmForNavigation の prepared audio フロー", () => 
     await vi.runOnlyPendingTimersAsync();
     const prepared = __forTest.getPreparedAudio();
     expect(prepared).not.toBeNull();
+    expect(prepared!.muted).toBe(true);
 
     // 画面遷移後の useBgm が startBgm を呼ぶシナリオ
     __forTest.startBgm("bgm_game", gamePath);
@@ -284,5 +289,7 @@ describe("use-bgm: prepareBgmForNavigation の prepared audio フロー", () => 
     // prepared スロットは消費されて空になる
     expect(__forTest.getPreparedAudio()).toBeNull();
     expect(__forTest.getPreparedPath()).toBe("");
+    // Issue #198: 再利用時に muted=false に戻して通常再生に切替
+    expect(prepared!.muted).toBe(false);
   });
 });

--- a/src/hooks/use-bgm.ts
+++ b/src/hooks/use-bgm.ts
@@ -29,6 +29,7 @@
 
 import { useEffect } from "react";
 
+import { getAudioCtx } from "@/lib/audio/audio-engine";
 import {
   getEffectiveBgmPath,
   useBgmOverrides,
@@ -69,6 +70,89 @@ let preparedAudio: HTMLAudioElement | null = null;
 let preparedPath = "";
 
 // =====================
+// GainNode 経由の音量制御 (Issue #198)
+// =====================
+//
+// iOS Safari は HTMLAudioElement.volume プロパティが無効 (read-only / set 無視)
+// で常に 1.0 で再生される。これにより BGM (BGM_VOLUME=0.3) が SFX (0.7) と
+// 比べて爆音になり、操作音がかき消される。
+//
+// 対策: AudioContext.createMediaElementSource() で HTMLAudio を Web Audio
+// グラフに繋ぎ、GainNode で実効的に音量制御する。GainNode は iOS Safari でも
+// 動作する。
+//
+// audio element ごとに GainNode を 1 つ持ち、WeakMap で関連付ける。
+// createMediaElementSource は同一 audio に対して 1 度しか呼べないため、
+// WeakMap キャッシュで二重呼出を防ぐ。AudioContext が利用不可な環境
+// (= 古いブラウザ / SSR) では WeakMap entry が無く、従来通り audio.volume
+// にフォールバックする。
+const audioGains = new WeakMap<HTMLAudioElement, GainNode>();
+
+function attachGainNode(audio: HTMLAudioElement): GainNode | null {
+  const cached = audioGains.get(audio);
+  if (cached) return cached;
+  const ctx = getAudioCtx();
+  if (!ctx) return null;
+  try {
+    const source = ctx.createMediaElementSource(audio);
+    const gain = ctx.createGain();
+    gain.gain.value = 0; // fade-in 前提の初期値
+    source.connect(gain);
+    gain.connect(ctx.destination);
+    audioGains.set(audio, gain);
+    return gain;
+  } catch {
+    // createMediaElementSource は同 audio 2 回目で InvalidStateError 等を投げ得る。
+    // 失敗時は audio.volume フォールバック (= iOS Safari では音量制御不可だが
+    // 致し方ない安全網)
+    return null;
+  }
+}
+
+function detachGainNode(audio: HTMLAudioElement): void {
+  const gain = audioGains.get(audio);
+  if (!gain) return;
+  try {
+    gain.disconnect();
+  } catch {
+    // ignore
+  }
+  audioGains.delete(audio);
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * audio に紐づく effective volume を設定する。GainNode があればそちら、
+ * 無ければ audio.volume にフォールバック。
+ */
+function setEffectiveVolume(audio: HTMLAudioElement, value: number): void {
+  const v = clamp01(value);
+  const gain = audioGains.get(audio);
+  if (gain) {
+    gain.gain.value = v;
+  } else {
+    try {
+      audio.volume = v;
+    } catch {
+      // ignore (iOS Safari で setter が無視される等)
+    }
+  }
+}
+
+/**
+ * audio の effective volume を読む。GainNode があればその値、無ければ
+ * audio.volume を返す。
+ */
+function getEffectiveVolume(audio: HTMLAudioElement): number {
+  const gain = audioGains.get(audio);
+  if (gain) return gain.gain.value;
+  return audio.volume;
+}
+
+// =====================
 // fade ヘルパ
 // =====================
 
@@ -80,9 +164,9 @@ function fadeVolume(
 ): void {
   // 同 audio に対する旧 fade を中断するため id 採番
   const myId = ++activeFadeId;
-  audio.volume = Math.max(0, Math.min(1, from));
+  setEffectiveVolume(audio, from);
   if (durationMs <= 0 || from === to) {
-    audio.volume = Math.max(0, Math.min(1, to));
+    setEffectiveVolume(audio, to);
     return;
   }
   const startTs = performance.now();
@@ -90,7 +174,7 @@ function fadeVolume(
     // 別の fade が始まった、または audio が差し替わった → 中断
     if (myId !== activeFadeId) return;
     const t = Math.min(1, (now - startTs) / durationMs);
-    audio.volume = Math.max(0, Math.min(1, from + (to - from) * t));
+    setEffectiveVolume(audio, from + (to - from) * t);
     if (t < 1) {
       window.requestAnimationFrame(tick);
     }
@@ -103,6 +187,8 @@ function fadeVolume(
 // =====================
 
 function destroyAudio(audio: HTMLAudioElement): void {
+  // Issue #198: 関連 GainNode / MediaElementSource を切断 (リーク防止)
+  detachGainNode(audio);
   try {
     audio.pause();
     audio.removeAttribute("src");
@@ -137,7 +223,7 @@ function startBgm(key: BgmEventKey | null, path: string): void {
   // 旧 audio を fade out → destroy
   const prev = currentAudio;
   if (prev) {
-    fadeVolume(prev, prev.volume, 0, FADE_DURATION_MS);
+    fadeVolume(prev, getEffectiveVolume(prev), 0, FADE_DURATION_MS);
     window.setTimeout(() => destroyAudio(prev), FADE_DURATION_MS + 50);
   }
 
@@ -162,18 +248,23 @@ function startBgm(key: BgmEventKey | null, path: string): void {
       // Issue #198: prepareBgmForNavigation で iOS Safari 対応のため muted=true で
       // unlock した状態。ここで解除して通常再生に戻す。
       audio.muted = false;
-      audio.volume = 0;
       audio.currentTime = 0;
     } catch {
       // ignore
     }
+    // GainNode は既に attach 済み (prepareBgmForNavigation 内で attach)。fade-in
+    // 起点として 0 にリセットする。
+    setEffectiveVolume(audio, 0);
   } else {
     audio = new Audio();
     // preload はネットワーク負荷を抑えるため metadata まで。play() で自動的に full load。
     audio.preload = "auto";
     audio.src = path;
     audio.loop = shouldLoopFlag;
-    audio.volume = 0;
+    // Issue #198: GainNode を attach。これが iOS Safari でも有効な音量制御の核。
+    // attach 失敗時は audio.volume フォールバック (= 既存挙動)
+    attachGainNode(audio);
+    setEffectiveVolume(audio, 0);
   }
 
   // shouldLoop=false で loop 終了時に自然停止 (state クリア)
@@ -239,7 +330,7 @@ function attemptRetry(): void {
     playPromise
       .then(() => {
         if (currentAudio === audio) {
-          fadeVolume(audio, audio.volume, targetVol, FADE_DURATION_MS);
+          fadeVolume(audio, getEffectiveVolume(audio), targetVol, FADE_DURATION_MS);
         }
         detachRetryListeners();
       })
@@ -248,7 +339,7 @@ function attemptRetry(): void {
       });
   } else {
     // 旧ブラウザ: play が undefined を返す。再生開始したと仮定。
-    fadeVolume(audio, audio.volume, targetVol, FADE_DURATION_MS);
+    fadeVolume(audio, getEffectiveVolume(audio), targetVol, FADE_DURATION_MS);
     detachRetryListeners();
   }
 }
@@ -299,7 +390,7 @@ function pauseForHidden(): void {
   if (currentAudio.paused) return; // 既に停止
   wasPlayingBeforeHidden = true;
   const a = currentAudio;
-  fadeVolume(a, a.volume, 0, HIDE_FADE_MS);
+  fadeVolume(a, getEffectiveVolume(a), 0, HIDE_FADE_MS);
   // フェードアウト完了後に pause。途中で visible に戻ったら setTimeout 内で
   // visibilityState を再チェックして no-op にする。
   window.setTimeout(() => {
@@ -323,7 +414,7 @@ function resumeFromVisible(): void {
   const targetVol = isMuted ? 0 : BGM_VOLUME;
   // フェードイン用に音量を 0 から開始 (HIDE_FADE_MS 完了前に visible 復帰した
   // 場合は volume が中途半端なので 0 にリセットして再 fade-in)。
-  a.volume = 0;
+  setEffectiveVolume(a, 0);
   const playPromise = a.play();
   if (playPromise && typeof playPromise.then === "function") {
     playPromise
@@ -444,11 +535,7 @@ export function useBgm(
 export function setBgmMuted(muted: boolean): void {
   isMuted = muted;
   if (currentAudio) {
-    try {
-      currentAudio.volume = muted ? 0 : BGM_VOLUME;
-    } catch {
-      // ignore
-    }
+    setEffectiveVolume(currentAudio, muted ? 0 : BGM_VOLUME);
   }
 }
 
@@ -522,16 +609,19 @@ export function prepareBgmForNavigation(href: string): void {
   //
   // Issue #198: iOS Safari では HTMLAudioElement.volume プロパティが無効
   // (read-only / set 無視) で常に 1.0 で再生される (WebKit 仕様)。
-  // そのため volume=0 だけでは音量制御できないので muted=true を併用する。
-  // muted は iOS Safari でも有効で、play() 開始から pause() までの数百 ms の
-  // 間も音が出ない。再利用時 (startBgm 側) で muted=false に戻して通常再生する。
+  // そのため:
+  //   - GainNode (createMediaElementSource 経由) で gain=0 にすれば音量制御可能
+  //   - フォールバックとして muted=true も併用 (= GainNode attach 失敗時の安全網)
+  // 再利用時 (startBgm 側) で muted=false に戻し、GainNode で fade-in する。
   try {
     const audio = new Audio();
     audio.preload = "auto";
     audio.src = path;
     audio.loop = true;
     audio.muted = true;
-    audio.volume = 0;
+    // Issue #198: GainNode を user gesture 内で attach (= AudioContext 操作)
+    attachGainNode(audio);
+    setEffectiveVolume(audio, 0);
     const playPromise = audio.play();
     if (playPromise && typeof playPromise.then === "function") {
       playPromise

--- a/src/hooks/use-bgm.ts
+++ b/src/hooks/use-bgm.ts
@@ -159,6 +159,9 @@ function startBgm(key: BgmEventKey | null, path: string): void {
     preparedPath = "";
     try {
       audio.loop = shouldLoopFlag;
+      // Issue #198: prepareBgmForNavigation で iOS Safari 対応のため muted=true で
+      // unlock した状態。ここで解除して通常再生に戻す。
+      audio.muted = false;
       audio.volume = 0;
       audio.currentTime = 0;
     } catch {
@@ -515,12 +518,19 @@ export function prepareBgmForNavigation(href: string): void {
     preparedAudio = null;
     preparedPath = "";
   }
-  // user gesture 内で audio element を 1 度 play() して unlock 状態にする
+  // user gesture 内で audio element を 1 度 play() して unlock 状態にする。
+  //
+  // Issue #198: iOS Safari では HTMLAudioElement.volume プロパティが無効
+  // (read-only / set 無視) で常に 1.0 で再生される (WebKit 仕様)。
+  // そのため volume=0 だけでは音量制御できないので muted=true を併用する。
+  // muted は iOS Safari でも有効で、play() 開始から pause() までの数百 ms の
+  // 間も音が出ない。再利用時 (startBgm 側) で muted=false に戻して通常再生する。
   try {
     const audio = new Audio();
     audio.preload = "auto";
     audio.src = path;
     audio.loop = true;
+    audio.muted = true;
     audio.volume = 0;
     const playPromise = audio.play();
     if (playPromise && typeof playPromise.then === "function") {

--- a/src/hooks/use-bgm.ts
+++ b/src/hooks/use-bgm.ts
@@ -29,7 +29,7 @@
 
 import { useEffect } from "react";
 
-import { getAudioCtx } from "@/lib/audio/audio-engine";
+import { getAudioCtx, unlockAudio } from "@/lib/audio/audio-engine";
 import {
   getEffectiveBgmPath,
   useBgmOverrides,
@@ -291,6 +291,10 @@ function startBgm(key: BgmEventKey | null, path: string): void {
   if (playPromise && typeof playPromise.then === "function") {
     playPromise
       .then(() => {
+        // Issue #198: GainNode 経由再生では AudioContext が running でないと
+        // destination に音が届かない。play() 成功時に必ず unlock を試みる
+        // (suspended なら resume、すでに running なら no-op)
+        void unlockAudio();
         // 成功: fade-in
         if (currentAudio === audio) {
           fadeVolume(audio, 0, targetVol, FADE_DURATION_MS);
@@ -317,8 +321,13 @@ function startBgm(key: BgmEventKey | null, path: string): void {
 let retryListenersAttached = false;
 
 function attemptRetry(): void {
+  // Issue #198: 本関数は click/touchstart/keydown の user gesture 経由で呼ばれる。
+  // GainNode 経由再生は AudioContext が running でないと音が destination に届かない
+  // ため、ここで AudioContext を resume する (user gesture 内なので確実に成功する)。
+  void unlockAudio();
   if (!currentAudio) return;
-  // 既に再生中なら何もしない (二重 play 防止)
+  // 既に再生中なら user gesture リトライ待ちは不要だが、AudioContext が
+  // suspended のまま無音だった可能性があるので unlockAudio は実行済み。listener 撤去。
   if (!currentAudio.paused) {
     detachRetryListeners();
     return;
@@ -419,6 +428,9 @@ function resumeFromVisible(): void {
   if (playPromise && typeof playPromise.then === "function") {
     playPromise
       .then(() => {
+        // Issue #198: GainNode 経由再生では AudioContext が running でないと
+        // destination に音が届かない。可視復帰時にも unlock を試みる。
+        void unlockAudio();
         if (currentAudio === a) {
           fadeVolume(a, 0, targetVol, FADE_DURATION_MS);
         }
@@ -620,8 +632,11 @@ export function prepareBgmForNavigation(href: string): void {
     audio.loop = true;
     audio.muted = true;
     // Issue #198: GainNode を user gesture 内で attach (= AudioContext 操作)
+    // 同タイミングで AudioContext を resume する (= GainNode 経由で音を destination
+    // に届けるためには AudioContext が running 必須)
     attachGainNode(audio);
     setEffectiveVolume(audio, 0);
+    void unlockAudio();
     const playPromise = audio.play();
     if (playPromise && typeof playPromise.then === "function") {
       playPromise


### PR DESCRIPTION
## Summary

PR #195 (Issue #189「音源再生最適化」) のマージ後、モバイル iPhone Safari 固有の不具合 3 件が連鎖的に発見されたため、Web Audio API Hybrid 方式 (\`createMediaElementSource\` + \`GainNode\`) への切替を含めて根治する。Closes #198。

| # | 不具合 | 原因 | 修正コミット |
|---|---|---|---|
| 1 | 対局開始ボタン押下で対局 BGM が一瞬鳴る + 遷移後に再生し直される | iOS Safari の \`HTMLAudioElement.volume\` 仕様違い (read-only) で \`prepareBgmForNavigation\` の \`volume=0\` が無視されてフル音量再生 | \`bdee8f0\` |
| 2 | モバイルで対局 BGM が爆音、SFX (駒指し / カード操作音) がかき消される | 同上 (\`audio.volume = 0.3\` も無視されて常に 1.0) | \`300433f\` |
| 3 | (新規) ホーム画面でクリックしても BGM が流れない、画面遷移すると流れ始める | Hybrid 化後の AudioContext が \`suspended\` のまま \`destination\` に音が届かない | \`5abfe08\` |

---

## 背景: iOS Safari の WebKit 仕様

WebKit ドキュメントに以下の明記あり:

> On iOS, the audio level is always under the user's physical control. The volume property is not settable in JavaScript. Reading the volume property always returns 1.0.

つまり iOS Safari は **\`HTMLAudioElement.volume\` プロパティが完全に無効** (set 無視 / read 常に 1.0)。これにより:

- \`audio.volume = 0\` で muted 再生したいケース → フル音量で鳴る
- \`audio.volume = 0.3\` で BGM 音量抑制したいケース → フル音量で鳴る (= SFX 0.7 と比べて爆音)

PR #195 までの実装では HTMLAudio 直接利用で、PC では \`audio.volume\` が機能していたため気付かれなかった。

### 解決アプローチ: Web Audio API Hybrid

\`AudioContext.createMediaElementSource(audio)\` で HTMLAudio を Web Audio グラフに繋ぎ、\`GainNode\` で音量制御する。GainNode は iOS Safari でも仕様通り動作する。

| 候補 | iOS volume制御 | メモリ | 既存実装変更量 | 採用 |
|---|---|---|---|---|
| HTML5 Audio 単独 | ❌ 無効 | ◎ | なし | ✗ (今回の問題) |
| Web Audio + AudioBuffer 単独 | ✅ | △ (~5 MB 常駐) | 大 (BGM 全書換) | ✗ |
| **HTML5 Audio + Web Audio Hybrid** | **✅** | **◎ ストリーミング** | 中 (volume 操作箇所のみ) | **✓** |
| Howler.js 復活 | △ (Issue #79 で外した経緯) | 自動 | 大 (依存復活) | ✗ |

Web Audio 単独の場合 BGM (~2.2 MB MP3 × 2) を全 decode してメモリ常駐させる必要があり、モバイル端末のメモリ・電池に不利のため採用せず。

---

## コミット別の詳細

### Commit 1: \`bdee8f0\` — preparedAudio に \`muted=true\` を追加

**問題**: \`prepareBgmForNavigation\` で「user gesture 内で次画面 BGM を \`audio.volume = 0\` で 1 度 \`play()\` → 即 \`pause()\`」して \`preparedAudio\` に保持する処理が、iOS Safari ではフル音量で再生されてしまい、対局 BGM が一瞬鳴る現象になっていた。

**修正**:
- \`prepareBgmForNavigation\` 内で audio に \`muted = true\` を追加 (volume と違って iOS でも有効)
- \`startBgm\` の \`preparedAudio\` 再利用ブロックで \`audio.muted = false\` に戻して通常再生に切替
- \`audio.currentTime = 0\` で先頭からの fade-in を担保

```ts
// prepareBgmForNavigation 内 (一部)
audio.muted = true;
audio.volume = 0;
const playPromise = audio.play();
playPromise.then(() => {
  audio.pause();
  audio.currentTime = 0;
  preparedAudio = audio;
});

// startBgm 内 (preparedAudio 再利用ブロック)
audio = preparedAudio;
audio.muted = false;  // ← 解除して通常再生
audio.currentTime = 0;
```

---

### Commit 2: \`300433f\` — BGM 音量を GainNode 経由に切替 (Hybrid 化)

**問題**: 通常の BGM 再生 (= \`startBgm\` 経路) で \`audio.volume = 0.3\` を設定しても iOS Safari では無視されて常に 1.0 で再生される。SFX (audio-engine 経由 GainNode 0.7) と比べて爆音になり操作音がかき消される。

**実装の柱**:

1. \`WeakMap<HTMLAudioElement, GainNode>\` で audio に GainNode を関連付け
2. \`attachGainNode(audio)\` ヘルパ: audio-engine の AudioContext を流用して \`createMediaElementSource → GainNode → destination\` の Web Audio グラフを構築。WeakMap に登録
3. \`detachGainNode(audio)\`: GainNode を disconnect + WeakMap から削除 (リーク防止)
4. \`setEffectiveVolume(audio, value)\`: GainNode があれば \`gain.gain.value\`、無ければ \`audio.volume\` にフォールバック
5. \`getEffectiveVolume(audio)\`: 同様の lookup で実効音量を読む

```ts
const audioGains = new WeakMap<HTMLAudioElement, GainNode>();

function attachGainNode(audio: HTMLAudioElement): GainNode | null {
  const cached = audioGains.get(audio);
  if (cached) return cached;
  const ctx = getAudioCtx();  // audio-engine の singleton 流用
  if (!ctx) return null;
  try {
    const source = ctx.createMediaElementSource(audio);
    const gain = ctx.createGain();
    gain.gain.value = 0;  // fade-in 前提
    source.connect(gain);
    gain.connect(ctx.destination);
    audioGains.set(audio, gain);
    return gain;
  } catch {
    return null;  // 失敗時は audio.volume フォールバック
  }
}

function setEffectiveVolume(audio: HTMLAudioElement, value: number): void {
  const v = clamp01(value);
  const gain = audioGains.get(audio);
  if (gain) {
    gain.gain.value = v;
  } else {
    try { audio.volume = v; } catch {}
  }
}
```

**書換箇所** (use-bgm.ts 内の volume 操作 全 6 箇所):

| 関数 | 修正前 | 修正後 |
|---|---|---|
| \`fadeVolume\` (rAF tick 内) | \`audio.volume = ...\` | \`setEffectiveVolume(audio, ...)\` |
| \`startBgm\` (旧 audio fade-out 起点) | \`prev.volume\` | \`getEffectiveVolume(prev)\` |
| \`startBgm\` (新 audio 初期化) | \`audio.volume = 0\` | \`attachGainNode(audio); setEffectiveVolume(audio, 0)\` |
| \`startBgm\` (preparedAudio 再利用) | \`audio.volume = 0\` | \`setEffectiveVolume(audio, 0)\` |
| \`pauseForHidden\` | \`a.volume\` | \`getEffectiveVolume(a)\` |
| \`resumeFromVisible\` | \`a.volume = 0\` | \`setEffectiveVolume(a, 0)\` |
| \`setBgmMuted\` | \`currentAudio.volume = ...\` | \`setEffectiveVolume(currentAudio, ...)\` |
| \`prepareBgmForNavigation\` | \`audio.volume = 0\` | \`attachGainNode(audio); setEffectiveVolume(audio, 0)\` |
| \`destroyAudio\` | (なし) | \`detachGainNode(audio)\` を冒頭追加 |

**フォールバック設計**: AudioContext が利用できない環境 (= 古いブラウザ / SSR) では GainNode が attach されず、従来通り \`audio.volume\` で制御 → 既存挙動と完全互換

---

### Commit 3: \`5abfe08\` — AudioContext suspended 無音バグの修正

**問題**: Hybrid 化により HTMLAudio の出力経路が \`AudioContext.destination\` 経由になったが、AudioContext は autoplay policy で **\`suspended\` 状態で開始** されるため、\`audio.play()\` が成功しても **音が destination に届かず無音** になっていた。

ユーザーには「再生されているように見える (ブラウザのミニメディアプレイヤーは反応) のに音が出ない」「画面遷移したら流れ始める」という症状で報告された (= 遷移時に \`playSfxOnce\` 経由で audio-engine の \`unlockAudio()\` が走って AudioContext が \`running\` になる)。

**修正**: \`use-bgm.ts\` から audio-engine の \`unlockAudio()\` を import し、\`audio.play()\` 経路全 4 箇所に \`void unlockAudio()\` を追加。

| 経路 | 配置 | 意味 |
|---|---|---|
| \`startBgm\` の play().then() | \`fadeVolume\` 直前 | 通常 BGM 再生時の resume 試行 |
| \`attemptRetry\` 冒頭 | 関数の最初 | user gesture リトライハンドラなので確実に gesture 内 = resume 確実 |
| \`resumeFromVisible\` の play().then() | \`fadeVolume\` 直前 | 可視復帰時の resume 試行 |
| \`prepareBgmForNavigation\` | \`attachGainNode\` 直後 | user gesture 内なので resume 確実 + 直後 play() で音が届く状態を担保 |

\`unlockAudio()\` は内部で \`ctx.state\` を見て \`suspended\` の時のみ \`resume()\` を呼ぶ ([audio-engine.ts](https://github.com/ryuichiTtb/Shogi/blob/main/src/lib/audio/audio-engine.ts) で実装済み)。既に \`running\` なら no-op。

---

## 主要ファイル変更点

### \`src/hooks/use-bgm.ts\` (+151 / -22)

| セクション | 変更概要 |
|---|---|
| import | \`audio-engine\` から \`getAudioCtx\` / \`unlockAudio\` を import |
| GainNode 関連ヘルパ群 (新設 ~80 行) | \`audioGains\` WeakMap / \`attachGainNode\` / \`detachGainNode\` / \`setEffectiveVolume\` / \`getEffectiveVolume\` / \`clamp01\` |
| \`fadeVolume\` | volume 操作を \`setEffectiveVolume\` 経由に変更 |
| \`startBgm\` | 新 audio 作成時に \`attachGainNode\` 呼出、preparedAudio 再利用時の \`muted = false\` 解除、play().then() で \`unlockAudio\` |
| \`destroyAudio\` | 冒頭で \`detachGainNode\` 呼出 |
| \`attemptRetry\` | 冒頭で \`unlockAudio\` (user gesture 内なので確実に resume 成功) |
| \`pauseForHidden\` / \`resumeFromVisible\` | volume 操作を helper 経由に変更、play().then() で \`unlockAudio\` |
| \`setBgmMuted\` | \`currentAudio.volume = ...\` を \`setEffectiveVolume\` 経由に |
| \`prepareBgmForNavigation\` | \`audio.muted = true\` 追加、\`attachGainNode\` 呼出、\`unlockAudio\` 呼出 |

### \`src/hooks/__tests__/use-bgm-visibility.test.ts\` (+147 / -2)

新規テスト 6 件を追加:

1. \`違う path への遷移準備で prepared audio が muted=true で作られ、currentAudio は変化しない\` (Commit 1 検証)
2. \`画面遷移後の startBgm で prepared audio が再利用され、muted が解除される\` (Commit 1 検証)
3. \`startBgm で audio.volume ではなく GainNode.gain.value で音量制御される\` (Commit 2 検証 / GainNode 経由制御)
4. \`setBgmMuted で GainNode.gain.value が 0 / BGM_VOLUME に切替\` (Commit 2 検証)
5. \`destroyAudio で GainNode が disconnect される (リーク防止)\` (Commit 2 検証)
6. \`prepareBgmForNavigation でも GainNode が attach される\` (Commit 2 検証)
7. \`startBgm の play() 成功時に AudioContext.resume() が呼ばれる\` (Commit 3 検証)

AudioContext + \`createMediaElementSource\` + GainNode を mock するセットアップを新設し、Hybrid 経路の動作を検証している。

---

## Test plan

### 自動テスト
- [x] \`npm run lint\` (0 errors / 既存 22 warnings は変更なし)
- [x] \`npm run typecheck\` (0 errors)
- [x] \`npm run test:ci\` (**323 passed** / 新規 6 件含む)
- [x] \`npm run build\` (成功)

### 実機検証 (Vercel preview / ユーザー確認済み)
| シナリオ | 期待動作 | 確認結果 |
|---|---|---|
| ホーム画面着地直後 | 無音 (autoplay policy 仕様) | ✅ |
| ホーム画面の任意の場所をタップ/クリック | BGM 流れ始める | ✅ (Commit 3 で復元) |
| /play → 対局開始ボタン押下 | ローディング中はホーム BGM 継続 | ✅ |
| 対局画面遷移後 | 対局 BGM が頭から fade-in (重複再生なし) | ✅ |
| モバイル iPhone Safari の音量バランス | BGM 0.3 / SFX 0.7 (PC と同じバランス) | ✅ (Commit 2 で正常化) |
| ロック画面 / 別タブ → 復帰 | 自動 fade-in 再開 | ✅ |
| デスクトップ Chrome / Safari | 一切デグレなし (audio.volume フォールバック経路) | ✅ |

---

## デグレ防止観点

### 1. 既存 API 互換性
\`useBgm\` / \`setBgmMuted\` / \`prepareBgmForNavigation\` の export シグネチャは一切変更なし。呼出側 (\`shogi-game\` / \`card-shogi-game\` / \`page.tsx\` / \`MaskedLink\` / \`match-setup\` 等) の書換不要。

### 2. AudioContext 利用不可環境のフォールバック
- \`getAudioCtx()\` が \`null\` を返す環境 (= SSR / 古いブラウザ / 開発用 jsdom)
- \`attachGainNode\` が WeakMap entry を作らず → \`setEffectiveVolume\` / \`getEffectiveVolume\` が \`audio.volume\` フォールバックパス
- → PR #195 までの挙動と完全同等

### 3. 二重 \`createMediaElementSource\` 呼出防止
- WeakMap キャッシュで同 audio に対する 2 回目の呼出を抑止
- 仕様上 \`InvalidStateError\` を投げるため try-catch でも safety net 確保

### 4. リーク防止
- \`destroyAudio\` で \`detachGainNode\` を必ず呼び、GainNode を \`disconnect()\` + WeakMap から削除
- WeakMap のため audio オブジェクトが GC されれば entry も自動削除

### 5. 既存テスト 11 件への影響
- 全 11 件 pass を維持 (= visibility / pagehide / pageshow / preparedAudio フローの既存テスト含む)
- 加えて新規 6 件追加で総数 17 件 (BGM テスト)

---

## 既知の制約・スコープ外

### 「画面開いた瞬間に BGM 自動再生」は仕様上不可能
ブラウザの autoplay policy (= Chrome / Safari / Firefox 全てで採用) により、ユーザー操作なしの音声 autoplay は block される。これは Web 標準の絶対制約で、コードで回避不可。

業界事例:
- Spotify / Apple Music: 着地時無音 + Play ボタン明示クリック
- YouTube: muted autoplay (動画は再生 / 音は手動 unmute) で擬似 autoplay
- Web ゲーム: 「Tap to Start」Splash 画面が業界標準

本 PR では「最初の任意操作後に BGM 再生」という Web 業界標準の挙動を提供する (= ユーザーレビュー済み)。

### Closes #198