### PR TITLE
feat: #193-PR1a AI/CPU アーキ刷新土台 + CPU vs CPU 観戦モード

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,12 +443,22 @@ Issue対応やコード変更依頼で実装・検証・コミットが完了し
      - `state.doubleMove` のような明示的な「ターン継続中」フラグを reducer に持つこと
      - DB 保存スキップ (`src/hooks/use-card-shogi-game.ts` の save useEffect) も該当フラグを考慮
 
-5. **テスト**
+5. **AI / 探索側の更新** (Issue #193 / PR1a で追加)
+   - **新カードが AI 側 `getLegalActions` で候補生成に含まれる**ように `src/lib/shogi/ai/turn/current-rules.ts` (or PR1d で追加される `action-generator.ts`) を更新
+     - PR1a 時点では move-only のため自動的にスキップされるが、PR1d で playCard 候補生成が入るときに必要
+   - **新カードが評価関数 (cardDigest) に影響する場合** は `src/lib/shogi/ai/cards/digest.ts` の `CardDigest` interface に該当フィールドを追加 (PR1d 段階で構造を整備)
+   - **新カードの価値を `evaluateCardDigest` に係数として追加** (PR1d 以降):
+     - 例: 新カードが「相手の駒を取る」効果なら、PIECE_VALUES と整合する単位 cp で価値を表現
+   - **AI fixture に新カードの基本ケースを追加**: `src/lib/shogi/ai/__tests__/card-digest.test.ts` / `action-generator.test.ts` (PR1d 期から運用) に該当カードの動作確認を 1〜2 ケース追加
+   - **bench fixture に新カード使用局面を追加** (棋力影響を測定): `perf-bench.test.ts` に新カード保有の midgame 局面を含めて、新カード追加前後で `depthCompleted` ±10% 以内であることを確認
+   - **影響なしの場合 (= 効果が単発で AI が探索に組み込めない種類)** は本節に「該当なし」と PR コメントで明記すれば足りる
+
+6. **テスト**
    - `npm run test:ci -- src/hooks/card-shogi/__tests__/undo-policy.test.ts` が緑であることを確認
    - 新カードの効果関数のユニットテストを `effects.test.ts` に追加
    - 1 ターン複数 ply 系の場合は reducer 統合テストも追加
 
-6. **prisma seed**
+7. **prisma seed**
    - `ALL_CARD_DEFS` 経由で自動的に Card マスタ・DeckEntry・PlayerCardCollection に投入される
    - 既存ローカル DB に反映するには `npm run db:seed` を実行
 

--- a/src/app/actions/game.ts
+++ b/src/app/actions/game.ts
@@ -51,6 +51,27 @@ async function loadDeckSpecForUser(userId: string): Promise<DeckSpec[]> {
     }));
 }
 
+// Issue #193 / PR1a: CPU vs CPU 観戦モード用の揮発初期化。
+// DB に Game レコードは作成せず、メモリ上の初期 state のみを返す (= 揮発モード)。
+// 観戦は対局を保存しないため Vercel Hobby Plan の Neon ボトルネックを回避できる。
+// gameId は "spectator-{uuid}" の固定 prefix で発行し、AI route 側で観戦モード判定の
+// 補助情報として使う想定 (route 側は spectatorMode フラグで判定するため必須ではない)。
+export async function createSpectatorGameState(): Promise<{
+  gameId: string;
+  initialState: GameState;
+  initialCardState: CardGameState;
+}> {
+  const user = await getCurrentAppUser();
+  const variant = getVariantById("card-shogi");
+  const initialState = createInitialGameState(variant);
+  // 観戦モードでも user 固有のデフォルトデッキを利用 (シングルプレイヤー同様)。
+  const deckSpec: DeckSpec[] = await loadDeckSpecForUser(user.id);
+  const initialCardState = createInitialCardState(deckSpec);
+  // 揮発 ID。crypto.randomUUID() は Node.js 19+ / Edge runtime で利用可。
+  const gameId = `spectator-${crypto.randomUUID()}`;
+  return { gameId, initialState, initialCardState };
+}
+
 // 新規ゲームを作成
 export async function createGame(
   difficulty: Difficulty,

--- a/src/app/api/ai-move/route.ts
+++ b/src/app/api/ai-move/route.ts
@@ -160,13 +160,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // ---- 所有者 + active 確認 (最小 DB read) ----
-  const game = await prisma.game.findUnique({
-    where: { id: body.gameId },
-    select: { id: true, playerId: true, status: true },
-  });
-  if (!game) return jsonError(404, "Game not found");
-  if (game.playerId !== userId) return jsonError(403, "Forbidden");
-  if (game.status !== "active") return jsonError(409, "Game not active");
+  // Issue #193 / PR1a (E-1): 観戦モード (CPU vs CPU) は揮発モードのため Game レコードが
+  // DB に存在しない。spectatorMode=true の場合は DB lookup と所有者検証をスキップする
+  // (gameId は "spectator-{uuid}" 形式の揮発 ID)。
+  // セキュリティ: 観戦モードは DB 書き込みなしのため悪用リスクは AI 計算リソース消費のみ。
+  // 1 ユーザー 1 観戦のレートリミットは next.config.mjs で別途実装予定 (進行中チェックリスト)。
+  // 認証 (userId 取得) は前段で完了済のため、ログインユーザーのみ観戦可能。
+  if (!body.spectatorMode) {
+    const game = await prisma.game.findUnique({
+      where: { id: body.gameId },
+      select: { id: true, playerId: true, status: true },
+    });
+    if (!game) return jsonError(404, "Game not found");
+    if (game.playerId !== userId) return jsonError(403, "Forbidden");
+    if (game.status !== "active") return jsonError(409, "Game not active");
+  }
 
   // ---- 多重 request 抑制 ----
   const flightKey = `${userId}:${body.gameId}`;

--- a/src/app/api/ai-move/route.ts
+++ b/src/app/api/ai-move/route.ts
@@ -22,7 +22,9 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getCurrentAppUser } from "@/lib/auth/current-user";
 import { prisma } from "@/lib/prisma";
 import { findBestMoveWithStats } from "@/lib/shogi/ai/engine";
+import { SPECTATOR_TIME_LIMIT_MS } from "@/lib/shogi/ai/strategy";
 import { getVariantById } from "@/lib/shogi/variants";
+import type { CardGameState } from "@/lib/shogi/cards/types";
 import type { Difficulty, GameState, Player } from "@/lib/shogi/types";
 
 export const runtime = "nodejs";
@@ -46,6 +48,13 @@ interface AiMoveRequestBody {
   difficulty: Difficulty;
   variantId: string;
   clientMoveCount: number;
+  // PR1a (E-2): cardState は optional。PR1a では受け取るだけで使わない (silent ignore)。
+  // 不正な構造でも 400 にはせず、cardState なし扱いとして扱う。深い検証は PR1d で導入。
+  cardState?: CardGameState;
+  // PR1a (E-1): CPU vs CPU 観戦モード。client 側 (useCardShogiGame) で両プレイヤー
+  // それぞれに正しい difficulty / spectatorMode を渡す前提で、route 側は spectatorMode
+  // フラグを受け取り timeLimitMs を SPECTATOR_TIME_LIMIT_MS で短縮する。
+  spectatorMode?: boolean;
 }
 
 // 同 user × gameId の探索を 1 本に制限する。新 request 到着で既存を abort。
@@ -70,7 +79,30 @@ function validateBody(raw: unknown): AiMoveRequestBody | null {
   if (typeof gs.currentPlayer !== "string" || !VALID_PLAYERS.has(gs.currentPlayer as Player)) return null;
   if (typeof gs.moveCount !== "number") return null;
   if (typeof gs.status !== "string") return null;
-  return raw as unknown as AiMoveRequestBody;
+
+  // PR1a (E-2): cardState は浅い検査のみで silent ignore。型不一致 / 構造欠落でも
+  // 400 返却せず undefined として扱う (= cardState なしリクエストと同等)。
+  // 深い検証は PR1d 着手時に src/lib/shogi/cards/validate.ts で zod-like に整備し、
+  // 不正時は 400 返却に格上げする。
+  const cardState =
+    raw.cardState !== undefined && isObject(raw.cardState)
+      ? (raw.cardState as unknown as CardGameState)
+      : undefined;
+
+  // PR1a (E-1): spectatorMode は boolean のみ許容、それ以外は false 扱い (silent ignore)。
+  const spectatorMode = raw.spectatorMode === true;
+
+  return {
+    gameId: raw.gameId as string,
+    requestId: raw.requestId as string,
+    gameState: raw.gameState as unknown as GameState,
+    player: raw.player as Player,
+    difficulty: raw.difficulty as Difficulty,
+    variantId: raw.variantId as string,
+    clientMoveCount: raw.clientMoveCount as number,
+    cardState,
+    spectatorMode,
+  };
 }
 
 function jsonError(status: number, error: string): NextResponse {
@@ -149,12 +181,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   try {
     const variant = getVariantById(body.variantId);
+    // PR1a (E-1): 観戦モード時のみ timeLimitMs を SPECTATOR_TIME_LIMIT_MS で短縮。
+    // それ以外は既存挙動 (DIFFICULTY_PARAMS[difficulty].timeLimitMs)。
     const result = findBestMoveWithStats(
       body.gameState,
       body.player,
       body.difficulty,
       variant,
-      { signal: controller.signal },
+      {
+        signal: controller.signal,
+        timeLimitMs: body.spectatorMode ? SPECTATOR_TIME_LIMIT_MS : undefined,
+      },
     );
     // client abort の場合は 499 相当だが、Next.js では client がもう listen して
     // いないので status は意味を持たない。fallback で 200 を返す。

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
-import { History, Swords, Castle } from "lucide-react";
+import { History, Swords, Castle, Eye } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ThemeSelector } from "@/components/game/theme-selector";
@@ -138,6 +138,25 @@ export default function Home() {
             >
               <Castle className="w-4 h-4 mr-2" />
               通常将棋で遊ぶ
+            </Button>
+          </motion.div>
+
+          {/* Issue #193 / PR1a: CPU vs CPU 観戦モード CTA */}
+          <motion.div
+            initial={!reduce ? { opacity: 0, y: 8 } : false}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.42, ease: "easeOut" }}
+          >
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() => navigateTo("/spectate")}
+              disabled={isPending}
+              className="w-full text-sm sm:text-base py-3 sm:py-4 bg-card/60 backdrop-blur-sm"
+              aria-label="CPU 同士の対局を観戦する"
+            >
+              <Eye className="w-4 h-4 mr-2" />
+              CPU 同士を観る
             </Button>
           </motion.div>
 

--- a/src/app/spectate/page.tsx
+++ b/src/app/spectate/page.tsx
@@ -11,7 +11,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { ArrowLeft, Eye } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -45,7 +44,8 @@ interface SpectatorGame {
 }
 
 export default function SpectatePage() {
-  const router = useRouter();
+  // ホームへ戻るリンクは MaskedLink (href="/") で完結するため useRouter は不要。
+  // 観戦開始 → 観戦画面遷移は client-side state (game) の切替で処理する。
   // 既定値: 先手 = 龍王 (超上級)、後手 = さくら (初級)。観戦体験として強さ差がある方が手の違いが見えやすい。
   const [characterIdA, setCharacterIdA] = useState<string>("ryuou");
   const [characterIdB, setCharacterIdB] = useState<string>("sakura");

--- a/src/app/spectate/page.tsx
+++ b/src/app/spectate/page.tsx
@@ -1,0 +1,163 @@
+// Issue #193 / PR1a: CPU vs CPU 観戦モード画面 (揮発モード)。
+//
+// 設計判断:
+// - DB に Game レコードを作らない (createSpectatorGameState が揮発初期化を返す)。
+//   ページ離脱・リロードで初期化される (G-2 進行中チェックリストの UX 想定)。
+// - phase: "setup" で難易度 A/B + キャラ A/B を選択、"playing" で CardShogiGame を
+//   spectatorMode=true で呼び両プレイヤー AI 駆動で対局を進行。
+// - PR1a 段階 7 では UI 切替は最小限 (faceDown 表示・ポーズボタン詳細実装は後追い)。
+//   観戦時は CardShogiGame が gameConfig.spectatorMode を見て useCardShogiGame の
+//   AI 自動応手 useEffect 経由で両 CPU を駆動する。
+
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CardShogiGame } from "@/components/game/card-shogi/card-shogi-game";
+import { CHARACTERS } from "@/data/characters";
+import { Button } from "@/components/ui/button";
+import { DIFFICULTY_LABELS } from "@/lib/shogi/ai/engine";
+import { createSpectatorGameState } from "@/app/actions/game";
+import type { CardGameState } from "@/lib/shogi/cards/types";
+import type { Difficulty, GameState } from "@/lib/shogi/types";
+
+interface SpectatorGame {
+  gameId: string;
+  initialState: GameState;
+  initialCardState: CardGameState;
+}
+
+export default function SpectatePage() {
+  const router = useRouter();
+  // 既定値は「両者超上級 (龍王)」。観戦体験として一番駒運びが安定するため。
+  const [difficultyA, setDifficultyA] = useState<Difficulty>("expert");
+  const [difficultyB, setDifficultyB] = useState<Difficulty>("expert");
+  const [characterIdA, setCharacterIdA] = useState<string>("ryuou");
+  const [characterIdB, setCharacterIdB] = useState<string>("ryuou");
+  const [game, setGame] = useState<SpectatorGame | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleStart = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const result = await createSpectatorGameState();
+      setGame(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  // 観戦中: CardShogiGame をフルスクリーンで描画。useCardShogiGame の
+  // AI 自動応手 useEffect が両プレイヤー (gameState.currentPlayer) を駆動する。
+  if (game) {
+    return (
+      <CardShogiGame
+        initialGameState={game.initialState}
+        initialCardState={game.initialCardState}
+        gameId={game.gameId}
+        gameConfig={{
+          variantId: "card-shogi",
+          difficulty: difficultyA,
+          playerColor: "sente", // 観戦モードでは未使用 (両プレイヤー AI 駆動)
+          characterId: characterIdA,
+          soundEnabled: true,
+          commentaryEnabled: false,
+          spectatorMode: true,
+          difficultyB,
+          characterIdB,
+        }}
+      />
+    );
+  }
+
+  // 観戦設定画面
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center p-6 gap-6">
+      <h1 className="text-2xl font-bold">CPU 同士を観る</h1>
+      <p className="text-sm text-muted-foreground text-center max-w-md">
+        2 人の AI を選んで対局を観戦できます。観戦結果は保存されません (
+        ページを閉じると初期化されます)。
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl w-full">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">先手 (A)</label>
+          <select
+            value={difficultyA}
+            onChange={(e) => setDifficultyA(e.target.value as Difficulty)}
+            disabled={pending}
+            className="w-full p-2 border rounded bg-background"
+          >
+            {(["beginner", "intermediate", "advanced", "expert"] as const).map((d) => (
+              <option key={d} value={d}>
+                {DIFFICULTY_LABELS[d]}
+              </option>
+            ))}
+          </select>
+          <select
+            value={characterIdA}
+            onChange={(e) => setCharacterIdA(e.target.value)}
+            disabled={pending}
+            className="w-full p-2 border rounded bg-background"
+          >
+            {CHARACTERS.filter((c) => c.difficulty === difficultyA).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.avatarEmoji} {c.name} - {c.title}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">後手 (B)</label>
+          <select
+            value={difficultyB}
+            onChange={(e) => setDifficultyB(e.target.value as Difficulty)}
+            disabled={pending}
+            className="w-full p-2 border rounded bg-background"
+          >
+            {(["beginner", "intermediate", "advanced", "expert"] as const).map((d) => (
+              <option key={d} value={d}>
+                {DIFFICULTY_LABELS[d]}
+              </option>
+            ))}
+          </select>
+          <select
+            value={characterIdB}
+            onChange={(e) => setCharacterIdB(e.target.value)}
+            disabled={pending}
+            className="w-full p-2 border rounded bg-background"
+          >
+            {CHARACTERS.filter((c) => c.difficulty === difficultyB).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.avatarEmoji} {c.name} - {c.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-destructive">エラー: {error}</div>
+      )}
+
+      <div className="flex gap-3">
+        <Button onClick={() => router.push("/")} variant="outline" disabled={pending}>
+          ホームへ戻る
+        </Button>
+        <Button onClick={handleStart} disabled={pending}>
+          {pending ? "準備中..." : "観戦を開始"}
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted-foreground max-w-md text-center mt-4">
+        観戦モードでは思考時間が短縮 (1.5 秒/手) され、200 手で強制引き分けとなります。
+        観戦体験を快適にするための設定で、AI 棋力評価とは独立した値です。
+      </p>
+    </main>
+  );
+}

--- a/src/app/spectate/page.tsx
+++ b/src/app/spectate/page.tsx
@@ -3,23 +3,40 @@
 // 設計判断:
 // - DB に Game レコードを作らない (createSpectatorGameState が揮発初期化を返す)。
 //   ページ離脱・リロードで初期化される (G-2 進行中チェックリストの UX 想定)。
-// - phase: "setup" で難易度 A/B + キャラ A/B を選択、"playing" で CardShogiGame を
-//   spectatorMode=true で呼び両プレイヤー AI 駆動で対局を進行。
-// - PR1a 段階 7 では UI 切替は最小限 (faceDown 表示・ポーズボタン詳細実装は後追い)。
-//   観戦時は CardShogiGame が gameConfig.spectatorMode を見て useCardShogiGame の
-//   AI 自動応手 useEffect 経由で両 CPU を駆動する。
+// - レイアウトは /play (MatchSetup) と統一。CHARACTERS 配列から先手 / 後手の
+//   2 キャラを選ぶカードグリッドで「強さ + キャラ」を 1 操作で決定 (各 difficulty に
+//   1 キャラ対応のため、別々の select で分ける必要なし)。
+// - ホームへ戻るリンクは MaskedLink で nav_back SFX + ローディングマスクを統一。
 
 "use client";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { CardShogiGame } from "@/components/game/card-shogi/card-shogi-game";
-import { CHARACTERS } from "@/data/characters";
+import { motion } from "framer-motion";
+import { ArrowLeft, Eye } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { DIFFICULTY_LABELS } from "@/lib/shogi/ai/engine";
+import { Badge } from "@/components/ui/badge";
+import { CHARACTERS } from "@/data/characters";
+import { CardShogiGame } from "@/components/game/card-shogi/card-shogi-game";
 import { createSpectatorGameState } from "@/app/actions/game";
+import { AppBackground } from "@/components/layout/app-background";
+import { PageMotion } from "@/components/layout/page-motion";
+import { ThemeSelector } from "@/components/game/theme-selector";
+import { AuthControls } from "@/components/auth/auth-controls";
+import { MaskedLink } from "@/components/navigation/masked-link";
+import { LoadingOverlay } from "@/components/loading-overlay";
+import { LOADING_STAGES } from "@/lib/loading-stages";
+import { cn } from "@/lib/utils";
 import type { CardGameState } from "@/lib/shogi/cards/types";
 import type { Difficulty, GameState } from "@/lib/shogi/types";
+
+const DIFFICULTY_INFO: Record<Difficulty, { label: string; description: string; color: string }> = {
+  beginner: { label: "初級", description: "将棋を覚えたばかり", color: "bg-green-100 text-green-800 border-green-200" },
+  intermediate: { label: "中級", description: "ある程度指せる", color: "bg-yellow-100 text-yellow-800 border-yellow-200" },
+  advanced: { label: "上級", description: "強い相手", color: "bg-red-100 text-red-800 border-red-200" },
+  expert: { label: "超上級", description: "五段クラス最強 AI", color: "bg-purple-100 text-purple-800 border-purple-200" },
+};
 
 interface SpectatorGame {
   gameId: string;
@@ -29,14 +46,15 @@ interface SpectatorGame {
 
 export default function SpectatePage() {
   const router = useRouter();
-  // 既定値は「両者超上級 (龍王)」。観戦体験として一番駒運びが安定するため。
-  const [difficultyA, setDifficultyA] = useState<Difficulty>("expert");
-  const [difficultyB, setDifficultyB] = useState<Difficulty>("expert");
+  // 既定値: 先手 = 龍王 (超上級)、後手 = さくら (初級)。観戦体験として強さ差がある方が手の違いが見えやすい。
   const [characterIdA, setCharacterIdA] = useState<string>("ryuou");
-  const [characterIdB, setCharacterIdB] = useState<string>("ryuou");
+  const [characterIdB, setCharacterIdB] = useState<string>("sakura");
   const [game, setGame] = useState<SpectatorGame | null>(null);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const characterA = CHARACTERS.find((c) => c.id === characterIdA) ?? CHARACTERS[3];
+  const characterB = CHARACTERS.find((c) => c.id === characterIdB) ?? CHARACTERS[0];
 
   const handleStart = async () => {
     setPending(true);
@@ -61,103 +79,207 @@ export default function SpectatePage() {
         gameId={game.gameId}
         gameConfig={{
           variantId: "card-shogi",
-          difficulty: difficultyA,
+          difficulty: characterA.difficulty,
           playerColor: "sente", // 観戦モードでは未使用 (両プレイヤー AI 駆動)
           characterId: characterIdA,
           soundEnabled: true,
           commentaryEnabled: false,
           spectatorMode: true,
-          difficultyB,
-          characterIdB,
+          difficultyB: characterB.difficulty,
+          characterIdB: characterIdB,
         }}
       />
     );
   }
 
-  // 観戦設定画面
+  // 観戦設定画面 (レイアウトは /play の MatchSetup と統一)
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-center p-6 gap-6">
-      <h1 className="text-2xl font-bold">CPU 同士を観る</h1>
-      <p className="text-sm text-muted-foreground text-center max-w-md">
-        2 人の AI を選んで対局を観戦できます。観戦結果は保存されません (
-        ページを閉じると初期化されます)。
-      </p>
+    <PageMotion>
+      <main className="flex flex-col h-dvh safe-area-inset overflow-hidden">
+        <AppBackground variant="setup" />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl w-full">
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">先手 (A)</label>
-          <select
-            value={difficultyA}
-            onChange={(e) => setDifficultyA(e.target.value as Difficulty)}
-            disabled={pending}
-            className="w-full p-2 border rounded bg-background"
-          >
-            {(["beginner", "intermediate", "advanced", "expert"] as const).map((d) => (
-              <option key={d} value={d}>
-                {DIFFICULTY_LABELS[d]}
-              </option>
-            ))}
-          </select>
-          <select
-            value={characterIdA}
-            onChange={(e) => setCharacterIdA(e.target.value)}
-            disabled={pending}
-            className="w-full p-2 border rounded bg-background"
-          >
-            {CHARACTERS.filter((c) => c.difficulty === difficultyA).map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.avatarEmoji} {c.name} - {c.title}
-              </option>
-            ))}
-          </select>
+        <div className="relative text-center py-2 sm:py-6 px-4 shrink-0">
+          {/* 画面左上: ホームへ戻るリンク (MaskedLink で nav_back SFX + spinner overlay) */}
+          <div className="absolute top-2 left-4 sm:top-3">
+            <MaskedLink
+              href="/"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="ホームへ戻る"
+              loadingVariant="spinner"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              ホーム
+            </MaskedLink>
+          </div>
+          <div className="absolute top-2 right-4 sm:top-3 flex items-center gap-2">
+            <AuthControls variant="indicator" />
+            <ThemeSelector />
+          </div>
+          <h1 className="text-xl sm:text-3xl font-bold tracking-tight">CPU 同士を観る</h1>
+          <p className="text-xs sm:text-sm text-muted-foreground">2 人の AI を選んで観戦</p>
         </div>
 
-        <div className="space-y-2">
-          <label className="block text-sm font-medium">後手 (B)</label>
-          <select
-            value={difficultyB}
-            onChange={(e) => setDifficultyB(e.target.value as Difficulty)}
+        <div className="flex-1 flex flex-col max-w-2xl mx-auto w-full px-4 pb-2 sm:pb-4 space-y-2 min-h-0 overflow-y-auto">
+          {/* 先手 (A) 選択 */}
+          <CharacterPicker
+            label="先手 (A) を選ぶ"
+            selectedId={characterIdA}
+            onSelect={setCharacterIdA}
+            layoutGroup="a"
             disabled={pending}
-            className="w-full p-2 border rounded bg-background"
-          >
-            {(["beginner", "intermediate", "advanced", "expert"] as const).map((d) => (
-              <option key={d} value={d}>
-                {DIFFICULTY_LABELS[d]}
-              </option>
-            ))}
-          </select>
-          <select
-            value={characterIdB}
-            onChange={(e) => setCharacterIdB(e.target.value)}
+          />
+
+          {/* 後手 (B) 選択 */}
+          <CharacterPicker
+            label="後手 (B) を選ぶ"
+            selectedId={characterIdB}
+            onSelect={setCharacterIdB}
+            layoutGroup="b"
             disabled={pending}
-            className="w-full p-2 border rounded bg-background"
+          />
+
+          {error && (
+            <div className="text-xs sm:text-sm text-destructive text-center">エラー: {error}</div>
+          )}
+
+          {/* スペーサー(モバイルでボタンを下寄せ) */}
+          <div className="flex-1 sm:hidden" />
+
+          {/* 観戦開始ボタン */}
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, delay: 0.18, ease: "easeOut" }}
+            className="shrink-0"
           >
-            {CHARACTERS.filter((c) => c.difficulty === difficultyB).map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.avatarEmoji} {c.name} - {c.title}
-              </option>
-            ))}
-          </select>
+            <Button
+              size="lg"
+              className="w-full text-sm sm:text-base py-3 sm:py-6"
+              onClick={handleStart}
+              disabled={pending}
+            >
+              <Eye className="w-4 h-4 mr-2" />
+              {`${characterA.name} vs ${characterB.name} を観戦`}
+            </Button>
+          </motion.div>
+
+          <p className="text-[10px] sm:text-xs text-muted-foreground text-center px-2">
+            観戦モードは思考時間を 1.5 秒に短縮、200 手で強制引き分けです。観戦結果は保存されません。
+          </p>
         </div>
-      </div>
 
-      {error && (
-        <div className="text-sm text-destructive">エラー: {error}</div>
-      )}
+        <LoadingOverlay
+          show={pending}
+          fullScreen
+          card
+          stages={LOADING_STAGES.matchSetup}
+          progress
+          message="準備中..."
+        />
+      </main>
+    </PageMotion>
+  );
+}
 
-      <div className="flex gap-3">
-        <Button onClick={() => router.push("/")} variant="outline" disabled={pending}>
-          ホームへ戻る
-        </Button>
-        <Button onClick={handleStart} disabled={pending}>
-          {pending ? "準備中..." : "観戦を開始"}
-        </Button>
-      </div>
+interface CharacterPickerProps {
+  label: string;
+  selectedId: string;
+  onSelect: (id: string) => void;
+  layoutGroup: string; // motion.layoutId 衝突回避用 ("a" / "b")
+  disabled: boolean;
+}
 
-      <p className="text-xs text-muted-foreground max-w-md text-center mt-4">
-        観戦モードでは思考時間が短縮 (1.5 秒/手) され、200 手で強制引き分けとなります。
-        観戦体験を快適にするための設定で、AI 棋力評価とは独立した値です。
-      </p>
-    </main>
+// MatchSetup と同じレイアウト (モバイル: 縦リスト / デスクトップ: 4列グリッド)。
+function CharacterPicker({ label, selectedId, onSelect, layoutGroup, disabled }: CharacterPickerProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay: 0.06, ease: "easeOut" }}
+    >
+      <Card size="sm" className="shrink-0 bg-card/85 backdrop-blur-sm">
+        <CardHeader className="pb-0 pt-0">
+          <CardTitle className="text-sm sm:text-base">{label}</CardTitle>
+        </CardHeader>
+        <CardContent className="pb-0">
+          {/* モバイル: コンパクトリスト */}
+          <div className="sm:hidden flex flex-col gap-1 relative">
+            {CHARACTERS.map((character) => {
+              const diffInfo = DIFFICULTY_INFO[character.difficulty];
+              const isSelected = selectedId === character.id;
+              return (
+                <button
+                  key={character.id}
+                  onClick={() => !disabled && onSelect(character.id)}
+                  disabled={disabled}
+                  className={cn(
+                    "relative flex items-center gap-2 px-2.5 py-1.5 rounded-lg border-2 text-left transition-all",
+                    "cursor-pointer disabled:cursor-not-allowed disabled:opacity-60",
+                    isSelected ? "border-transparent bg-primary/5" : "border-border hover:border-primary/40",
+                  )}
+                >
+                  {isSelected && (
+                    <motion.div
+                      layoutId={`spectator-${layoutGroup}-mobile`}
+                      className="absolute inset-0 rounded-lg border-2 border-primary pointer-events-none"
+                      transition={{ type: "spring", stiffness: 320, damping: 28 }}
+                    />
+                  )}
+                  <span className="text-xl shrink-0">{character.avatarEmoji}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-bold text-sm">{character.name}</span>
+                      <Badge variant="outline" className={cn("text-[10px] px-1.5 py-0", diffInfo.color)}>
+                        {diffInfo.label}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground">{character.title}</div>
+                  </div>
+                  {isSelected && <div className="w-2 h-2 rounded-full bg-primary shrink-0 relative z-10" />}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* デスクトップ: 4列グリッド */}
+          <div className="hidden sm:grid grid-cols-4 gap-3 relative">
+            {CHARACTERS.map((character) => {
+              const diffInfo = DIFFICULTY_INFO[character.difficulty];
+              const isSelected = selectedId === character.id;
+              return (
+                <button
+                  key={character.id}
+                  onClick={() => !disabled && onSelect(character.id)}
+                  disabled={disabled}
+                  className={cn(
+                    "relative p-3 rounded-xl border-2 text-left transition-all",
+                    "hover:shadow-md cursor-pointer disabled:cursor-not-allowed disabled:opacity-60",
+                    isSelected ? "border-transparent bg-primary/5 shadow-sm" : "border-border hover:border-primary/40",
+                  )}
+                >
+                  {isSelected && (
+                    <motion.div
+                      layoutId={`spectator-${layoutGroup}-desktop`}
+                      className="absolute inset-0 rounded-xl border-2 border-primary pointer-events-none"
+                      transition={{ type: "spring", stiffness: 320, damping: 28 }}
+                    />
+                  )}
+                  {isSelected && (
+                    <div className="absolute top-2 right-2 w-2 h-2 rounded-full bg-primary z-10" />
+                  )}
+                  <div className="text-3xl mb-1">{character.avatarEmoji}</div>
+                  <div className="font-bold text-sm">{character.name}</div>
+                  <div className="text-xs text-muted-foreground mb-1">{character.title}</div>
+                  <Badge variant="outline" className={cn("text-xs", diffInfo.color)}>
+                    {diffInfo.label}
+                  </Badge>
+                  <p className="text-xs text-muted-foreground mt-0.5">{diffInfo.description}</p>
+                </button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
   );
 }

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import { LoadingOverlay } from "@/components/loading-overlay";
 import { MaskedLink } from "@/components/navigation/masked-link";
 import { LOADING_STAGES } from "@/lib/loading-stages";
-import { ChevronUp, ChevronDown, Volume2, VolumeX } from "lucide-react";
+import { ChevronUp, ChevronDown, Pause, Volume2, VolumeX } from "lucide-react";
 
 import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
 import { useSound, playSfxOnce } from "@/hooks/use-sound";
@@ -2138,6 +2138,22 @@ export function CardShogiGame({
 
       {/* Issue #81: 早指し時に駒の少し下に表示するバッジ */}
       <FastMoveBadgeLayer items={fastMoveBadges} onComplete={removeFastMoveBadge} />
+
+      {/* Issue #193 / PR1a: 観戦モード一時停止中の中央インジケータ。
+          spectatorMode && isPaused のときに半透明オーバーレイで Pause アイコンを
+          画面中央に表示。pointer-events-none で背後の操作 (GameControls の再開ボタン) は
+          引き続き反応するため、ユーザーは再開を即実行できる。 */}
+      {spectatorMode && isPaused && !isExitingHome && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center pointer-events-none bg-background/40 backdrop-blur-[2px]">
+          <div className="flex flex-col items-center gap-2 bg-card/95 px-6 py-5 sm:px-8 sm:py-6 rounded-2xl shadow-xl border-2 border-primary/30">
+            <Pause className="w-12 h-12 sm:w-16 sm:h-16 text-primary" strokeWidth={2.5} />
+            <div className="text-base sm:text-lg font-bold">一時停止中</div>
+            <div className="text-xs text-muted-foreground text-center">
+              再開ボタンで観戦を続けられます
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Issue #193 / PR1a: 観戦モードのホーム戻り確認ダイアログ。
           ダイアログ表示中は CPU を pause した状態を維持し、確認 OK で

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -30,6 +30,13 @@ import { AuthControls } from "@/components/auth/auth-controls";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { getShogiBoardCellSize } from "@/lib/shogi/board-layout";
 
@@ -348,13 +355,39 @@ export function CardShogiGame({
   const aiColor: Player = playerColor === "sente" ? "gote" : "sente";
   const isPlayerTurn = gameState.currentPlayer === playerColor;
 
-  // Issue #193 / PR1a: 観戦モードの「ホームへ戻る」ボタン。揮発モードのため
-  // ページ離脱で初期化される (G-2 進行中チェックリスト想定)。in-flight な AI 探索を
-  // 確実に停止するため、useCardShogiGame の cancelAiRequest 経由は不要 (unmount 時の
-  // useEffect cleanup で abort される)。
-  const handleExitSpectator = useCallback(() => {
+  // Issue #193 / PR1a: 観戦モードの「ホームへ戻る」フロー。
+  // 1. ボタン押下: 確認ダイアログを表示 + CPU 進行を即時停止 (一時停止と同じ挙動)
+  // 2. 確認 OK: ローディングマスクを表示しつつ router.push("/") でホーム画面へ遷移
+  // 3. キャンセル: ダイアログを閉じ、ダイアログ表示前の Pause 状態に戻す
+  //    (ダイアログ表示前から既に Pause していた場合は Resume しない)
+  const [showExitDialog, setShowExitDialog] = useState(false);
+  const [isExitingHome, setIsExitingHome] = useState(false);
+  // ダイアログ表示時点で既に isPaused=true だったかを保持し、キャンセル時の挙動を分岐する。
+  const pausedBeforeExitRef = useRef(false);
+
+  const handleRequestExit = useCallback(() => {
+    pausedBeforeExitRef.current = isPaused;
+    if (!isPaused) {
+      // ダイアログ表示中も CPU を止めるため、まだ Pause されていない場合に PAUSE_GAME を発行。
+      pauseSpectator();
+    }
+    setShowExitDialog(true);
+  }, [isPaused, pauseSpectator]);
+
+  const handleConfirmExit = useCallback(() => {
+    setShowExitDialog(false);
+    setIsExitingHome(true);
+    // ローディングマスクを 1 frame 描画してから遷移 (体感的な滑らかさのため)。
     router.push("/");
   }, [router]);
+
+  const handleCancelExit = useCallback(() => {
+    setShowExitDialog(false);
+    // ダイアログ表示前から Pause されていた場合は何もしない (ユーザーの Pause を維持)
+    if (!pausedBeforeExitRef.current) {
+      resumeSpectator();
+    }
+  }, [resumeSpectator]);
 
   // BGM (Issue #79):
   //   - useBgm が BGM の単一オーナー。dev tool で event override が設定された
@@ -1587,7 +1620,7 @@ export function CardShogiGame({
             isPaused={isPaused}
             onPauseSpectator={pauseSpectator}
             onResumeSpectator={resumeSpectator}
-            onExitSpectator={handleExitSpectator}
+            onExitSpectator={handleRequestExit}
           />
         </div>
       </section>
@@ -1623,7 +1656,7 @@ export function CardShogiGame({
                 isPaused={isPaused}
                 onPauseSpectator={pauseSpectator}
                 onResumeSpectator={resumeSpectator}
-                onExitSpectator={handleExitSpectator}
+                onExitSpectator={handleRequestExit}
               />
             ) : (
               /* 終局時: 結果ボタンを常時表示。蛍光緑、現状の約 2 倍幅、結果カード
@@ -1813,7 +1846,7 @@ export function CardShogiGame({
               isPaused={isPaused}
               onPauseSpectator={pauseSpectator}
               onResumeSpectator={resumeSpectator}
-              onExitSpectator={handleExitSpectator}
+              onExitSpectator={handleRequestExit}
             />
           </div>
         </aside>
@@ -2104,15 +2137,42 @@ export function CardShogiGame({
       {/* Issue #81: 早指し時に駒の少し下に表示するバッジ */}
       <FastMoveBadgeLayer items={fastMoveBadges} onComplete={removeFastMoveBadge} />
 
+      {/* Issue #193 / PR1a: 観戦モードのホーム戻り確認ダイアログ。
+          ダイアログ表示中は CPU を pause した状態を維持し、確認 OK で
+          ローディングマスク (LoadingOverlay) を表示しつつ router.push("/") する。 */}
+      <Dialog
+        open={showExitDialog}
+        onOpenChange={(open) => {
+          if (!open) handleCancelExit();
+        }}
+      >
+        <DialogContent className="max-w-xs">
+          <DialogHeader>
+            <DialogTitle>ホームへ戻りますか？</DialogTitle>
+            <DialogDescription>
+              観戦を中断してホーム画面に戻ります。観戦結果は保存されません。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2 justify-end mt-2">
+            <Button variant="outline" onClick={handleCancelExit}>
+              キャンセル
+            </Button>
+            <Button onClick={handleConfirmExit}>ホームへ戻る</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       {/* Issue #163: 「もう一局」(=createGame Server Action 後 router.push) 中のローディングマスク。
           xl/xl 未満/モバイル の各レイアウトで同じ isPending を共有しているため Overlay 1 つで全カバー。
-          ビジュアルは他のリッチローディング (回転カード + プログレスバー + ステージ文言) に統一。 */}
+          ビジュアルは他のリッチローディング (回転カード + プログレスバー + ステージ文言) に統一。
+          Issue #193 / PR1a: 観戦モードのホーム戻り (isExitingHome) も同 Overlay を流用、
+          ステージ文言は LOADING_STAGES.homeNavigate に切替。 */}
       <LoadingOverlay
-        show={isPending}
+        show={isPending || isExitingHome}
         fullScreen
         card
         progress
-        stages={LOADING_STAGES.matchRestart}
+        stages={isExitingHome ? LOADING_STAGES.homeNavigate : LOADING_STAGES.matchRestart}
       />
       {/* Issue #176: AI 思考が連続失敗した場合のリカバリ UI */}
       <AiErrorModal

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -1621,7 +1621,6 @@ export function CardShogiGame({
             spectatorMode={spectatorMode}
             isPaused={isPaused}
             onPauseSpectator={pauseSpectator}
-            onResumeSpectator={resumeSpectator}
             onExitSpectator={handleRequestExit}
           />
         </div>
@@ -1657,7 +1656,6 @@ export function CardShogiGame({
                 spectatorMode={spectatorMode}
                 isPaused={isPaused}
                 onPauseSpectator={pauseSpectator}
-                onResumeSpectator={resumeSpectator}
                 onExitSpectator={handleRequestExit}
               />
             ) : (
@@ -1847,7 +1845,6 @@ export function CardShogiGame({
               spectatorMode={spectatorMode}
               isPaused={isPaused}
               onPauseSpectator={pauseSpectator}
-              onResumeSpectator={resumeSpectator}
               onExitSpectator={handleRequestExit}
             />
           </div>
@@ -2140,19 +2137,24 @@ export function CardShogiGame({
       <FastMoveBadgeLayer items={fastMoveBadges} onComplete={removeFastMoveBadge} />
 
       {/* Issue #193 / PR1a: 観戦モード一時停止中の中央インジケータ。
-          spectatorMode && isPaused のときに半透明オーバーレイで Pause アイコンを
-          画面中央に表示。pointer-events-none で背後の操作 (GameControls の再開ボタン) は
-          引き続き反応するため、ユーザーは再開を即実行できる。 */}
+          オーバーレイ自体がクリック可能で、どこをクリックしても resumeSpectator が
+          発火して観戦を再開できる。半透明 + 軽い backdrop-blur で全体がぼんやり
+          マスクされた状態を表現する。 */}
       {spectatorMode && isPaused && !isExitingHome && (
-        <div className="fixed inset-0 z-40 flex items-center justify-center pointer-events-none bg-background/40 backdrop-blur-[2px]">
-          <div className="flex flex-col items-center gap-2 bg-card/95 px-6 py-5 sm:px-8 sm:py-6 rounded-2xl shadow-xl border-2 border-primary/30">
+        <button
+          type="button"
+          onClick={resumeSpectator}
+          aria-label="クリックで観戦を再開"
+          className="fixed inset-0 z-40 flex items-center justify-center bg-background/40 backdrop-blur-[2px] cursor-pointer"
+        >
+          <div className="flex flex-col items-center gap-2 bg-card/95 px-6 py-5 sm:px-8 sm:py-6 rounded-2xl shadow-xl border-2 border-primary/30 pointer-events-none">
             <Pause className="w-12 h-12 sm:w-16 sm:h-16 text-primary" strokeWidth={2.5} />
             <div className="text-base sm:text-lg font-bold">一時停止中</div>
             <div className="text-xs text-muted-foreground text-center">
-              再開ボタンで観戦を続けられます
+              画面をクリックで再開
             </div>
           </div>
-        </div>
+        </button>
       )}
 
       {/* Issue #193 / PR1a: 観戦モードのホーム戻り確認ダイアログ。

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -10,8 +10,8 @@ import { LOADING_STAGES } from "@/lib/loading-stages";
 import { ChevronUp, ChevronDown, Volume2, VolumeX } from "lucide-react";
 
 import { useCardShogiGame } from "@/hooks/use-card-shogi-game";
-import { useSound } from "@/hooks/use-sound";
-import { useBgm } from "@/hooks/use-bgm";
+import { useSound, playSfxOnce } from "@/hooks/use-sound";
+import { useBgm, prepareBgmForNavigation } from "@/hooks/use-bgm";
 import { useCardBoardSize } from "@/hooks/use-card-board-size";
 
 import { ShogiBoard, type ShogiBoardHandle } from "../shogi-board";
@@ -377,7 +377,9 @@ export function CardShogiGame({
   const handleConfirmExit = useCallback(() => {
     setShowExitDialog(false);
     setIsExitingHome(true);
-    // ローディングマスクを 1 frame 描画してから遷移 (体感的な滑らかさのため)。
+    // 他画面のホーム戻りリンク (MaskedLink) と効果音 / BGM 切替を統一する。
+    playSfxOnce("nav_back");
+    prepareBgmForNavigation("/");
     router.push("/");
   }, [router]);
 

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -329,6 +329,11 @@ export function CardShogiGame({
     cancelDoubleMove,
     aiError,
     retryAiMove,
+    // Issue #193 / PR1a: 観戦モード専用 (一時停止 / 再開)。spectatorMode は
+    // serializableConfig 経由で取得済 (上の const spectatorMode = ...)。
+    isPaused,
+    pauseSpectator,
+    resumeSpectator,
   } = useCardShogiGame({
     initialState: initialGameState,
     initialCardState,
@@ -342,6 +347,14 @@ export function CardShogiGame({
   const playerColor = gameConfig.playerColor;
   const aiColor: Player = playerColor === "sente" ? "gote" : "sente";
   const isPlayerTurn = gameState.currentPlayer === playerColor;
+
+  // Issue #193 / PR1a: 観戦モードの「ホームへ戻る」ボタン。揮発モードのため
+  // ページ離脱で初期化される (G-2 進行中チェックリスト想定)。in-flight な AI 探索を
+  // 確実に停止するため、useCardShogiGame の cancelAiRequest 経由は不要 (unmount 時の
+  // useEffect cleanup で abort される)。
+  const handleExitSpectator = useCallback(() => {
+    router.push("/");
+  }, [router]);
 
   // BGM (Issue #79):
   //   - useBgm が BGM の単一オーナー。dev tool で event override が設定された
@@ -1571,6 +1584,10 @@ export function CardShogiGame({
             canUndo={canUndo}
             gameActive={isGameActive}
             spectatorMode={spectatorMode}
+            isPaused={isPaused}
+            onPauseSpectator={pauseSpectator}
+            onResumeSpectator={resumeSpectator}
+            onExitSpectator={handleExitSpectator}
           />
         </div>
       </section>
@@ -1603,6 +1620,10 @@ export function CardShogiGame({
                 gameActive={isGameActive}
                 hideSound
                 spectatorMode={spectatorMode}
+                isPaused={isPaused}
+                onPauseSpectator={pauseSpectator}
+                onResumeSpectator={resumeSpectator}
+                onExitSpectator={handleExitSpectator}
               />
             ) : (
               /* 終局時: 結果ボタンを常時表示。蛍光緑、現状の約 2 倍幅、結果カード
@@ -1789,6 +1810,10 @@ export function CardShogiGame({
               gameActive={isGameActive}
               hideSound
               spectatorMode={spectatorMode}
+              isPaused={isPaused}
+              onPauseSpectator={pauseSpectator}
+              onResumeSpectator={resumeSpectator}
+              onExitSpectator={handleExitSpectator}
             />
           </div>
         </aside>

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -270,6 +270,10 @@ export function CardShogiGame({
     ...serializableConfig,
     variant: getVariantById(serializableConfig.variantId),
   };
+  // Issue #193 / PR1a: 観戦モードでは UI 操作 (手札クリック / 投了 / 待った 等) を完全に
+  // 無効化する。useCardShogiGame 側の callback も no-op になっているが、UI 層でも
+  // 早期 return して効果音 (card_select 等) の発火やボタン描画を抑止する。
+  const spectatorMode = serializableConfig.spectatorMode ?? false;
 
   const character = getCharacterById(gameConfig.characterId);
   const { playSfx, toggleMute, isMuted, isReady } = useSound();
@@ -900,23 +904,30 @@ export function CardShogiGame({
   const handleHandPieceClick = useCallback(
     (piece: Parameters<typeof selectHandPiece>[0]) => {
       if (isDrawAnimating || isPlayingCard || isCheckBreakAnimating) return;
+      // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+      if (spectatorMode) return;
       selectHandPiece(piece);
     },
-    [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, selectHandPiece],
+    [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, spectatorMode, selectHandPiece],
   );
   const handleBeginPlayCard = useCallback(
     (id: string) => {
       if (isDrawAnimating || isPlayingCard || isCheckBreakAnimating) return;
+      // Issue #193 / PR1a: 観戦モードはユーザー操作不可。card_select SFX も
+      // 鳴らさないよう SFX 呼出より前で早期 return する。
+      if (spectatorMode) return;
       // Issue #79 派生: 手札クリックで中央 popup を開く SFX (default = カードをめくる)
       playSfx("card_select");
       beginPlayCard(id);
     },
-    [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, beginPlayCard, playSfx],
+    [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, spectatorMode, beginPlayCard, playSfx],
   );
   const handleDeselect = useCallback(() => {
     if (isDrawAnimating || isPlayingCard || isCheckBreakAnimating) return;
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (spectatorMode) return;
     deselect();
-  }, [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, deselect]);
+  }, [isDrawAnimating, isPlayingCard, isCheckBreakAnimating, spectatorMode, deselect]);
 
   // 演出中は最新ドローカードを手札表示から除外し、演出完了後に手札に現れたように見せる。
   // FIFO 化により queue 内の全カード ID を hidden 対象にする (#130)。
@@ -1559,6 +1570,7 @@ export function CardShogiGame({
             onToggleMute={toggleMute}
             canUndo={canUndo}
             gameActive={isGameActive}
+            spectatorMode={spectatorMode}
           />
         </div>
       </section>
@@ -1590,6 +1602,7 @@ export function CardShogiGame({
                 canUndo={canUndo}
                 gameActive={isGameActive}
                 hideSound
+                spectatorMode={spectatorMode}
               />
             ) : (
               /* 終局時: 結果ボタンを常時表示。蛍光緑、現状の約 2 倍幅、結果カード
@@ -1775,6 +1788,7 @@ export function CardShogiGame({
               canUndo={canUndo}
               gameActive={isGameActive}
               hideSound
+              spectatorMode={spectatorMode}
             />
           </div>
         </aside>

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -74,6 +74,10 @@ interface SerializableGameConfig {
   // false → useBgm に null を渡し BGM 停止。
   soundEnabled: boolean;
   commentaryEnabled: boolean;
+  // Issue #193 / PR1a: CPU vs CPU 観戦モード関連 (gameConfig 経由で useCardShogiGame に伝播)。
+  spectatorMode?: boolean;
+  difficultyB?: Difficulty;
+  characterIdB?: string;
 }
 
 interface CardShogiGameProps {

--- a/src/components/game/game-controls.tsx
+++ b/src/components/game/game-controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Flag, Home, Pause, Play, RotateCcw, Volume2, VolumeX } from "lucide-react";
+import { Flag, Home, Pause, RotateCcw, Volume2, VolumeX } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -25,11 +25,12 @@ interface GameControlsProps {
   // Issue #193 / PR1a: CPU vs CPU 観戦モード。true のとき投了 / 待ったボタンを
   // 描画しない (= ユーザー操作不可、両 CPU 駆動のみで進行)。音量トグルは引き続き表示。
   spectatorMode?: boolean;
-  // Issue #193 / PR1a: 観戦モード専用の一時停止 / 再開 / ホーム戻り。
-  // spectatorMode=true && gameActive=true のときに描画。
+  // Issue #193 / PR1a: 観戦モード専用の一時停止 / ホーム戻り。
+  // spectatorMode=true && gameActive=true のときに描画。再開操作は本コンポーネント
+  // ではなく、card-shogi-game の中央オーバーレイ (画面クリック) で行う UX のため、
+  // onResumeSpectator は本 props から除外している。
   isPaused?: boolean;
   onPauseSpectator?: () => void;
-  onResumeSpectator?: () => void;
   onExitSpectator?: () => void;
 }
 
@@ -48,7 +49,6 @@ export function GameControls({
   spectatorMode = false,
   isPaused = false,
   onPauseSpectator,
-  onResumeSpectator,
   onExitSpectator,
 }: GameControlsProps) {
   const [showResignDialog, setShowResignDialog] = useState(false);
@@ -103,19 +103,23 @@ export function GameControls({
           </>
         )}
 
-        {/* Issue #193 / PR1a: 観戦モード専用の一時停止 / 再開 / ホーム戻りボタン */}
+        {/* Issue #193 / PR1a: 観戦モード専用の一時停止 / ホーム戻りボタン。
+            ボタン表示は常に「一時停止」のままで切替えない (再開操作は中央オーバーレイの
+            クリックで行う UX に統一)。一時停止中に本ボタンを再押下しても reducer 側で
+            isPaused=true 状態のため副作用なし (no-op)。 */}
         {gameActive && spectatorMode && (
           <>
             <Button
               variant="outline"
               size={compact ? "icon" : "sm"}
-              onClick={isPaused ? onResumeSpectator : onPauseSpectator}
+              onClick={onPauseSpectator}
+              disabled={isPaused}
               className={compact ? "h-9 w-9" : "gap-1.5"}
-              aria-label={isPaused ? "再開" : "一時停止"}
-              title={isPaused ? "再開" : "一時停止"}
+              aria-label="一時停止"
+              title="一時停止"
             >
-              {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
-              {!compact && (isPaused ? "再開" : "一時停止")}
+              <Pause className="w-4 h-4" />
+              {!compact && "一時停止"}
             </Button>
 
             <Button

--- a/src/components/game/game-controls.tsx
+++ b/src/components/game/game-controls.tsx
@@ -22,6 +22,9 @@ interface GameControlsProps {
   compact?: boolean;
   // 音量トグルを非表示にする。card-shogi の 4列レイアウトでは音はヘッダーに分離するため。
   hideSound?: boolean;
+  // Issue #193 / PR1a: CPU vs CPU 観戦モード。true のとき投了 / 待ったボタンを
+  // 描画しない (= ユーザー操作不可、両 CPU 駆動のみで進行)。音量トグルは引き続き表示。
+  spectatorMode?: boolean;
 }
 
 // 固定高さ: 36px
@@ -36,6 +39,7 @@ export function GameControls({
   gameActive,
   compact = false,
   hideSound = false,
+  spectatorMode = false,
 }: GameControlsProps) {
   const [showResignDialog, setShowResignDialog] = useState(false);
 
@@ -59,7 +63,8 @@ export function GameControls({
           </Button>
         )}
 
-        {gameActive && (
+        {/* Issue #193 / PR1a: 観戦モードでは投了 / 待ったボタンを描画しない (両 CPU 駆動のみ) */}
+        {gameActive && !spectatorMode && (
           <>
             <Button
               variant="outline"

--- a/src/components/game/game-controls.tsx
+++ b/src/components/game/game-controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Flag, RotateCcw, Volume2, VolumeX } from "lucide-react";
+import { Flag, Home, Pause, Play, RotateCcw, Volume2, VolumeX } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -25,6 +25,12 @@ interface GameControlsProps {
   // Issue #193 / PR1a: CPU vs CPU 観戦モード。true のとき投了 / 待ったボタンを
   // 描画しない (= ユーザー操作不可、両 CPU 駆動のみで進行)。音量トグルは引き続き表示。
   spectatorMode?: boolean;
+  // Issue #193 / PR1a: 観戦モード専用の一時停止 / 再開 / ホーム戻り。
+  // spectatorMode=true && gameActive=true のときに描画。
+  isPaused?: boolean;
+  onPauseSpectator?: () => void;
+  onResumeSpectator?: () => void;
+  onExitSpectator?: () => void;
 }
 
 // 固定高さ: 36px
@@ -40,6 +46,10 @@ export function GameControls({
   compact = false,
   hideSound = false,
   spectatorMode = false,
+  isPaused = false,
+  onPauseSpectator,
+  onResumeSpectator,
+  onExitSpectator,
 }: GameControlsProps) {
   const [showResignDialog, setShowResignDialog] = useState(false);
 
@@ -89,6 +99,35 @@ export function GameControls({
             >
               <Flag className="w-4 h-4" />
               {!compact && "投了"}
+            </Button>
+          </>
+        )}
+
+        {/* Issue #193 / PR1a: 観戦モード専用の一時停止 / 再開 / ホーム戻りボタン */}
+        {gameActive && spectatorMode && (
+          <>
+            <Button
+              variant="outline"
+              size={compact ? "icon" : "sm"}
+              onClick={isPaused ? onResumeSpectator : onPauseSpectator}
+              className={compact ? "h-9 w-9" : "gap-1.5"}
+              aria-label={isPaused ? "再開" : "一時停止"}
+              title={isPaused ? "再開" : "一時停止"}
+            >
+              {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
+              {!compact && (isPaused ? "再開" : "一時停止")}
+            </Button>
+
+            <Button
+              variant="outline"
+              size={compact ? "icon" : "sm"}
+              onClick={onExitSpectator}
+              className={compact ? "h-9 w-9" : "gap-1.5"}
+              aria-label="ホームへ戻る"
+              title="ホームへ戻る"
+            >
+              <Home className="w-4 h-4" />
+              {!compact && "ホーム"}
             </Button>
           </>
         )}

--- a/src/hooks/ai/use-ai-request.ts
+++ b/src/hooks/ai/use-ai-request.ts
@@ -31,6 +31,7 @@ import type {
   Move,
   Player,
 } from "@/lib/shogi/types";
+import type { CardGameState } from "@/lib/shogi/cards/types";
 import type { SearchStats } from "@/lib/shogi/ai/search-context";
 
 export interface AiMoveRequestParams {
@@ -40,6 +41,12 @@ export interface AiMoveRequestParams {
   difficulty: Difficulty;
   variantId: string;
   clientMoveCount: number;
+  // Issue #193 / PR1a: optional な cardState 送信経路。PR1a では route 側で
+  // silent ignore (型不一致でも 400 返却せず無視)、PR1d で評価関数に組込予定。
+  cardState?: CardGameState;
+  // Issue #193 / PR1a: CPU vs CPU 観戦モードフラグ。route 側で timeLimitMs を
+  // SPECTATOR_TIME_LIMIT_MS (1500ms) に短縮して観戦体験を向上させる。
+  spectatorMode?: boolean;
 }
 
 export interface AiMoveResponse {

--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -48,6 +48,11 @@ function makeInitialState(
     doubleMove: null,
     forbiddenMateMoves: [],
     undoSnapshots: [],
+    // Issue #193 / PR1a (B-3 対応): 観戦モード関連の新規フィールド。既存テストでは
+    // 常に false (= 人間プレイ時の挙動) を想定。観戦モード固有の挙動 (早指し disable /
+    // PAUSE_GAME / RESUME_GAME) は別途専用テストで検証する想定。
+    spectatorMode: false,
+    isPaused: false,
   };
 }
 

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -76,7 +76,12 @@ export type ShogiAction =
   // フラグを更新するだけで、AI 自動応手 useEffect 側がフラグを見て request abort と
   // dispatch ガードを行う。
   | { type: "PAUSE_GAME" }
-  | { type: "RESUME_GAME" };
+  | { type: "RESUME_GAME" }
+  // Issue #193 / PR1a (C-5): 観戦モード固有の終局判定。SPECTATOR_MAX_MOVES (200 手)
+  // 到達時に use-card-shogi-game の useEffect が dispatch する。spectatorMode === false の
+  // 人間プレイ時は no-op (= 強制終了は観戦モード専用)。終了条件優先順位: 千日手 (最優先、
+  // 既存 status="draw" 判定) → カードアクション上限 → 200 手到達の順。
+  | { type: "END_SPECTATOR_GAME" };
 
 export type Action = ShogiAction | CardAction;
 
@@ -1466,6 +1471,17 @@ export function reducer(
     case "RESUME_GAME":
       if (!state.spectatorMode) return state;
       return { ...state, isPaused: false };
+
+    // Issue #193 / PR1a (C-5): 観戦モード固有の強制引き分け終局。
+    // SPECTATOR_MAX_MOVES 到達で use-card-shogi-game の useEffect から dispatch される。
+    // GameStatus に "spectator_max_moves" を追加し winner="draw" 扱い。
+    case "END_SPECTATOR_GAME":
+      if (!state.spectatorMode) return state;
+      if (state.gameState.status !== "active") return state;
+      return {
+        ...state,
+        gameState: { ...state.gameState, status: "spectator_max_moves", winner: "draw" },
+      };
 
     default:
       return state;

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -70,7 +70,13 @@ export type ShogiAction =
   // preCardState から完全復元 → カードは手札に戻り、マナも消費されない。
   // movesLeft=2 でも movesLeft=1 でも実行可能 (= 2手目完了前ならいつでもキャンセル可)。
   | { type: "CANCEL_DOUBLE_MOVE" }
-  | { type: "BEGIN_TURN_TIMER"; player: Player };
+  | { type: "BEGIN_TURN_TIMER"; player: Player }
+  // Issue #193 / PR1a: CPU vs CPU 観戦モードのポーズ機能。spectatorMode === true
+  // のときのみ実効する (人間プレイ時のポーズは別 Issue で扱う)。reducer は isPaused
+  // フラグを更新するだけで、AI 自動応手 useEffect 側がフラグを見て request abort と
+  // dispatch ガードを行う。
+  | { type: "PAUSE_GAME" }
+  | { type: "RESUME_GAME" };
 
 export type Action = ShogiAction | CardAction;
 
@@ -154,6 +160,16 @@ export interface CardShogiGameStateInternal {
   // リロード後は in-memory の本フィールドが空 [] となり、UNDO は不可になる
   // (eventLog も空でリロード後 → getUndoScope null → canUndo false が先に効くが、二重に保守的)。
   undoSnapshots: UndoSnapshot[];
+  // Issue #193 / PR1a: CPU vs CPU 観戦モードフラグ。対局開始時に確定し、対局中は変化しない。
+  // - false (既定): 人間プレイ。早指しボーナス・自動進行・ポーズなどは従来挙動を完全保持。
+  // - true: 観戦モード。makeMoveWithEffects の早指し判定をスキップ (= MANA_FAST_BONUS 不発)、
+  //   PAUSE_GAME / RESUME_GAME を受付ける。DB 保存は use-card-shogi-game 側で別途スキップ。
+  spectatorMode: boolean;
+  // Issue #193 / PR1a: 観戦モード専用のポーズフラグ。spectatorMode === false のときは常に false
+  // (= PAUSE_GAME / RESUME_GAME を dispatch しても無視)。人間プレイ時のポーズ機能は別 Issue で扱う。
+  // ポーズ中は AI 自動応手 useEffect 側で request を cancel し、副作用ある dispatch も
+  // ガードする (reducer 自身は本フラグを保持するだけで副作用を生まない)。
+  isPaused: boolean;
 }
 
 // Issue #132: 待ったスナップショット。reducer 内部で「移動直前の状態」を保持する。
@@ -218,7 +234,10 @@ function makeMoveWithEffects(
   gameState: GameState,
   cardState: CardGameState,
   move: Move,
-  options?: { mode?: MakeMoveMode },
+  // Issue #193 / PR1a: spectatorMode は CPU vs CPU 観戦モード時に true。
+  // 早指し判定 (FAST_THRESHOLD_MS) を完全 disable し、両 CPU の連続指しによる
+  // マナ蓄積異常を防ぐ。spectatorMode=false の人間プレイ時は完全に従来挙動を保持。
+  options?: { mode?: MakeMoveMode; spectatorMode?: boolean },
 ): {
   gameState: GameState;
   cardState: CardGameState;
@@ -228,6 +247,7 @@ function makeMoveWithEffects(
   triggeredCheckBreak: boolean;
 } {
   const mode: MakeMoveMode = options?.mode ?? "normal";
+  const spectatorMode = options?.spectatorMode ?? false;
   const opponent: Player = move.player === "sente" ? "gote" : "sente";
   const events: GameEvent[] = [];
 
@@ -332,8 +352,13 @@ function makeMoveWithEffects(
   if (mode === "normal") {
     // 通常の指し手: マナチャージ + 早指し判定 + タイマークリア
     const lastStarted = cardStateNext.lastTurnStartedAt[move.player];
+    // Issue #193 / PR1a: 観戦モード時は早指し判定を完全スキップ (両 CPU が常に <4 秒で
+    // 指してマナ蓄積が異常になることを防ぐ)。spectatorMode=false の人間プレイ時は
+    // 完全に従来挙動を保持する。
     const isFastMove =
-      lastStarted !== null && Date.now() - lastStarted < FAST_THRESHOLD_MS;
+      !spectatorMode &&
+      lastStarted !== null &&
+      Date.now() - lastStarted < FAST_THRESHOLD_MS;
     const manaAmount =
       MANA_PER_TURN + (isFastMove ? MANA_FAST_BONUS : 0);
     cardStateNext = {
@@ -749,6 +774,7 @@ export function reducer(
       if (dm && dm.movesLeft === 2) {
         const result = makeMoveWithEffects(state.gameState, state.cardState, action.move, {
           mode: "double_move_first",
+          spectatorMode: state.spectatorMode,
         });
         // 1手目で詰みが成立 (相手玉) したら即終了 + カード finalize (新仕様)
         const gameOver = result.gameState.status !== "active";
@@ -789,6 +815,7 @@ export function reducer(
       if (dm && dm.movesLeft === 1) {
         const result = makeMoveWithEffects(state.gameState, state.cardState, action.move, {
           mode: "double_move_second",
+          spectatorMode: state.spectatorMode,
         });
         return finalizeDoubleMoveCardConsumption({
           ...state,
@@ -807,7 +834,9 @@ export function reducer(
       }
 
       // 通常 MAKE_MOVE
-      const result = makeMoveWithEffects(state.gameState, state.cardState, action.move);
+      const result = makeMoveWithEffects(state.gameState, state.cardState, action.move, {
+        spectatorMode: state.spectatorMode,
+      });
       const stateAfter: CardShogiGameStateInternal = {
         ...state,
         gameState: result.gameState,
@@ -849,6 +878,7 @@ export function reducer(
       if (dm && dm.movesLeft === 2) {
         const result = makeMoveWithEffects(state.gameState, state.cardState, moveWithPromote, {
           mode: "double_move_first",
+          spectatorMode: state.spectatorMode,
         });
         const gameOver = result.gameState.status !== "active";
         if (gameOver) {
@@ -887,6 +917,7 @@ export function reducer(
       if (dm && dm.movesLeft === 1) {
         const result = makeMoveWithEffects(state.gameState, state.cardState, moveWithPromote, {
           mode: "double_move_second",
+          spectatorMode: state.spectatorMode,
         });
         return finalizeDoubleMoveCardConsumption({
           ...state,
@@ -905,7 +936,9 @@ export function reducer(
       }
 
       // 通常 CONFIRM_PROMOTION
-      const result = makeMoveWithEffects(state.gameState, state.cardState, moveWithPromote);
+      const result = makeMoveWithEffects(state.gameState, state.cardState, moveWithPromote, {
+        spectatorMode: state.spectatorMode,
+      });
       const stateAfter: CardShogiGameStateInternal = {
         ...state,
         gameState: result.gameState,
@@ -1421,6 +1454,18 @@ export function reducer(
         doubleMove: null,
       };
     }
+
+    // Issue #193 / PR1a: CPU vs CPU 観戦モードのポーズ機能。
+    // spectatorMode === false の人間プレイ時は完全に no-op (= 常に既存挙動を保持)。
+    // 観戦時のみ isPaused フラグを切替えるが、reducer は状態を持つだけで副作用は生まない。
+    // AI 自動応手 useEffect 側がフラグを見て request abort と dispatch ガードを実施する。
+    case "PAUSE_GAME":
+      if (!state.spectatorMode) return state;
+      return { ...state, isPaused: true };
+
+    case "RESUME_GAME":
+      if (!state.spectatorMode) return state;
+      return { ...state, isPaused: false };
 
     default:
       return state;

--- a/src/hooks/card-shogi/use-db-persistence-guard.ts
+++ b/src/hooks/card-shogi/use-db-persistence-guard.ts
@@ -1,0 +1,23 @@
+// Issue #193 / PR1a (B-1 対応): DB 保存 4 経路 (saveCardShogiMove /
+// persistCardShogiState / saveCardShogiResign / undoCardShogiGameState) のスキップ判定を
+// 一元管理する共通フック。
+//
+// CPU vs CPU 観戦モード (spectatorMode=true) は揮発モードのため DB に何も保存しない:
+// - Game レコードは createGame の cpu-vs-cpu 経路で作成しない (段階7 で実装予定)
+// - 各 useEffect 冒頭で `if (!canPersist) return;` で skip
+//
+// 設計判断 (F-2 進行中チェックリスト関連): 副作用なしの純粋判定だが、計画 md の
+// 設計どおり use* 接頭辞の hook で集約する (4 経路で同じロジックを使うため、将来の
+// ルール拡張で副作用 (Context 経由ログ出力等) を追加するときの拡張点として残す)。
+// PR1a 段階では完全な純粋関数で動作。
+
+"use client";
+
+export interface DbPersistenceGuard {
+  // true なら DB 保存処理を継続、false なら skip。
+  canPersist: boolean;
+}
+
+export function useDbPersistenceGuard(spectatorMode: boolean): DbPersistenceGuard {
+  return { canPersist: !spectatorMode };
+}

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -156,6 +156,12 @@ export function useCardShogiGame({
       }
       const move = result.response.move;
       if (!move) {
+        // Issue #193 / PR1a (I-5): AI が move=null を返すのは合法手なし (詰み・stalemate)
+        // のケース。reducer 側で gameState.status は既に "checkmate" / "stalemate" 等の
+        // 終局状態に変化済 (= 直前の MAKE_MOVE で evaluateGameEnd が判定済み) のため、
+        // ここでは isAiThinking フラグのみ解除して終局演出を妨げないようにする。
+        // 観戦モード両 CPU 駆動でも同様に動作 (どちらかが詰めば AI useEffect の
+        // gameState.status !== "active" ガードで以後の request は発火しない)。
         dispatch({ type: "SET_AI_THINKING", thinking: false });
         return;
       }
@@ -246,7 +252,9 @@ export function useCardShogiGame({
     ).catch((e) => {
       console.error("saveCardShogiMove failed", e);
     });
-  }, [state.gameState, state.cardState, state.doubleMove, gameId, disableServerSync]);
+    // Issue #193 / PR1a: canPersist は spectatorMode から派生し対局中は変化しないため
+    // deps 追加で実害なし、react-hooks/exhaustive-deps 要件を満たす。
+  }, [state.gameState, state.cardState, state.doubleMove, gameId, disableServerSync, canPersist]);
 
   // Issue #132: カード使用 / ドロー / トラップ設置直後の cardState 即時保存。
   // 駒指し以外のカード操作は moveCount を増やさないため、上の save useEffect では発火しない。
@@ -273,6 +281,7 @@ export function useCardShogiGame({
     persistCardShogiState(gameId, state.gameState, state.cardState).catch((e) => {
       console.error("persistCardShogiState failed", e);
     });
+    // Issue #193 / PR1a: canPersist deps 追加 (理由は上の useEffect と同じ)。
   }, [
     state.cardState,
     state.gameState,
@@ -282,6 +291,7 @@ export function useCardShogiGame({
     state.isCheckBreakAnimating,
     gameId,
     disableServerSync,
+    canPersist,
   ]);
 
   // ----- 公開API -----
@@ -477,7 +487,8 @@ export function useCardShogiGame({
     ).catch((e) => {
       console.error("undoCardShogiGameState failed", e);
     });
-  }, [state.gameState, state.cardState, gameId, disableServerSync]);
+    // Issue #193 / PR1a: canPersist deps 追加 (上 2 つの useEffect と同様の理由)。
+  }, [state.gameState, state.cardState, gameId, disableServerSync, canPersist]);
 
   const deselect = useCallback(() => {
     dispatch({ type: "DESELECT" });

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -58,6 +58,11 @@ export function useCardShogiGame({
     doubleMove: null,
     forbiddenMateMoves: [],
     undoSnapshots: [],
+    // Issue #193 / PR1a: gameConfig に spectatorMode が含まれる場合 (CPU vs CPU 観戦)
+    // のみ true、人間プレイ時は false で完全に従来挙動を保持。段階7 で gameConfig 型を
+    // 拡張して観戦モード createGame 経路を整備する想定 (現時点では未指定なら false)。
+    spectatorMode: gameConfig.spectatorMode ?? false,
+    isPaused: false,
   });
 
   const aiPlayer: Player = gameConfig.playerColor === "sente" ? "gote" : "sente";

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -20,6 +20,9 @@ import { isValidCardTargetSquare } from "@/lib/shogi/cards/effects";
 // useReducer + useEffect + useCallback の薄いフックとして公開 API のみを担う。
 import { reducer } from "./card-shogi/reducer";
 import { canUndoFromState } from "./card-shogi/undo-policy";
+import { useDbPersistenceGuard } from "./card-shogi/use-db-persistence-guard";
+import { SPECTATOR_MAX_MOVES } from "@/lib/shogi/ai/strategy";
+import type { Difficulty } from "@/lib/shogi/types";
 
 interface UseCardShogiGameOptions {
   initialState: GameState;
@@ -65,7 +68,14 @@ export function useCardShogiGame({
     isPaused: false,
   });
 
+  // Issue #193 / PR1a: 観戦モードでは playerColor が意味を持たないため、useEffect 内で
+  // gameState.currentPlayer に応じて動的に aiPlayer を計算する (E-1 対応)。
+  // ここでの aiPlayer 変数は通常モード用 (= 後方互換ガード)。
   const aiPlayer: Player = gameConfig.playerColor === "sente" ? "gote" : "sente";
+
+  // PR1a: 観戦モード時の DB 保存スキップ判定 (B-1 対応)。spectatorMode=false の人間プレイ時は
+  // 常に canPersist=true で従来挙動を保持。
+  const { canPersist } = useDbPersistenceGuard(state.spectatorMode);
 
   // 番が回ってきた時点で早指しタイマーを開始する。
   // 自分・AI 双方に適用しないと AI 側だけ常に通常チャージ(+1)扱いになる。
@@ -93,9 +103,23 @@ export function useCardShogiGame({
   // AI 自動応手
   useEffect(() => {
     const { gameState } = state;
+    // Issue #193 / PR1a: 観戦モードでは両プレイヤー AI 駆動。currentPlayer に応じて
+    // 該当する difficulty で request する (E-1 対応)。先手=difficulty、後手=difficultyB
+    // (未指定なら difficulty にフォールバック)。
+    const effectiveAiPlayer: Player = state.spectatorMode
+      ? gameState.currentPlayer
+      : aiPlayer;
+    const effectiveDifficulty: Difficulty = state.spectatorMode
+      ? gameState.currentPlayer === "sente"
+        ? gameConfig.difficulty
+        : gameConfig.difficultyB ?? gameConfig.difficulty
+      : gameConfig.difficulty;
+
     if (
       gameState.status !== "active" ||
-      gameState.currentPlayer !== aiPlayer ||
+      gameState.currentPlayer !== effectiveAiPlayer ||
+      // PR1a: 観戦モードのポーズ中は AI 思考をブロック (F-3 進行中チェックリスト関連)
+      state.isPaused ||
       disableAi ||
       state.isAiThinking ||
       state.cardState.pendingCard !== null ||
@@ -115,10 +139,14 @@ export function useCardShogiGame({
       const result = await aiRequestMove({
         gameId,
         gameState,
-        player: aiPlayer,
-        difficulty: gameConfig.difficulty,
+        player: effectiveAiPlayer,
+        difficulty: effectiveDifficulty,
         variantId: gameConfig.variant.id,
         clientMoveCount: gameState.moveCount,
+        // PR1a (E-2 silent ignore): cardState を route に渡す。route 側で受け取るだけで使わない (PR1d で活用)。
+        cardState: state.cardState,
+        // PR1a (E-1): 観戦モード時は route 側で timeLimitMs を SPECTATOR_TIME_LIMIT_MS=1500ms に短縮する。
+        spectatorMode: state.spectatorMode,
       });
       if (result.stale) {
         // 待った / 終局 / unmount / 上書き / onError 経由の早期 abort。
@@ -153,6 +181,8 @@ export function useCardShogiGame({
     state.isDrawing,
     state.isPlayingCard,
     state.isCheckBreakAnimating,
+    // PR1a: 観戦モードのポーズ解除時に AI 思考を再開できるよう依存配列に追加 (F-3 関連)
+    state.isPaused,
     disableAi,
     aiRetryCounter,
   ]);
@@ -163,6 +193,18 @@ export function useCardShogiGame({
       cancelAiRequest();
     }
   }, [state.gameState.status, cancelAiRequest]);
+
+  // Issue #193 / PR1a (C-5): 観戦モード固有の強制終局判定。
+  // 終了条件優先順位: 千日手 (最優先、既存 status 判定で repetition / perpetual_check に変わる) →
+  // カードアクション上限 5 回 (PR1a では未発動、PR3 のルール変更時の安全弁) →
+  // SPECTATOR_MAX_MOVES (200 手) 到達で強制引き分け。
+  useEffect(() => {
+    if (!state.spectatorMode) return;
+    if (state.gameState.status !== "active") return;
+    if (state.gameState.moveCount >= SPECTATOR_MAX_MOVES) {
+      dispatch({ type: "END_SPECTATOR_GAME" });
+    }
+  }, [state.spectatorMode, state.gameState.status, state.gameState.moveCount]);
 
   const dismissAiError = useCallback(() => setAiError(null), []);
   const retryAiMove = useCallback(() => {
@@ -178,6 +220,8 @@ export function useCardShogiGame({
     // これにより 1手目分の GameMove レコードは作られず、リロード時の DB 状態は
     // カード使用前にロールバックする (二手指しキャンセル相当)。
     if (disableServerSync) return;
+    // Issue #193 / PR1a (B-1): 観戦モード (CPU vs CPU) では DB 保存しない (揮発モード)。
+    if (!canPersist) return;
     if (state.doubleMove !== null) return;
 
     const moveCount = state.gameState.moveCount;
@@ -221,6 +265,8 @@ export function useCardShogiGame({
   useEffect(() => {
     if (state.doubleMove !== null) return;
     if (disableServerSync) return;
+    // Issue #193 / PR1a (B-1): 観戦モード時は DB 保存しない (揮発モード)。
+    if (!canPersist) return;
     if (state.isPlayingCard || state.isDrawing || state.isCheckBreakAnimating) return;
     if (state.cardState === lastPersistedCardStateRef.current) return;
     lastPersistedCardStateRef.current = state.cardState;
@@ -377,6 +423,8 @@ export function useCardShogiGame({
     if (state.gameState.status !== "resign") return;
     if (resignedRef.current) return;
     if (disableServerSync) return;
+    // Issue #193 / PR1a (B-1): 観戦モード時は DB 保存しない (揮発モード)。
+    if (!canPersist) return;
     resignedRef.current = true;
     const winner = state.gameState.winner ?? "";
     void saveCardShogiResign(gameId, state.gameState, state.cardState, winner);
@@ -407,6 +455,9 @@ export function useCardShogiGame({
     pendingUndoSyncRef.current = false;
     lastSavedMoveCountRef.current = state.gameState.moveCount;
     if (disableServerSync) return;
+    // Issue #193 / PR1a (B-1): 観戦モード時は DB 保存しない (揮発モード)。
+    // ただし観戦モードでは UI 側で undo 操作が disable されているため通常はここに来ないが、保険として残す。
+    if (!canPersist) return;
     undoCardShogiGameState(
       gameId,
       state.gameState,

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -295,6 +295,11 @@ export function useCardShogiGame({
     (pos: Position) => {
       const { gameState, cardState, selectedSquare, selectedHandPiece, legalMoves } = state;
       if (gameState.status !== "active") return;
+      // Issue #193 / PR1a: 観戦モード (CPU vs CPU) ではユーザー操作を完全に無効化する。
+      // 両プレイヤー AI 駆動の進行を妨げないため、selectSquare / selectHandPiece /
+      // drawCard / beginPlayCard / confirmPlayCard / cancelPlayCard / undo /
+      // resign / undoDoubleMoveFirst / cancelDoubleMove のすべてに同等のガードを追加。
+      if (state.spectatorMode) return;
       if (gameState.currentPlayer !== gameConfig.playerColor) return;
       // ドロー演出 / カード使用演出中は盤面操作禁止 (Issue #82)。
       // ※ pendingCard.selectTarget 時は currentPlayer 反転前なのでここを通る必要があるため、
@@ -389,13 +394,15 @@ export function useCardShogiGame({
 
   const selectHandPiece = useCallback(
     (pieceType: string) => {
+      // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+      if (state.spectatorMode) return;
       if (state.cardState.pendingCard) return;
       if (state.isDrawing || state.isPlayingCard) return; // Issue #82: 演出中は弾く
       if (state.isCheckBreakAnimating) return; // Issue #82 (王手崩し): トラップ演出中
       if (state.gameState.currentPlayer !== gameConfig.playerColor) return;
       dispatch({ type: "SELECT_HAND_PIECE", pieceType });
     },
-    [state.gameState.currentPlayer, gameConfig.playerColor, state.cardState.pendingCard, state.isDrawing, state.isPlayingCard, state.isCheckBreakAnimating],
+    [state.spectatorMode, state.gameState.currentPlayer, gameConfig.playerColor, state.cardState.pendingCard, state.isDrawing, state.isPlayingCard, state.isCheckBreakAnimating],
   );
 
   const confirmPromotion = useCallback((promote: boolean) => {
@@ -407,11 +414,13 @@ export function useCardShogiGame({
   }, []);
 
   const resign = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー投了不可 (両 CPU 駆動の進行のみ)
+    if (state.spectatorMode) return;
     // Issue #155: DB 保存は dispatch 結果が反映された state を見て useEffect 経由で
     // 行う (use-shogi-game.ts と同じ方式)。boardState + cardState を一緒に
     // "resign" 状態で永続化するため saveCardShogiResign を使う。
     dispatch({ type: "RESIGN" });
-  }, []);
+  }, [state.spectatorMode]);
 
   // Issue #155: 投了確定後の DB 保存 (card-shogi variant)。
   //   - saveCardShogiResign で boardState (status: "resign" を含む) と
@@ -437,11 +446,13 @@ export function useCardShogiGame({
   // ref フラグを立てて next render の useEffect (後述) で post-UNDO state を確定後にサーバーアクションを呼ぶ。
   const pendingUndoSyncRef = useRef(false);
   const undo = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードは undo 不可 (両 CPU 駆動の進行のみ)
+    if (state.spectatorMode) return;
     if (state.gameState.moveHistory.length < 2) return;
     if (state.cardState.pendingCard) return;
     pendingUndoSyncRef.current = true;
     dispatch({ type: "UNDO" });
-  }, [state.gameState.moveHistory.length, state.cardState.pendingCard]);
+  }, [state.spectatorMode, state.gameState.moveHistory.length, state.cardState.pendingCard]);
 
   // Issue #132: UNDO 完了後の DB 巻き戻し + 保存カウンタリセット。
   // pendingUndoSyncRef フラグが立っている時のみ実行し、巻き戻し後の state を DB に反映する。
@@ -473,8 +484,10 @@ export function useCardShogiGame({
   }, []);
 
   const drawCard = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (state.spectatorMode) return;
     dispatch({ type: "DRAW_CARD", player: gameConfig.playerColor });
-  }, [gameConfig.playerColor]);
+  }, [state.spectatorMode, gameConfig.playerColor]);
 
   // Issue #78: ドロー演出完了時に呼ぶ。currentPlayer を相手に渡し AI 思考を解禁する。
   const finalizeDraw = useCallback(() => {
@@ -483,14 +496,18 @@ export function useCardShogiGame({
 
   const beginPlayCard = useCallback(
     (instanceId: string) => {
+      // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+      if (state.spectatorMode) return;
       dispatch({ type: "BEGIN_PLAY_CARD", player: gameConfig.playerColor, instanceId });
     },
-    [gameConfig.playerColor],
+    [state.spectatorMode, gameConfig.playerColor],
   );
 
   const confirmPlayCard = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (state.spectatorMode) return;
     dispatch({ type: "CONFIRM_PLAY_CARD" });
-  }, []);
+  }, [state.spectatorMode]);
 
   // Issue #82: カード使用演出完了時に呼ぶ。currentPlayer を相手に渡し AI 思考を解禁する。
   const finalizePlayCard = useCallback(() => {
@@ -498,8 +515,10 @@ export function useCardShogiGame({
   }, []);
 
   const cancelPlayCard = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (state.spectatorMode) return;
     dispatch({ type: "CANCEL_PLAY_CARD" });
-  }, []);
+  }, [state.spectatorMode]);
 
   // Issue #82 (王手崩し): トラップ演出完了時に呼ぶ。AI 思考とユーザー操作のロックを解除。
   const finalizeCheckBreak = useCallback(() => {
@@ -509,15 +528,19 @@ export function useCardShogiGame({
   // Issue #82 (二手指し): 1手目を取り消して preFirstMoveState から復元。
   // movesLeft===1 の時のみ動作。カードはまだ使用したまま、もう一度 1手目を選び直せる。
   const undoDoubleMoveFirst = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (state.spectatorMode) return;
     dispatch({ type: "UNDO_DOUBLE_MOVE_FIRST" });
-  }, []);
+  }, [state.spectatorMode]);
 
   // Issue #82 (二手指し / 新仕様): カード使用自体をキャンセル。
   // preCardState から完全復元、カードは手札に戻り、マナも消費されない。
   // movesLeft=2 (1手目前) でも movesLeft=1 (1手目後) でも実行可能。
   const cancelDoubleMove = useCallback(() => {
+    // Issue #193 / PR1a: 観戦モードはユーザー操作不可
+    if (state.spectatorMode) return;
     dispatch({ type: "CANCEL_DOUBLE_MOVE" });
-  }, []);
+  }, [state.spectatorMode]);
 
   return {
     gameState: state.gameState,

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -542,6 +542,22 @@ export function useCardShogiGame({
     dispatch({ type: "CANCEL_DOUBLE_MOVE" });
   }, [state.spectatorMode]);
 
+  // Issue #193 / PR1a: 観戦モード専用の一時停止 / 再開。
+  // spectatorMode === true のときのみ動作 (人間プレイ時は no-op)。
+  // PAUSE_GAME → reducer が isPaused=true → AI 自動応手 useEffect が
+  // isPaused ガードで return → cancelAiRequest で in-flight の探索もキャンセル。
+  // RESUME_GAME → isPaused=false → 自動応手再 trigger。
+  const pauseSpectator = useCallback(() => {
+    if (!state.spectatorMode) return;
+    dispatch({ type: "PAUSE_GAME" });
+    cancelAiRequest();
+  }, [state.spectatorMode, cancelAiRequest]);
+
+  const resumeSpectator = useCallback(() => {
+    if (!state.spectatorMode) return;
+    dispatch({ type: "RESUME_GAME" });
+  }, [state.spectatorMode]);
+
   return {
     gameState: state.gameState,
     selectedSquare: state.selectedSquare,
@@ -580,5 +596,10 @@ export function useCardShogiGame({
     aiError,
     dismissAiError,
     retryAiMove,
+    // Issue #193 / PR1a: 観戦モード専用の状態と操作
+    spectatorMode: state.spectatorMode,
+    isPaused: state.isPaused,
+    pauseSpectator,
+    resumeSpectator,
   };
 }

--- a/src/lib/shogi/ai/__tests__/strategy-equivalence.test.ts
+++ b/src/lib/shogi/ai/__tests__/strategy-equivalence.test.ts
@@ -1,0 +1,89 @@
+// Issue #193 / PR1a 段階9: SearchStrategy 抽象の構造的等価性テスト。
+//
+// PR1a の最重要 DoD: PR1a 前後で findBestMoveWithStats の返却 move が完全一致 (= 振る舞いキープ)。
+// 100 局面 × standard variant + 80 局面 × card-shogi 中盤・終盤 の本格 fixture は
+// PR1c-2 着手前に scripts/gen-fixture-strategy.ts で生成する想定。
+//
+// 本テストは PR1a 段階で「Strategy アダプタが DIFFICULTY_PARAMS パススルーとして
+// 構造的に正しく動作する」最低限の検証に留める (高速で CI 内で実行可)。
+// 振る舞いキープの本格検証 (= 実際に findBestMoveWithStats を 180 局面で呼ぶ) は
+// PR1c-2 で fixture-driven に拡張する。
+
+import { describe, it, expect } from "vitest";
+import { DIFFICULTY_PARAMS } from "@/lib/shogi/ai/engine";
+import {
+  createStrategy,
+  GennoStrategy,
+  MusashiStrategy,
+  RyuouStrategy,
+  SakuraStrategy,
+  SPECTATOR_TIME_LIMIT_MS,
+} from "@/lib/shogi/ai/strategy";
+
+describe("SearchStrategy: createStrategy factory", () => {
+  it("各 Difficulty に対応するキャラインスタンスを返す", () => {
+    expect(createStrategy("beginner").characterId).toBe("sakura");
+    expect(createStrategy("intermediate").characterId).toBe("musashi");
+    expect(createStrategy("advanced").characterId).toBe("genno");
+    expect(createStrategy("expert").characterId).toBe("ryuou");
+  });
+
+  it("各 Strategy のインスタンスは LegacyStrategyAdapter のサブクラス", () => {
+    expect(createStrategy("beginner")).toBeInstanceOf(SakuraStrategy);
+    expect(createStrategy("intermediate")).toBeInstanceOf(MusashiStrategy);
+    expect(createStrategy("advanced")).toBeInstanceOf(GennoStrategy);
+    expect(createStrategy("expert")).toBeInstanceOf(RyuouStrategy);
+  });
+});
+
+describe("SearchStrategy: targetReadingPly (Issue #193 本文の棋力目安)", () => {
+  it("さくら=1 / 武蔵=3 / 玄翁老師=5 / 龍王=6", () => {
+    expect(createStrategy("beginner").targetReadingPly).toBe(1);
+    expect(createStrategy("intermediate").targetReadingPly).toBe(3);
+    expect(createStrategy("advanced").targetReadingPly).toBe(5);
+    expect(createStrategy("expert").targetReadingPly).toBe(6);
+  });
+});
+
+describe("SearchStrategy: DIFFICULTY_PARAMS パススルー (PR1a 振る舞いキープ)", () => {
+  it("通常モード (spectator=false) では DIFFICULTY_PARAMS と完全一致", () => {
+    for (const difficulty of [
+      "beginner",
+      "intermediate",
+      "advanced",
+      "expert",
+    ] as const) {
+      const s = createStrategy(difficulty);
+      const params = DIFFICULTY_PARAMS[difficulty];
+      expect(s.maxSearchDepth).toBe(params.maxDepth);
+      expect(s.timeLimitMs).toBe(params.timeLimitMs);
+      expect(s.addNoise).toBe(params.addNoise);
+      expect(s.nearEqualThreshold).toBe(params.nearEqualThreshold);
+      expect(s.useBook).toBe(params.useBook);
+      expect(s.spectator).toBe(false);
+    }
+  });
+});
+
+describe("SearchStrategy: 観戦モード timeLimitMs 短縮 (β-3)", () => {
+  it("spectator=true で expert (3500ms) は SPECTATOR_TIME_LIMIT_MS=1500ms に短縮", () => {
+    const expert = createStrategy("expert", { spectator: true });
+    expect(expert.timeLimitMs).toBe(SPECTATOR_TIME_LIMIT_MS);
+    expect(expert.spectator).toBe(true);
+  });
+
+  it("spectator=true で beginner (800ms) は元値より短い → 元のまま (Math.min)", () => {
+    const beginner = createStrategy("beginner", { spectator: true });
+    // beginner の DIFFICULTY_PARAMS.timeLimitMs は 800ms で SPECTATOR_TIME_LIMIT_MS=1500 より小さい
+    // Math.min(800, 1500) = 800 なので元のまま
+    expect(beginner.timeLimitMs).toBe(DIFFICULTY_PARAMS.beginner.timeLimitMs);
+  });
+
+  it("addNoise / nearEqualThreshold / useBook は spectator フラグに影響されない", () => {
+    const expertSpec = createStrategy("expert", { spectator: true });
+    const expertNormal = createStrategy("expert");
+    expect(expertSpec.addNoise).toBe(expertNormal.addNoise);
+    expect(expertSpec.nearEqualThreshold).toBe(expertNormal.nearEqualThreshold);
+    expect(expertSpec.useBook).toBe(expertNormal.useBook);
+  });
+});

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -144,10 +144,16 @@ export function findBestMoveWithStats(
     signal: options.signal,
   });
 
-  // 定石ブック (序盤のみ)
+  // 定石ブック (序盤のみ)。
+  // Issue #193 / PR1a: card-shogi では openingBook lookup を無効化。
+  // ドロー/カード操作で board hash がズレるため定石が機能しないこと、および
+  // 振る舞いキープ例外として明示的に「card-shogi の両者合計 30 ply (= 各 15 手)
+  // で意図的振る舞い変更」を許容する。MAX_BOOK_MOVES * 2 は両者合計手数 (ply) で、
+  // MAX_BOOK_MOVES = 15 (各プレイヤー側の手数上限)。
+  const useBookForVariant = params.useBook && variant.id === "standard";
   let usedBook = false;
   let bookMove: Move | null = null;
-  if (params.useBook && state.moveCount < MAX_BOOK_MOVES * 2) {
+  if (useBookForVariant && state.moveCount < MAX_BOOK_MOVES * 2) {
     const candidate = getBookMove(state, player);
     if (candidate) {
       const legalMoves = getFullLegalMoves(state, player, variant);

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -119,6 +119,9 @@ export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
 // 旧 calculateAiMove は Stage B で削除済み。
 export interface FindBestMoveOptions {
   signal?: AbortSignal;
+  // Issue #193 / PR1a: 観戦モード (CPU vs CPU) で timeLimitMs を 1500ms 等に短縮するための override。
+  // 未指定時は DIFFICULTY_PARAMS[difficulty].timeLimitMs (既存挙動) を使用。
+  timeLimitMs?: number;
 }
 
 export interface FindBestMoveResult {
@@ -134,8 +137,10 @@ export function findBestMoveWithStats(
   options: FindBestMoveOptions = {},
 ): FindBestMoveResult {
   const params = DIFFICULTY_PARAMS[difficulty];
+  // Issue #193: options.timeLimitMs が指定されていれば override (観戦モード用)、なければ既存挙動
+  const effectiveTimeLimitMs = options.timeLimitMs ?? params.timeLimitMs;
   const ctx = createSearchContext({
-    timeLimitMs: params.timeLimitMs,
+    timeLimitMs: effectiveTimeLimitMs,
     signal: options.signal,
   });
 
@@ -177,7 +182,7 @@ export function findBestMoveWithStats(
     player,
     {
       maxDepth: params.maxDepth,
-      timeLimitMs: params.timeLimitMs,
+      timeLimitMs: effectiveTimeLimitMs,
       addNoise: params.addNoise,
       nearEqualThreshold: params.nearEqualThreshold,
     },

--- a/src/lib/shogi/ai/strategy/genno.ts
+++ b/src/lib/shogi/ai/strategy/genno.ts
@@ -1,0 +1,11 @@
+// Issue #193 / PR1a: 玄翁老師 Strategy (上級・targetReadingPly=5)。
+// PR1a では LegacyStrategyAdapter のシン・アダプタ。PR1d でキャラ別ヒューリスティクス充填予定。
+
+import { LegacyStrategyAdapter } from "./legacy-adapter";
+import type { SearchStrategyOptions } from "./types";
+
+export class GennoStrategy extends LegacyStrategyAdapter {
+  constructor(opts: SearchStrategyOptions = {}) {
+    super("genno", "advanced", 5, opts);
+  }
+}

--- a/src/lib/shogi/ai/strategy/index.ts
+++ b/src/lib/shogi/ai/strategy/index.ts
@@ -6,7 +6,11 @@ import { LegacyStrategyAdapter } from "./legacy-adapter";
 import { MusashiStrategy } from "./musashi";
 import { RyuouStrategy } from "./ryuou";
 import { SakuraStrategy } from "./sakura";
-import { SPECTATOR_TIME_LIMIT_MS } from "./spectator-override";
+import {
+  SPECTATOR_MAX_CARD_OPS_PER_TURN,
+  SPECTATOR_MAX_MOVES,
+  SPECTATOR_TIME_LIMIT_MS,
+} from "./spectator-override";
 import type { SearchStrategy, SearchStrategyOptions } from "./types";
 
 export type {
@@ -22,6 +26,8 @@ export {
   GennoStrategy,
   RyuouStrategy,
   SPECTATOR_TIME_LIMIT_MS,
+  SPECTATOR_MAX_MOVES,
+  SPECTATOR_MAX_CARD_OPS_PER_TURN,
 };
 
 // Difficulty から該当キャラ Strategy を生成する factory。

--- a/src/lib/shogi/ai/strategy/index.ts
+++ b/src/lib/shogi/ai/strategy/index.ts
@@ -1,0 +1,44 @@
+// Issue #193 / PR1a: SearchStrategy モジュールの集約 export と Difficulty → Strategy factory。
+
+import type { Difficulty } from "@/lib/shogi/types";
+import { GennoStrategy } from "./genno";
+import { LegacyStrategyAdapter } from "./legacy-adapter";
+import { MusashiStrategy } from "./musashi";
+import { RyuouStrategy } from "./ryuou";
+import { SakuraStrategy } from "./sakura";
+import { SPECTATOR_TIME_LIMIT_MS } from "./spectator-override";
+import type { SearchStrategy, SearchStrategyOptions } from "./types";
+
+export type {
+  SearchStrategy,
+  SearchStrategyOptions,
+  SelectMoveInput,
+  SelectMoveResult,
+} from "./types";
+export {
+  LegacyStrategyAdapter,
+  SakuraStrategy,
+  MusashiStrategy,
+  GennoStrategy,
+  RyuouStrategy,
+  SPECTATOR_TIME_LIMIT_MS,
+};
+
+// Difficulty から該当キャラ Strategy を生成する factory。
+// CPU vs CPU 観戦モードで先手・後手それぞれに別 Strategy インスタンスを作る場合は、
+// 各プレイヤーの difficulty で本 factory を呼び分ける (E-1 対応の client 側分岐想定)。
+export function createStrategy(
+  difficulty: Difficulty,
+  opts: SearchStrategyOptions = {},
+): SearchStrategy {
+  switch (difficulty) {
+    case "beginner":
+      return new SakuraStrategy(opts);
+    case "intermediate":
+      return new MusashiStrategy(opts);
+    case "advanced":
+      return new GennoStrategy(opts);
+    case "expert":
+      return new RyuouStrategy(opts);
+  }
+}

--- a/src/lib/shogi/ai/strategy/legacy-adapter.ts
+++ b/src/lib/shogi/ai/strategy/legacy-adapter.ts
@@ -1,0 +1,66 @@
+// Issue #193 / PR1a: SearchStrategy のシン・アダプタ実装。
+//
+// PR1a では DIFFICULTY_PARAMS パススルーで findBestMoveWithStats を呼ぶだけ。
+// 各キャラ別 Strategy (sakura.ts / musashi.ts / genno.ts / ryuou.ts) は本クラスを
+// 継承して characterId / difficulty / targetReadingPly を固定するだけの空殻。
+// PR1d で内部に cardDigest 評価・キャラ別ヒューリスティクス (Strategy.shouldDraw 等) を
+// 充填する想定。
+//
+// `addNoise` / `nearEqualThreshold` / `useBook` は PR1a では DIFFICULTY_PARAMS パススルー
+// (search.ts / engine.ts からの直接参照もそのまま)、PR1c-2 で Strategy 経由に再集約する。
+//
+// 詳細: docs/plans/issue-193.md「PR1a 主な変更 2.」「PR1c-2 詳細」参照。
+
+import { DIFFICULTY_PARAMS, findBestMoveWithStats } from "@/lib/shogi/ai/engine";
+import type { Difficulty } from "@/lib/shogi/types";
+import { SPECTATOR_TIME_LIMIT_MS } from "./spectator-override";
+import type {
+  SearchStrategy,
+  SearchStrategyOptions,
+  SelectMoveInput,
+  SelectMoveResult,
+} from "./types";
+
+export class LegacyStrategyAdapter implements SearchStrategy {
+  readonly characterId: string;
+  readonly difficulty: Difficulty;
+  readonly maxSearchDepth: number;
+  readonly targetReadingPly: number;
+  readonly timeLimitMs: number;
+  readonly addNoise: number;
+  readonly nearEqualThreshold: number;
+  readonly useBook: boolean;
+  readonly spectator: boolean;
+
+  constructor(
+    characterId: string,
+    difficulty: Difficulty,
+    targetReadingPly: number,
+    opts: SearchStrategyOptions = {},
+  ) {
+    this.characterId = characterId;
+    this.difficulty = difficulty;
+    this.targetReadingPly = targetReadingPly;
+    this.spectator = opts.spectator ?? false;
+
+    const params = DIFFICULTY_PARAMS[difficulty];
+    this.maxSearchDepth = params.maxDepth;
+    // 観戦モード時は timeLimitMs を SPECTATOR_TIME_LIMIT_MS まで短縮 (UX 用)。
+    // 元値より短い場合のみ短縮 (= beginner 800ms 等は元のまま)。
+    this.timeLimitMs = this.spectator
+      ? Math.min(params.timeLimitMs, SPECTATOR_TIME_LIMIT_MS)
+      : params.timeLimitMs;
+    this.addNoise = params.addNoise;
+    this.nearEqualThreshold = params.nearEqualThreshold;
+    this.useBook = params.useBook;
+  }
+
+  selectMove(input: SelectMoveInput): SelectMoveResult {
+    // PR1a: 観戦モード時のみ timeLimitMs を override し、それ以外は完全に既存挙動を維持。
+    // cardState は PR1a では未使用 (PR1d で findBestMoveWithStats に渡す経路を追加予定)。
+    return findBestMoveWithStats(input.state, input.player, this.difficulty, input.variant, {
+      signal: input.signal,
+      timeLimitMs: this.spectator ? this.timeLimitMs : undefined,
+    });
+  }
+}

--- a/src/lib/shogi/ai/strategy/musashi.ts
+++ b/src/lib/shogi/ai/strategy/musashi.ts
@@ -1,0 +1,11 @@
+// Issue #193 / PR1a: 武蔵 Strategy (中級・targetReadingPly=3)。
+// PR1a では LegacyStrategyAdapter のシン・アダプタ。PR1d でキャラ別ヒューリスティクス充填予定。
+
+import { LegacyStrategyAdapter } from "./legacy-adapter";
+import type { SearchStrategyOptions } from "./types";
+
+export class MusashiStrategy extends LegacyStrategyAdapter {
+  constructor(opts: SearchStrategyOptions = {}) {
+    super("musashi", "intermediate", 3, opts);
+  }
+}

--- a/src/lib/shogi/ai/strategy/ryuou.ts
+++ b/src/lib/shogi/ai/strategy/ryuou.ts
@@ -1,0 +1,11 @@
+// Issue #193 / PR1a: 龍王 Strategy (超上級・targetReadingPly=6)。
+// PR1a では LegacyStrategyAdapter のシン・アダプタ。PR1d でキャラ別ヒューリスティクス充填予定。
+
+import { LegacyStrategyAdapter } from "./legacy-adapter";
+import type { SearchStrategyOptions } from "./types";
+
+export class RyuouStrategy extends LegacyStrategyAdapter {
+  constructor(opts: SearchStrategyOptions = {}) {
+    super("ryuou", "expert", 6, opts);
+  }
+}

--- a/src/lib/shogi/ai/strategy/sakura.ts
+++ b/src/lib/shogi/ai/strategy/sakura.ts
@@ -1,0 +1,11 @@
+// Issue #193 / PR1a: さくら Strategy (初級・targetReadingPly=1)。
+// PR1a では LegacyStrategyAdapter のシン・アダプタ。PR1d でキャラ別ヒューリスティクス充填予定。
+
+import { LegacyStrategyAdapter } from "./legacy-adapter";
+import type { SearchStrategyOptions } from "./types";
+
+export class SakuraStrategy extends LegacyStrategyAdapter {
+  constructor(opts: SearchStrategyOptions = {}) {
+    super("sakura", "beginner", 1, opts);
+  }
+}

--- a/src/lib/shogi/ai/strategy/spectator-override.ts
+++ b/src/lib/shogi/ai/strategy/spectator-override.ts
@@ -10,3 +10,13 @@
 // 1500ms × 100 手 ≒ 2.5 分に短縮し、観戦体験の冗長さを抑える。
 // bench fixture (棋力評価) は元の timeLimitMs (3500ms 等) で実行 — 観戦時の短縮は UX 用、棋力測定は元値。
 export const SPECTATOR_TIME_LIMIT_MS = 1500;
+
+// 観戦モード時の 1 局あたり最大手数 (gameState.moveCount は両者合計 ply)。
+// 200 ply (= 各 100 手) で強制引き分け扱い。無限カードドロー・膠着への保険。
+// 終局判定優先順位: 千日手 (最優先、既存仕様) → カードアクション上限 → 200 手到達。
+export const SPECTATOR_MAX_MOVES = 200;
+
+// 観戦モード時の 1 ターンあたりカードアクション上限。
+// 現行ルールは 1 ターン 1 アクションのため発動しないが、PR3 以降のルール変更
+// (任意回数のドロー/カード使用) 時の安全弁として PR1a 段階で定数だけ用意。
+export const SPECTATOR_MAX_CARD_OPS_PER_TURN = 5;

--- a/src/lib/shogi/ai/strategy/spectator-override.ts
+++ b/src/lib/shogi/ai/strategy/spectator-override.ts
@@ -1,0 +1,12 @@
+// Issue #193 / PR1a: 観戦モード (CPU vs CPU) で適用する Strategy パラメータの定数集約。
+//
+// 第 4 次レビュー F-1 進行中チェックリストの推奨に従い、本ファイルは
+// 「定数集約のみ」に責務限定する。観戦モードの timeLimitMs 上書きは
+// 各 Strategy の constructor (opts.spectator) で内部処理する設計。
+//
+// 詳細: docs/plans/issue-193.md「PR1a 主な変更 6.」参照。
+
+// 観戦モード時の探索時間上限 (ms)。CPU 1 手 3.5s × 100 手 ≒ 6 分の体験を
+// 1500ms × 100 手 ≒ 2.5 分に短縮し、観戦体験の冗長さを抑える。
+// bench fixture (棋力評価) は元の timeLimitMs (3500ms 等) で実行 — 観戦時の短縮は UX 用、棋力測定は元値。
+export const SPECTATOR_TIME_LIMIT_MS = 1500;

--- a/src/lib/shogi/ai/strategy/types.ts
+++ b/src/lib/shogi/ai/strategy/types.ts
@@ -1,0 +1,57 @@
+// Issue #193 / PR1a: SearchStrategy 抽象の型定義。
+//
+// 難易度差別化を Strategy パターンで実装する基盤。PR1a 段階では空殻
+// (LegacyStrategyAdapter が DIFFICULTY_PARAMS パススルーで findBestMoveWithStats を呼ぶ)
+// として導入し、PR1d で中身 (cardDigest 評価、shouldDraw 等のキャラ別ロジック) を充填する。
+//
+// `addNoise` / `nearEqualThreshold` / `useBook` は PR1a では DIFFICULTY_PARAMS パススルーで
+// 現状維持。PR1c-2 (Strategy 再集約 refactor) で search.ts / engine.ts からの直接参照を
+// Strategy 経由に切替える。
+//
+// 詳細: docs/plans/issue-193.md「拡張性設計の核」「PR1a 主な変更 2.」「PR1c-2 詳細」参照。
+
+import type { CardGameState } from "@/lib/shogi/cards/types";
+import type { Difficulty, GameState, Move, Player, RuleVariant } from "@/lib/shogi/types";
+import type { SearchStats } from "@/lib/shogi/ai/search-context";
+
+export interface SearchStrategyOptions {
+  // CPU vs CPU 観戦モード。true のとき timeLimitMs を SPECTATOR_TIME_LIMIT_MS まで短縮。
+  spectator?: boolean;
+}
+
+// AI が一手を選ぶときの入力。cardState は PR1a では受け取るだけで未使用 (PR1d で利用)。
+export interface SelectMoveInput {
+  state: GameState;
+  player: Player;
+  variant: RuleVariant;
+  cardState?: CardGameState;
+  signal?: AbortSignal;
+}
+
+export interface SelectMoveResult {
+  move: Move | null;
+  stats: SearchStats;
+}
+
+// SearchStrategy: キャラ別の探索パラメータと意思決定を抽象化する。
+// PR1a の各 Strategy 実装は LegacyStrategyAdapter のシン・アダプタ。
+export interface SearchStrategy {
+  // キャラクター ID (data/characters.ts の id と整合: "sakura" / "musashi" / "genno" / "ryuou")
+  readonly characterId: string;
+  // 既存 DIFFICULTY_PARAMS のキー
+  readonly difficulty: Difficulty;
+  // 反復深化の上限値 (= DIFFICULTY_PARAMS[difficulty].maxDepth)
+  readonly maxSearchDepth: number;
+  // ユーザー向け棋力目安としての先読み手数 (Issue #193 本文より): 1 / 3 / 5 / 6
+  readonly targetReadingPly: number;
+  // 探索時間上限 (ms)。spectator=true のときは SPECTATOR_TIME_LIMIT_MS で上書き。
+  readonly timeLimitMs: number;
+  // PR1a では DIFFICULTY_PARAMS パススルー、PR1c-2 で Strategy 経由参照に切替。
+  readonly addNoise: number;
+  readonly nearEqualThreshold: number;
+  readonly useBook: boolean;
+  readonly spectator: boolean;
+
+  // 一手選択。PR1a 段階では内部で findBestMoveWithStats を呼ぶアダプタ実装。
+  selectMove(input: SelectMoveInput): SelectMoveResult;
+}

--- a/src/lib/shogi/ai/turn/current-rules.ts
+++ b/src/lib/shogi/ai/turn/current-rules.ts
@@ -17,6 +17,7 @@ export class CurrentRules implements TurnRules {
 
   // 現行ルールは「1 アクション = 1 ターン終了」。
   // history・state は将来ルールで使うシグネチャ整合のため受け取るが、現行では未参照。
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isTurnTerminating(_action: TurnAction, _history: TurnAction[], _state: AiTurnState): boolean {
     return true;
   }

--- a/src/lib/shogi/ai/turn/current-rules.ts
+++ b/src/lib/shogi/ai/turn/current-rules.ts
@@ -1,0 +1,48 @@
+// Issue #193 / PR1a: 現行ルール (1 アクション = 1 ターン) の TurnRules 実装。
+//
+// 振る舞いキープを最重要視するため、PR1a の getLegalActions は move-only を返す
+// (= AI の探索候補は従来通り駒指しのみ)。draw / playCard の生成は PR1d で導入する。
+// applyAction の draw / playCard 分岐は PR1d で実装するため、PR1a では throw する
+// (PR1a の AI 探索パスからは move 以外で呼ばれない)。
+//
+// 詳細: docs/plans/issue-193.md「PR1a 詳細」「PR1d 詳細」参照。
+
+import { applyMoveForSearch } from "@/lib/shogi/board";
+import { getFullLegalMoves } from "@/lib/shogi/moves";
+import type { Player, RuleVariant } from "@/lib/shogi/types";
+import type { AiTurnState, ApplyActionResult, TurnAction, TurnRules } from "./types";
+
+export class CurrentRules implements TurnRules {
+  constructor(private readonly variant: RuleVariant) {}
+
+  // 現行ルールは「1 アクション = 1 ターン終了」。
+  // history・state は将来ルールで使うシグネチャ整合のため受け取るが、現行では未参照。
+  isTurnTerminating(_action: TurnAction, _history: TurnAction[], _state: AiTurnState): boolean {
+    return true;
+  }
+
+  // PR1a では振る舞いキープのため move-only を返す。draw / playCard は PR1d で追加。
+  getLegalActions(state: AiTurnState, player: Player): TurnAction[] {
+    const moves = getFullLegalMoves(state.gameState, player, this.variant);
+    return moves.map((move) => ({ kind: "move" as const, move }));
+  }
+
+  // move 以外は PR1d で実装。PR1a の AI 探索からは呼ばれない (getLegalActions が move のみを返すため)。
+  applyAction(state: AiTurnState, action: TurnAction): ApplyActionResult {
+    if (action.kind === "move") {
+      const nextGameState = applyMoveForSearch(state.gameState, action.move);
+      return {
+        next: {
+          gameState: nextGameState,
+          cardState: state.cardState,
+          doubleMove: state.doubleMove,
+        },
+        events: [],
+        turnEnded: true,
+      };
+    }
+    throw new Error(
+      `CurrentRules.applyAction: action.kind="${action.kind}" は PR1d で実装予定 (PR1a の AI 探索パスからは呼ばれません)`,
+    );
+  }
+}

--- a/src/lib/shogi/ai/turn/types.ts
+++ b/src/lib/shogi/ai/turn/types.ts
@@ -1,0 +1,65 @@
+// Issue #193 / PR1a: AI 探索内で扱う統一行動型 TurnAction と、合法生成・適用・
+// ターン終了判定を切替えるための抽象 TurnRules を定義する。
+//
+// reducer (src/hooks/card-shogi/reducer.ts) は触らず、AI 探索側のみで二重化する設計。
+// 詳細は docs/plans/issue-193.md「拡張性設計の核 — TurnAction 抽象」参照。
+//
+// 現行ルール (CurrentRules) では 1 アクションでターン終了するが、将来ルール
+// (FutureRules、PR3 以降で追加予定) では「マナに応じて任意回数のドロー/カード使用 +
+// 最後に必ず駒1手」のように move を含むまでターン継続する形に切替えられる。
+// TurnRules.isTurnTerminating の実装差替だけでルール変更耐性を担保する。
+
+import type { CardGameState, CardId, CardTarget, GameEvent } from "@/lib/shogi/cards/types";
+import type { GameState, Move, Player } from "@/lib/shogi/types";
+
+// AI 探索内で扱う統一行動型。
+// - move: 通常の駒指し (既存 Move の薄いラッパ)
+// - draw: 山札ドロー (マナ DRAW_COST 消費)
+// - playCard: 手札カード使用 (def.cost マナ消費 + 効果適用)
+export type TurnAction =
+  | { kind: "move"; move: Move }
+  | { kind: "draw" }
+  | { kind: "playCard"; cardInstanceId: string; defId: CardId; target?: CardTarget };
+
+// AI 探索内部で参照する世界モデル。reducer state とは独立。
+// - gameState: 既存の駒・盤面・手番情報
+// - cardState: マナ・手札・山札・トラップ・drawProgress
+// - doubleMove: 二手指し継続中の状態 (active プレイヤーと残り手数)。null は通常局面。
+//   reducer の doubleMove スナップショット (preFirstMoveState/preCardState) は AI 側では
+//   持たない (探索内では1手目を仮想適用してから2手目を選ぶため、戻し用スナップショットは不要)。
+export interface AiTurnState {
+  gameState: GameState;
+  cardState: CardGameState;
+  doubleMove: {
+    active: Player;
+    movesLeft: 1 | 2;
+  } | null;
+}
+
+// applyAction の戻り値。
+// - next: 適用後の新しい AiTurnState
+// - events: 既存 reducer と同じ GameEvent ストリーム (将来の同期検証で使用)
+// - turnEnded: このアクションでターンが終了するか (PR1d-3 の super-action 探索で
+//   1手目は false, 2手目で true を返すなど、negamax 側の player 反転制御に使う)
+export interface ApplyActionResult {
+  next: AiTurnState;
+  events: GameEvent[];
+  turnEnded: boolean;
+}
+
+// ルール切替の核となる抽象。
+// 現行ルール: src/lib/shogi/ai/turn/current-rules.ts の CURRENT_TURN_RULES
+// 将来ルール: PR3 以降で追加予定 (例: future-rules.ts の FUTURE_TURN_RULES)
+export interface TurnRules {
+  // ターン終了判定。history はそのターン内で既に適用済の TurnAction 列。
+  // 現行: 単発のアクションで常に true (= 1 アクション = 1 ターン)
+  // 将来: action.kind === "move" を含むまで false (= 任意回数の draw/playCard 後に move でターン終了)
+  isTurnTerminating(action: TurnAction, history: TurnAction[], state: AiTurnState): boolean;
+
+  // 合法 TurnAction 列挙。root のみカードアクションを許容するなど、ルール側で枝刈りも行う。
+  getLegalActions(state: AiTurnState, player: Player): TurnAction[];
+
+  // アクション適用。reducer の makeMoveWithEffects と二重化されるが、二重化の不一致は
+  // PR1a 段階では fixture (strategy-equivalence.test.ts) でカバーする。
+  applyAction(state: AiTurnState, action: TurnAction): ApplyActionResult;
+}

--- a/src/lib/shogi/variants/types.ts
+++ b/src/lib/shogi/variants/types.ts
@@ -114,6 +114,20 @@ export interface GameConfig {
   // false → useBgm に null を渡し BGM 停止 (#79 統合)。
   soundEnabled: boolean;
   commentaryEnabled: boolean;
+  // Issue #193 / PR1a: CPU vs CPU 観戦モード。true のとき:
+  // - 両プレイヤー AI 駆動 (use-card-shogi-game の AI 自動応手 useEffect が currentPlayer を
+  //   見て該当 difficulty で request)
+  // - reducer の spectatorMode フラグ → 早指しボーナス無効化
+  // - DB 保存スキップ (useDbPersistenceGuard)
+  // - timeLimitMs 1500ms 短縮 (route.ts → findBestMoveWithStats)
+  // - 200 手強制引き分け / カードアクション上限の終局判定追加
+  // 段階7 で createGame の揮発モード経路と合わせて活用、PR1a の人間プレイ画面では未使用 (= false)。
+  spectatorMode?: boolean;
+  // 観戦モード時の後手側 (gote) 難易度・キャラ。spectatorMode === true のときに使用。
+  // useCardShogiGame は gameState.currentPlayer === "sente" なら difficulty、
+  // gameState.currentPlayer === "gote" なら difficultyB (or fallback で difficulty) を使う。
+  difficultyB?: Difficulty;
+  characterIdB?: string;
 }
 
 // 手の種類

--- a/src/lib/shogi/variants/types.ts
+++ b/src/lib/shogi/variants/types.ts
@@ -151,7 +151,10 @@ export type GameStatus =
   | "perpetual_check"
   | "impasse"
   | "timeout"
-  | "stalemate";
+  | "stalemate"
+  // Issue #193 / PR1a: CPU vs CPU 観戦モードでの強制終了 (SPECTATOR_MAX_MOVES=200 手到達)。
+  // winner は "draw" 扱い。spectatorMode === false の人間プレイでは発生しない。
+  | "spectator_max_moves";
 
 export interface GameState {
   board: Board;


### PR DESCRIPTION
## Summary
- Issue #193 の段階的実装の **PR1a (アーキ刷新の土台 + CPU vs CPU 観戦)** を実装
- TurnAction/TurnRules 抽象 + SearchStrategy 空殻アダプタを新設し、PR1d 以降の cardDigest 評価とキャラ別ロジック充填の足場を確立
- 観戦モード (`/spectate`) を追加し、揮発モード (DB 保存なし) で CPU vs CPU 対局を可視化
- 既存 advanced/expert の挙動は完全保持 (Strategy アダプタは DIFFICULTY_PARAMS パススルー、reducer の早指し判定も spectatorMode=false で従来挙動)

詳細はマージ後の PR コメントを参照。

## Test plan
- [ ] `npm run lint`: PR1a 追加分 warning 0 件 (既存リポジトリ全体エラーは PR スコープ外)
- [ ] `npm run typecheck`: PR1a 追加分エラー 0 件
- [ ] `npm run test:ci`: 16 ファイル / 311 テスト + strategy-equivalence 7 テスト緑
- [ ] `npm run build`: ✓ Compiled successfully、`/spectate` ルート生成確認
- [ ] Vercel preview deploy: ホーム → 「CPU 同士を観る」→ キャラ A/B 選択 → 観戦開始 → 千日手 or 200 手で終局
- [ ] 観戦モード: ユーザー操作 (盤面/手札/投了/待った) が全て無効
- [ ] 観戦モード: 一時停止ボタン → 中央オーバーレイ表示 → 画面クリックで再開
- [ ] 観戦モード: ホームボタン → 確認ダイアログ → ローディングマスク → ホーム遷移
- [ ] 通常モード (人間 vs CPU): PR1a 前後で挙動が完全一致 (Strategy アダプタは振る舞いキープ)

## Related
- Issue #193 (本 PR の親): https://github.com/ryuichiTtb/Shogi/issues/193
- 計画 md: [docs/plans/issue-193.md](https://github.com/ryuichiTtb/Shogi/blob/main/docs/plans/issue-193.md) (4 サイクルレビュー累計 43 件反映済)
- 集約 Issue: #190 / #76 (本 Issue 全 PR 完了時にユーザー指示でクローズ予定)