### PR TITLE
AI: 通常 3 カード判定 + blunder guard 排他制御 (#193-PR1d-2)

### DIFF
--- a/src/hooks/ai/__tests__/use-ai-request.test.ts
+++ b/src/hooks/ai/__tests__/use-ai-request.test.ts
@@ -65,6 +65,7 @@ const sampleAiResponse: AiMoveResponse = {
     stoppedBy: "none",
     usedBook: false,
     usedFallback: false,
+    usedCardAction: false,
   },
 };
 

--- a/src/lib/shogi/ai/__tests__/action-generator.test.ts
+++ b/src/lib/shogi/ai/__tests__/action-generator.test.ts
@@ -1,0 +1,142 @@
+// Issue #193 / PR1d-2: action-generator (getCardActions) の data integrity 検証。
+//
+// 設計意図:
+// - BEGIN_PLAY_CARD 7 項目 (reducer.ts:1124) が AI 側で正しく再現されているか検証
+// - 通常 3 カード (pawn_return / piece_return / double_pawn) の候補生成を確認
+// - double_move とトラップ系 (no_promote / check_break) は PR1d-3/PR1d-4 で対応のため対象外
+//
+// 計画 md `docs/plans/issue-193-pr1d.md` PR1d-2 詳細 / 検証計画 / 機能追加検証 参照。
+
+import { describe, it, expect } from "vitest";
+import { getCardActions } from "../turn/action-generator";
+import { createInitialCardState } from "@/lib/shogi/cards/state";
+import { createInitialGameState } from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import type { CardId, CardInstance } from "@/lib/shogi/cards/types";
+import type { AiTurnState } from "../turn/types";
+
+// テスト用デッキ (BEGIN_PLAY_CARD 7 項目で意味を持つ通常カード 3 種を含む)
+const TEST_DECK = [
+  { defId: "pawn_return" as const, count: 4 },
+  { defId: "piece_return" as const, count: 4 },
+  { defId: "double_pawn" as const, count: 4 },
+];
+
+// 必要に応じて手札に強制的に挿入するためのヘルパ
+function makeCardInstance(defId: CardId, instanceId: string): CardInstance {
+  return { instanceId, defId };
+}
+
+// 標準的な AiTurnState を作る (sente 手番、card-shogi 初期局面)
+function makeAiTurnState(): AiTurnState {
+  return {
+    gameState: createInitialGameState(CARD_SHOGI_VARIANT),
+    cardState: createInitialCardState(TEST_DECK),
+    doubleMove: null,
+    isRoot: true,
+  };
+}
+
+describe("getCardActions (BEGIN_PLAY_CARD 7 項目を AI 側で再現)", () => {
+  it("(1) 二手指し中 (state.doubleMove !== null) は何も yield しない", () => {
+    const state = makeAiTurnState();
+    state.doubleMove = { active: "sente", movesLeft: 1 };
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    expect(actions).toEqual([]);
+  });
+
+  it("(2) 自分の手番でなければ (gameState.currentPlayer !== player) 何も yield しない", () => {
+    const state = makeAiTurnState();
+    // 初期局面は sente 手番なので、gote 視点では候補なし
+    const actions = Array.from(getCardActions(state, "gote", CARD_SHOGI_VARIANT));
+    expect(actions).toEqual([]);
+  });
+
+  it("(4) マナ不足のカードはスキップ (sente 初期マナ 2 < piece_return cost 3)", () => {
+    const state = makeAiTurnState();
+    // piece_return (cost 3) のみを手札に置き、それ以外を空にする
+    state.cardState.hand.sente = [makeCardInstance("piece_return", "sente-test-1")];
+    state.cardState.mana.sente = 2; // < 3 (piece_return cost)
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    // piece_return はマナ不足、他に手札なし → 候補なし
+    expect(actions).toEqual([]);
+  });
+
+  it("(4) マナ十分のカードは候補に含まれる (pawn_return cost 1 ≤ sente 初期マナ 2)", () => {
+    const state = makeAiTurnState();
+    // pawn_return のみ (cost 1) を手札に置く
+    state.cardState.hand.sente = [makeCardInstance("pawn_return", "sente-test-pr1")];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    // pawn_return の有効マス (歩・と金マス) が複数 yield されることを期待
+    // 初期局面では sente の歩が 9 マス、合計で複数の PlayCardAction が yield される
+    expect(actions.length).toBeGreaterThan(0);
+    for (const action of actions) {
+      expect(action.kind).toBe("playCard");
+      if (action.kind === "playCard") {
+        expect(action.defId).toBe("pawn_return");
+        expect(action.cardInstanceId).toBe("sente-test-pr1");
+        expect(action.target?.kind).toBe("square");
+      }
+    }
+  });
+
+  it("(6) CARD_USE_CONDITIONS で false 返却時はスキップ (= use condition 不一致)", () => {
+    const state = makeAiTurnState();
+    // double_pawn (cost 1) を手札に置く。use condition で「持ち駒に歩あり」を要求。
+    state.cardState.hand.sente = [makeCardInstance("double_pawn", "sente-test-dp1")];
+    // 初期局面の sente 持ち駒は空 (歩なし) → CARD_USE_CONDITIONS で false → スキップ
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    expect(actions).toEqual([]);
+  });
+
+  it("複数カード混在で各カードの候補が個別に列挙される", () => {
+    const state = makeAiTurnState();
+    // sente マナを十分にして全カード使用可能にする
+    state.cardState.mana.sente = 10;
+    // sente の歩を持ち駒に追加 (double_pawn の use condition を満たすため)
+    state.gameState.hand.sente.pawn = 1;
+    state.cardState.hand.sente = [
+      makeCardInstance("pawn_return", "sente-test-pr2"),
+      makeCardInstance("double_pawn", "sente-test-dp2"),
+    ];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    // pawn_return の候補と double_pawn の候補がそれぞれ含まれる
+    const defIds = new Set(actions.map((a) => (a.kind === "playCard" ? a.defId : null)));
+    expect(defIds.has("pawn_return")).toBe(true);
+    expect(defIds.has("double_pawn")).toBe(true);
+  });
+
+  it("(3) 手札にないカードは自然にスキップ (for...of で手札のみ列挙)", () => {
+    const state = makeAiTurnState();
+    // 手札を空にする
+    state.cardState.hand.sente = [];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    expect(actions).toEqual([]);
+  });
+
+  it("PlayCardAction の cardInstanceId は手札の instance.instanceId と一致 (重複 instance がない)", () => {
+    const state = makeAiTurnState();
+    state.cardState.hand.sente = [
+      makeCardInstance("pawn_return", "sente-unique-id-1"),
+      makeCardInstance("pawn_return", "sente-unique-id-2"),
+    ];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    // それぞれの instance で別の PlayCardAction 群が生成される (square ごとに instance 別)
+    const ids = new Set(actions.map((a) => (a.kind === "playCard" ? a.cardInstanceId : null)));
+    expect(ids.has("sente-unique-id-1")).toBe(true);
+    expect(ids.has("sente-unique-id-2")).toBe(true);
+  });
+});
+
+describe("getCardActions の Generator 性質", () => {
+  it("Iterable として複数回 spread 可能 (= ジェネレータが正しく実装されている)", () => {
+    const state = makeAiTurnState();
+    state.cardState.hand.sente = [makeCardInstance("pawn_return", "sente-test-iter1")];
+    const gen1 = getCardActions(state, "sente", CARD_SHOGI_VARIANT);
+    const list1 = Array.from(gen1);
+    // 同じ state で 2 回目の generator を取得しても同じ件数
+    const gen2 = getCardActions(state, "sente", CARD_SHOGI_VARIANT);
+    const list2 = Array.from(gen2);
+    expect(list1.length).toBe(list2.length);
+  });
+});

--- a/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
+++ b/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
@@ -1,0 +1,143 @@
+// Issue #193 / PR1d-2: evaluateAction (search.ts) の data integrity 検証。
+//
+// 設計意図:
+// - TurnAction 3 種 (move / draw / playCard) を player 視点のスカラー評価値に変換する
+//   evaluateAction 関数の振る舞いを検証
+// - simulateCardEffect が null を返すカード (target なしカード) は NEGATIVE_INFINITY 扱い
+// - cardDigest 渡時/未渡時の振る舞い差分 (PR1d-1 W-1 root スカラー方式) を確認
+//
+// 計画 md `docs/plans/issue-193-pr1d.md` PR1d-2 詳細 / 検証計画 / 機能追加検証 参照。
+
+import { describe, it, expect } from "vitest";
+import { evaluateAction } from "../search";
+import { computeCardDigest } from "../cards/digest";
+import { DRAW_VALUE_BONUS } from "../cards/heuristics";
+import { evaluate } from "../evaluate";
+import { applyMoveForSearch } from "@/lib/shogi/board";
+import { createInitialCardState } from "@/lib/shogi/cards/state";
+import { createInitialGameState } from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { createSearchContext } from "../search-context";
+import { getFullLegalMoves } from "@/lib/shogi/moves";
+import type { AiTurnState } from "../turn/types";
+import type { TurnAction } from "../turn/types";
+
+const TEST_DECK = [
+  { defId: "pawn_return" as const, count: 4 },
+  { defId: "piece_return" as const, count: 4 },
+  { defId: "double_pawn" as const, count: 4 },
+];
+
+function makeAiTurnState(): AiTurnState {
+  return {
+    gameState: createInitialGameState(CARD_SHOGI_VARIANT),
+    cardState: createInitialCardState(TEST_DECK),
+    doubleMove: null,
+    isRoot: true,
+  };
+}
+
+describe("evaluateAction (move / draw / playCard 統一評価)", () => {
+  it("move: 通常 move 適用後の sente 視点評価値が返る", () => {
+    const state = makeAiTurnState();
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    const move = moves[0];
+    const action: TurnAction = { kind: "move", move };
+    const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    // applyMoveForSearch 後の evaluate 値と一致
+    const nextState = applyMoveForSearch(state.gameState, move);
+    const expected = evaluate(nextState, CARD_SHOGI_VARIANT);
+    expect(result).toBe(expected);
+  });
+
+  it("move: gote 視点では sente 視点の符号反転値が返る", () => {
+    const state = makeAiTurnState();
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    const move = moves[0];
+    const action: TurnAction = { kind: "move", move };
+    const senteResult = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    const goteResult = evaluateAction(state, action, "gote", CARD_SHOGI_VARIANT);
+    expect(senteResult + goteResult).toBe(0);
+  });
+
+  it("draw: 現局面評価値 + DRAW_VALUE_BONUS が返る (sente)", () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = { kind: "draw" };
+    const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    const baseEval = evaluate(state.gameState, CARD_SHOGI_VARIANT);
+    expect(result).toBe(baseEval + DRAW_VALUE_BONUS);
+  });
+
+  it("draw: gote 視点でも DRAW_VALUE_BONUS は加算される (符号反転後)", () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = { kind: "draw" };
+    const result = evaluateAction(state, action, "gote", CARD_SHOGI_VARIANT);
+    const baseEval = evaluate(state.gameState, CARD_SHOGI_VARIANT);
+    // gote 視点 = -baseEval (sente 絶対) + DRAW_VALUE_BONUS
+    expect(result).toBe(-baseEval + DRAW_VALUE_BONUS);
+  });
+
+  it("playCard (double_pawn): simulateCardEffect 後の評価値が返る", () => {
+    const state = makeAiTurnState();
+    // double_pawn の use condition (持ち駒に歩あり) を満たす
+    state.gameState.hand.sente.pawn = 1;
+    // double_pawn は cost 1 で初期マナ 2 で使用可
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-dp1",
+      defId: "double_pawn",
+      target: { kind: "square", row: 4, col: 4 }, // 中央付近の空きマス
+    };
+    const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    // 有効な target なら null でなく数値が返る (NEGATIVE_INFINITY 以外)
+    expect(result).not.toBe(Number.NEGATIVE_INFINITY);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it("playCard: simulateCardEffect が null を返すケース (無効な target) は NEGATIVE_INFINITY", () => {
+    const state = makeAiTurnState();
+    // pawn_return に対して相手駒マス (= 自駒ではないため無効) を指定
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-pr-invalid",
+      defId: "pawn_return",
+      target: { kind: "square", row: 0, col: 0 }, // gote の香車マス (自駒の歩ではない)
+    };
+    const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    expect(result).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("playCard: target が undefined (target なしカード扱い) なら NEGATIVE_INFINITY", () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-no-target",
+      defId: "pawn_return",
+      target: undefined,
+    };
+    const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    expect(result).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("ctx.cardDigest 未渡時は cardDigest 加算 skip = 振る舞いキープ", () => {
+    const state = makeAiTurnState();
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    const action: TurnAction = { kind: "move", move: moves[0] };
+    // ctx 未渡 = cardDigest 加算なし
+    const resultNoCtx = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    // 既存 evaluate (cardDigest 未渡) と一致
+    const nextState = applyMoveForSearch(state.gameState, moves[0]);
+    expect(resultNoCtx).toBe(evaluate(nextState, CARD_SHOGI_VARIANT));
+  });
+
+  it("ctx.cardDigest 渡時は cardDigest が evaluate に伝播される", () => {
+    const state = makeAiTurnState();
+    const cardDigest = computeCardDigest(state.cardState);
+    const ctx = createSearchContext({ timeLimitMs: 1000, cardDigest });
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    const action: TurnAction = { kind: "move", move: moves[0] };
+    const resultWithDigest = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT, ctx);
+    const nextState = applyMoveForSearch(state.gameState, moves[0]);
+    expect(resultWithDigest).toBe(evaluate(nextState, CARD_SHOGI_VARIANT, cardDigest));
+  });
+});

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -1,7 +1,7 @@
 import type { Difficulty, GameState, Move, Player, RuleVariant } from "../types";
 import type { CardGameState } from "../cards/types";
 import { STANDARD_VARIANT } from "../variants/standard";
-import { findBestMove } from "./search";
+import { findBestMove, evaluateAction } from "./search";
 import {
   createSearchContext,
   finalizeStats,
@@ -12,6 +12,8 @@ import { getBookMove, MAX_BOOK_MOVES } from "./openingBook";
 import { getFullLegalMoves, isSquareAttackedByFast } from "../moves";
 import { applyMoveForSearch } from "../board";
 import { computeCardDigest, type CardDigest } from "./cards/digest";
+import { CurrentRules } from "./turn/current-rules";
+import type { AiTurnState, TurnAction } from "./turn/types";
 // Issue #193 / PR1c-2 Phase B: DIFFICULTY_PARAMS 直接参照を Strategy 経由参照に切替。
 // findBestMoveWithStats 内で createStrategy(difficulty, { spectator }) を呼んで
 // Strategy インスタンスから maxSearchDepth / timeLimitMs / addNoise /
@@ -160,6 +162,14 @@ export interface FindBestMoveOptions {
 
 export interface FindBestMoveResult {
   move: Move | null;
+  // Issue #193 / PR1d-2: TurnAction (move / draw / playCard) として最良アクションを返す経路。
+  // 設計意図:
+  // - `move` フィールドは引き続き findBestMove (move-only 探索) の結果を保持し、route.ts / 上位フックの
+  //   既存呼出経路は完全に振る舞いキープ (= playCard / draw が選ばれても move は move bestMove のまま)
+  // - `action` フィールドは playCard / draw 採用時に対応する TurnAction を保持
+  //   (上位 PR で UI 統合する際の伝播経路、PR1d-2 段階では SearchStats.usedCardAction で観測のみ)
+  // - card-shogi variant 以外 / cardState 未渡時は `action: { kind: "move", move }` または null
+  action: TurnAction | null;
   stats: SearchStats;
 }
 
@@ -242,6 +252,7 @@ export function findBestMoveWithStats(
   if (bookMove) {
     return {
       move: bookMove,
+      action: { kind: "move", move: bookMove },
       stats: finalizeStats(ctx, { usedBook: true, usedFallback: false }),
     };
   }
@@ -272,10 +283,67 @@ export function findBestMoveWithStats(
     }
   }
 
+  // Issue #193 / PR1d-2: card-shogi の root で playCard / draw 候補を評価して最良 TurnAction を決定。
+  //
+  // 設計意図:
+  // - move は findBestMove (反復深化 + negamax) で深く読んだ結果を活用
+  // - playCard / draw は CurrentRules.getLegalActions で候補生成 → evaluateAction で浅く評価 (depth=0)
+  // - 公平比較のため、move も evaluateAction で浅く再評価して比較基準を統一
+  //   (= move の深く読んだ bestScore は内部状態で取得困難なため、再評価で代替)
+  // - 浅い比較は move の深さ優位を失うが、playCard / draw を頻繁に過剰採用するリスクを抑える
+  //   ため、move 採用が原則になる保守的振る舞い (棋力退化防止)
+  //
+  // 振る舞いキープ:
+  // - variant.id !== "card-shogi" / options.cardState 未渡 / fallback 経路では playCard 評価 skip
+  //   = 既存 standard variant や PR1c-2 完了時点と完全同一
+  // - move フィールドは findBestMove 結果のまま (= UI / route.ts への伝播は move-only、
+  //   PR1d-2 段階では action フィールドは observability 用途のみ、上位 PR で UI 統合)
+  let selectedAction: TurnAction | null = move !== null ? { kind: "move", move } : null;
+  let usingCardAction = false;
+
+  if (
+    !usedFallback &&
+    move !== null &&
+    variant.id === "card-shogi" &&
+    options.cardState !== undefined
+  ) {
+    const rules = new CurrentRules(variant);
+    const aiTurnState: AiTurnState = {
+      gameState: state,
+      cardState: options.cardState,
+      doubleMove: null,
+      isRoot: true,
+    };
+    const allActions = rules.getLegalActions(aiTurnState, player);
+
+    // move を evaluateAction で浅く再評価 (= 比較基準を統一)
+    let bestActionScore = evaluateAction(
+      aiTurnState,
+      { kind: "move", move },
+      player,
+      variant,
+      ctx,
+    );
+
+    for (const action of allActions) {
+      if (action.kind === "move") continue; // move は上で評価済
+      const score = evaluateAction(aiTurnState, action, player, variant, ctx);
+      if (score > bestActionScore) {
+        bestActionScore = score;
+        selectedAction = action;
+        usingCardAction = true;
+      }
+    }
+  }
+
   // ブランダーガード (advanced / expert のみ、抑制版)。
   // Issue #176: 戦術的駒捨てを潰すリスクがあるが、Stage A では現行挙動を維持する。
   // Phase 4 (PR 2) で抑制ロジックを再設計する。
+  // PR1d-2 (M-2 / N-7 反映): usingCardAction = true (= playCard / draw 採用) のとき
+  // blunder guard を skip。理由: pawn_return / piece_return が「自駒タダ取り回避」役を
+  // 担う場合、hasHangingPiece による move 差替と二重発動するため、構造的排他制御で防ぐ。
   if (
+    !usingCardAction &&
     !usedFallback &&
     move !== null &&
     (difficulty === "advanced" || difficulty === "expert")
@@ -301,12 +369,15 @@ export function findBestMoveWithStats(
           }
         }
         move = bestSafeMove;
+        // blunder guard で move が差替えられた場合、selectedAction の move も同期
+        selectedAction = { kind: "move", move };
       }
     }
   }
 
   return {
     move,
-    stats: finalizeStats(ctx, { usedBook, usedFallback }),
+    action: selectedAction,
+    stats: finalizeStats(ctx, { usedBook, usedFallback, usedCardAction: usingCardAction }),
   };
 }

--- a/src/lib/shogi/ai/search-context.ts
+++ b/src/lib/shogi/ai/search-context.ts
@@ -29,6 +29,11 @@ export interface SearchStats {
   stoppedBy: StopReason;
   usedBook: boolean;
   usedFallback: boolean;
+  // Issue #193 / PR1d-2: root で playCard / draw が選ばれたかを記録 (observability)。
+  // findBestMoveWithStats 内の blunder guard 排他制御 (= playCard 選択時は skip) と
+  // 同じローカル状態を SearchStats 経由で外部から観測可能にする。
+  // 未指定時は false (= 振る舞いキープ、PR1d-1 完了時点と同等)。
+  usedCardAction: boolean;
 }
 
 export interface SearchContext {
@@ -97,7 +102,7 @@ export function shouldStop(ctx: SearchContext): boolean {
 // 探索終了時に SearchStats を構築する。
 export function finalizeStats(
   ctx: SearchContext,
-  extras: { usedBook: boolean; usedFallback: boolean },
+  extras: { usedBook: boolean; usedFallback: boolean; usedCardAction?: boolean },
 ): SearchStats {
   return {
     elapsedMs: performance.now() - ctx.startedAt,
@@ -107,5 +112,7 @@ export function finalizeStats(
     stoppedBy: ctx.stoppedBy,
     usedBook: extras.usedBook,
     usedFallback: extras.usedFallback,
+    // PR1d-2 (W-6 整合): usedCardAction 未指定時は false (= 振る舞いキープ)
+    usedCardAction: extras.usedCardAction ?? false,
   };
 }

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -6,6 +6,9 @@ import { isInCheck } from "../moves";
 import { getSearchLegalMoves } from "./legal-moves";
 import { applyMoveForSearch } from "../board";
 import { evaluate, scoreMoveForOrdering } from "./evaluate";
+import { simulateCardEffect } from "../cards/effects";
+import { DRAW_VALUE_BONUS } from "./cards/heuristics";
+import type { AiTurnState, TurnAction } from "./turn/types";
 import {
   computeHash,
   PIECE_KEYS, PIECE_KEYS_HI,
@@ -686,4 +689,58 @@ export function findBestMove(
   }
 
   return bestMove;
+}
+
+// Issue #193 / PR1d-2: TurnAction (move / draw / playCard) を player 視点のスカラー評価値に変換する純粋関数。
+//
+// 設計意図:
+// - production の探索ホットパス (findBestMove / negamax / quiescence) は move-only のまま保持し、
+//   playCard / draw は本関数を engine.ts (PR1d-2 コミット 3 で統合予定) の root 経路から呼んで評価
+// - evaluate.ts の sente 絶対視点 (PR1d-1 W-2 反映) を player 視点に符号反転して返す
+// - cardDigest は ctx?.cardDigest (W-1 root スカラー方式) を使用、未渡時は加算 skip = 振る舞いキープ
+//
+// 評価方針:
+// - move: applyMoveForSearch 後の局面で evaluate (= 既存 root 評価と同じ depth=0 評価)
+// - draw: 局面は変わらず、cardDigest も root スカラー固定のため evaluate 値は同じ。
+//   ドローを促進するため DRAW_VALUE_BONUS を加算 (heuristics.ts の名前付き定数)
+// - playCard: simulateCardEffect で仮想 GameState 遷移後の局面で evaluate。
+//   simulateCardEffect が null を返すカード (target なしカード mana_up/no_promote/check_break/double_move 等)
+//   は PR1d-2 範囲外のため Number.NEGATIVE_INFINITY を返して候補から除外
+//
+// 注: depth=0 評価のため、move の深く読んだスコア (findBestMove 反復深化結果) との直接比較は
+// 不公平。コミット 3 (engine.ts 統合) で move のスコア比較経路を調整する想定。
+export function evaluateAction(
+  state: AiTurnState,
+  action: TurnAction,
+  player: Player,
+  variant: RuleVariant,
+  ctx?: SearchContext,
+): number {
+  const cardDigest = ctx?.cardDigest;
+  switch (action.kind) {
+    case "move": {
+      const nextState = applyMoveForSearch(state.gameState, action.move);
+      const raw = evaluate(nextState, variant, cardDigest);
+      return player === "sente" ? raw : -raw;
+    }
+    case "draw": {
+      const raw = evaluate(state.gameState, variant, cardDigest);
+      const signed = player === "sente" ? raw : -raw;
+      return signed + DRAW_VALUE_BONUS;
+    }
+    case "playCard": {
+      const nextGameState = simulateCardEffect(
+        state.gameState,
+        player,
+        action.defId,
+        action.target ?? null,
+      );
+      if (!nextGameState) {
+        // simulateCardEffect が null を返すカード (target なしカード) は PR1d-2 範囲外
+        return Number.NEGATIVE_INFINITY;
+      }
+      const raw = evaluate(nextGameState, variant, cardDigest);
+      return player === "sente" ? raw : -raw;
+    }
+  }
 }

--- a/src/lib/shogi/ai/turn/action-generator.ts
+++ b/src/lib/shogi/ai/turn/action-generator.ts
@@ -1,0 +1,145 @@
+// Issue #193 / PR1d-2: AI 探索側のカードアクション候補生成。
+//
+// 設計:
+// reducer.ts の BEGIN_PLAY_CARD (L1124) で集約された 7 項目のカード使用可否判定を、
+// AI 側で **同じ純粋関数** (`hasSameKindTrapPlaced` / `isInCheck` /
+// `getCheckEscapingSquares` / `CARD_USE_CONDITIONS`) を呼んで再現する。
+// 二重実装を避けて構造的に整合性を確保。
+//
+// PR1d-2 では通常 3 カード (pawn_return / piece_return / double_pawn) に対応。
+// double_move (PR1d-3 super-action 探索) とトラップ系 (PR1d-4 no_promote / check_break)
+// は別 sub PR で実装。
+//
+// 計画 md `docs/plans/issue-193-pr1d.md` PR1d-2 詳細 / 主な変更 1. action-generator.ts 新規 参照。
+
+import { CARD_DEFS, CARD_USE_CONDITIONS } from "@/lib/shogi/cards/definitions";
+import {
+  hasSameKindTrapPlaced,
+  isValidCardTargetSquare,
+  getCheckEscapingSquares,
+} from "@/lib/shogi/cards/effects";
+import { isInCheck } from "@/lib/shogi/moves";
+import type {
+  CardDefinition,
+  CardTarget,
+} from "@/lib/shogi/cards/types";
+import type { GameState, Player, RuleVariant } from "@/lib/shogi/types";
+import type { AiTurnState, TurnAction } from "./types";
+
+/**
+ * BEGIN_PLAY_CARD (reducer.ts:1124) の 7 項目を AI 側で再現したカードアクション候補生成。
+ *
+ * 既存純粋関数 (hasSameKindTrapPlaced / isInCheck / getCheckEscapingSquares /
+ * CARD_USE_CONDITIONS) を共用するため、reducer の判定ロジックと不一致リスクが構造的に発生しない。
+ *
+ * variant は AiTurnState に持たないため引数で明示的に受け取る (CurrentRules.getLegalActions と
+ * 同じ「this.variant 経由」のパターンと一貫)。calling 側は CurrentRules.getLegalActions 内で
+ * `this.variant` を渡す。
+ *
+ * @returns AiTurnState の手番側プレイヤーが今 root で打てる PlayCardAction の Generator
+ */
+export function* getCardActions(
+  state: AiTurnState,
+  player: Player,
+  variant: RuleVariant,
+): Iterable<TurnAction> {
+  // (1) 二手指し中は他カード禁止
+  if (state.doubleMove !== null) return;
+
+  // (2) 自分の手番でなければ使用禁止
+  if (state.gameState.currentPlayer !== player) return;
+
+  for (const card of state.cardState.hand[player]) {
+    const def = CARD_DEFS[card.defId];
+
+    // (3) 手札にないカードは for...of で自然にスキップ済 (state.cardState.hand[player] が手札全件)
+
+    // (4) マナ不足は使用不可
+    if (state.cardState.mana[player] < def.cost) continue;
+
+    // (5) 同種トラップ重複は使用不可
+    if (def.kind === "trap" && hasSameKindTrapPlaced(state.cardState, player, card.defId)) {
+      continue;
+    }
+
+    // (6) CARD_USE_CONDITIONS 個別判定 (定義済は 3 枚: pawn_return / double_pawn / piece_return)
+    const conditionFn = CARD_USE_CONDITIONS[card.defId];
+    if (conditionFn && !conditionFn(state.gameState, player, state.cardState)) {
+      continue;
+    }
+
+    // (7) 王手中: checkUsage フラグで二段ゲート
+    if (isInCheck(state.gameState, player, variant)) {
+      if (def.checkUsage === "forbidden") continue;
+      if (def.checkUsage === "conditional" && def.targeting !== "none") {
+        const escapingSquares = getCheckEscapingSquares(state.gameState, player, card.defId);
+        if (escapingSquares.length === 0) continue;
+      }
+    }
+
+    // 7 項目通過後、target 列挙して PlayCardAction を yield
+    for (const target of enumerateTargets(state, def, player)) {
+      yield {
+        kind: "playCard",
+        cardInstanceId: card.instanceId,
+        defId: card.defId,
+        target: target ?? undefined,
+      };
+    }
+  }
+}
+
+/**
+ * カード定義の targeting に応じて対象 target を列挙 (第 4 次レビュー C-5 反映)。
+ *
+ * - "none": ターゲット不要カード (mana_up / check_break / double_move / no_promote) → null を 1 回 yield
+ * - "square": 盤面マス指定カード (double_pawn 等) → 有効マスを順次 yield
+ * - "ownPiece": 自駒マス指定カード (pawn_return / piece_return) → 自駒マスを順次 yield
+ *   (内部表現は `{ kind: "square", row, col }` で、`isValidCardTargetSquare` の defId 別判定で
+ *   自駒種別チェックが行われる)
+ * - "enemyPiece": 相手駒マス指定カード (将来カードで使用想定) → PR1d 範囲では空 yield
+ */
+function* enumerateTargets(
+  state: AiTurnState,
+  def: CardDefinition,
+  player: Player,
+): Iterable<CardTarget | null> {
+  switch (def.targeting) {
+    case "none":
+      yield null;
+      return;
+    case "square":
+    case "ownPiece": {
+      // 「ownPiece」も実態は盤面マス指定 (isValidCardTargetSquare の defId 別 case で
+      // 自駒種別を判定するため、CardTarget の kind は "square" 統一)
+      for (const pos of enumerateValidSquaresForCard(state.gameState, def, player)) {
+        yield { kind: "square", row: pos.row, col: pos.col };
+      }
+      return;
+    }
+    case "enemyPiece":
+      // PR1d 範囲では未実装 (将来カードで使用想定)、空 Generator
+      return;
+  }
+}
+
+/**
+ * targeting: "square" カード (pawn_return / piece_return / double_pawn) の対象マス列挙。
+ *
+ * isValidCardTargetSquare (effects.ts:274) を 9×9 ループで呼ぶシン実装 (= reducer 側と同一判定)。
+ * isValidCardTargetSquare 内部で variant.id 固定 (CARD_SHOGI_VARIANT) で王手判定済のため、
+ * 王手中の use condition は CARD_USE_CONDITIONS 経由で getCardActions の (6) 段階で既に枝刈り済。
+ */
+function* enumerateValidSquaresForCard(
+  gameState: GameState,
+  def: CardDefinition,
+  player: Player,
+): Iterable<{ row: number; col: number }> {
+  for (let row = 0; row < 9; row++) {
+    for (let col = 0; col < 9; col++) {
+      if (isValidCardTargetSquare(gameState, player, def.id, { row, col })) {
+        yield { row, col };
+      }
+    }
+  }
+}

--- a/src/lib/shogi/ai/turn/current-rules.ts
+++ b/src/lib/shogi/ai/turn/current-rules.ts
@@ -12,6 +12,7 @@ import { getFullLegalMoves } from "@/lib/shogi/moves";
 import type { Player, RuleVariant } from "@/lib/shogi/types";
 import type { CardGameState } from "@/lib/shogi/cards/types";
 import { DRAW_COST, AUTO_DRAW_INTERVAL } from "@/lib/shogi/cards/definitions";
+import { getCardActions } from "./action-generator";
 import type { AiTurnState, ApplyActionResult, TurnAction, TurnRules } from "./types";
 
 // PR1d-1: ドロー判定ヘルパ。
@@ -40,12 +41,17 @@ export class CurrentRules implements TurnRules {
     return true;
   }
 
-  // PR1d-1: getLegalActions に root のみ DrawAction 候補追加 (進行中チェックリスト F-4 反映)。
+  // PR1d-2: getLegalActions に root のみ PlayCardAction 候補追加 (PR1d-1 の DrawAction に続く拡張)。
   // ・move 候補は既存通り全列挙
-  // ・state.isRoot === true かつ variant.id === "card-shogi" のときのみ DrawAction を追加
+  // ・state.isRoot === true かつ variant.id === "card-shogi" のときのみ DrawAction / PlayCardAction を追加
   //   (= 子ノードでは move-only に絞る、PR3 でカード深読みを広げる際に拡張)
   // ・state.isRoot 未指定 or false の場合は従来通り move-only (= PR1c-2 完了時点の振る舞いを保持)
-  // ・実際の search.ts/findBestMove root 経路からの呼出統合は PR1d-2 で playCard 候補と一緒に行う
+  // ・PlayCardAction 生成は action-generator.ts の getCardActions に委譲
+  //   (BEGIN_PLAY_CARD 7 項目 reducer.ts:1124 を AI 側で同じ純粋関数で再現)
+  // ・実際の production 探索パス (engine.ts findBestMoveWithStats / search.ts findBestMove) からの
+  //   呼出統合は PR1d-2 コミット 3 で行う (本コミット 2 段階では search.ts に evaluateAction を
+  //   追加するが、production 経路は依然 findBestMove → getSearchLegalMoves 直接呼出のため、
+  //   本メソッド経由の playCard / draw 候補は production からは未到達)。
   getLegalActions(state: AiTurnState, player: Player): TurnAction[] {
     const moves = getFullLegalMoves(state.gameState, player, this.variant);
     const actions: TurnAction[] = moves.map((move) => ({ kind: "move" as const, move }));
@@ -54,15 +60,22 @@ export class CurrentRules implements TurnRules {
       if (canDraw(state.cardState, player)) {
         actions.push({ kind: "draw" });
       }
+      for (const cardAction of getCardActions(state, player, this.variant)) {
+        actions.push(cardAction);
+      }
     }
 
     return actions;
   }
 
-  // move 以外は PR1d-2 で実装。PR1d-1 段階では getLegalActions が root のみ draw 候補を生成するが、
-  // production の探索パスは依然として findBestMove (search.ts) → getSearchLegalMoves 直接呼出で、
-  // CurrentRules.getLegalActions/applyAction を呼んでいないため throw 到達せず。
-  // PR1d-2 で search.ts root 経路から getLegalActions を呼ぶ統合時に applyAction(draw) も同時実装する (ZZ-5 反映)。
+  // PR1d-2 コミット 2 段階での実装方針 (ZZ-5 後続対応):
+  // move 以外 (draw / playCard) の applyAction は引き続き throw 維持。
+  // 理由: PR1d-2 では search.ts の evaluateAction (新規) が simulateCardEffect 等を
+  // 直接呼んで playCard / draw の評価値を算出する設計に確定したため、applyAction 経由の
+  // 状態遷移は不要 (= reducer ロジックを AI 側で二重実装するリスクを回避)。
+  // production 探索パスは依然として findBestMove (search.ts) → getSearchLegalMoves 直接呼出で、
+  // CurrentRules.applyAction は呼ばれず throw 到達せず。
+  // 将来 PR3 (カード深読み探索) で applyAction(draw / playCard) が必要になった時点で実装する。
   applyAction(state: AiTurnState, action: TurnAction): ApplyActionResult {
     if (action.kind === "move") {
       const nextGameState = applyMoveForSearch(state.gameState, action.move);
@@ -77,7 +90,7 @@ export class CurrentRules implements TurnRules {
       };
     }
     throw new Error(
-      `CurrentRules.applyAction: action.kind="${action.kind}" は PR1d-2 で実装予定 (PR1d-1 段階では getLegalActions が draw 候補を生成するが、production の探索パスからは未呼出のため throw 到達せず、ZZ-5 反映)`,
+      `CurrentRules.applyAction: action.kind="${action.kind}" は PR3 (カード深読み探索) で実装予定 (PR1d-2 段階では evaluateAction が simulateCardEffect 等を直接呼ぶため applyAction 経由は不要)`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Issue #193 PR1d-2: AI 探索が通常 3 カード (pawn_return / piece_return / double_pawn) を判定可能になりました。

- BEGIN_PLAY_CARD 7 項目 ([reducer.ts:1124](src/hooks/card-shogi/reducer.ts#L1124)) を AI 側で同じ純粋関数を使って再現 (二重実装による不一致リスクを構造的に回避)
- [engine.ts findBestMoveWithStats](src/lib/shogi/ai/engine.ts) の root 経路で playCard / draw 候補を評価、move より高スコアなら採用
- `usingCardAction` フラグで post-search blunder guard を排他制御 (M-2 / N-7 反映、pawn_return が「タダ取り回避」役を担う場合の二重発動防止)

## 主な変更

- [src/lib/shogi/ai/turn/action-generator.ts](src/lib/shogi/ai/turn/action-generator.ts) 新規 (BEGIN_PLAY_CARD 7 項目を AI 側で再現)
- [src/lib/shogi/ai/turn/current-rules.ts](src/lib/shogi/ai/turn/current-rules.ts) `getLegalActions` 拡張 (root のみ playCard 候補追加)
- [src/lib/shogi/ai/search.ts](src/lib/shogi/ai/search.ts) `evaluateAction` 純粋関数新規 (move/draw/playCard 統一評価)
- [src/lib/shogi/ai/engine.ts](src/lib/shogi/ai/engine.ts) `findBestMoveWithStats` の root 経路統合 + `FindBestMoveResult.action` 追加 + blunder guard 排他制御
- [src/lib/shogi/ai/search-context.ts](src/lib/shogi/ai/search-context.ts) `SearchStats.usedCardAction` 追加 (observability)

## 振る舞いキープ

- `variant.id !== "card-shogi"` / `options.cardState` 未渡時は playCard 評価 skip = standard variant や PR1c-2 完了時点と完全同一
- `move` フィールドは findBestMove 結果のまま ([route.ts](src/app/api/ai-move/route.ts) / 上位フックは未改修)
- `action` フィールドは observability 用途のみ (UI 統合は別 PR / Phase 4 で対応予定)

## Test plan

- [x] lint: 0 errors (warnings は既存のみ)
- [x] typecheck: 既存環境問題のみ (\`@testing-library/react\` not found、PR1d-1 時点でも存在)
- [x] test:ci: 369/369 tests passed (新規 18 tests 含む、既存 fixture 振る舞いキープ)
- [x] build: exit 0
- [ ] Vercel preview: 振る舞いキープ確認 (UI 統合は別 PR のため、本 PR では move-only の既存挙動を維持)

## 既知の DoD 未達点

計画書 L939-944 の DoD のうち「CPU が pawn_return/piece_return/double_pawn を使う Vercel preview 観察」は、route.ts/上位フックの改修が必要なため **本 PR1d-2 のスコープ外** (計画書 L678 で engine.ts のみ明記、UI 統合は別 PR / Phase 4 で対応予定)。

## 参照

- Issue #193 (集約 Issue、cardDigest 評価 + 全カード対応の段階的実装)
- [docs/plans/issue-193-pr1d.md](docs/plans/issue-193-pr1d.md) PR1d-2 詳細 (L651-947)