### PR TITLE
fix: iOS Safari でホーム BGM が鳴らないバグを修正 (#213)

### DIFF
--- a/src/hooks/use-bgm.ts
+++ b/src/hooks/use-bgm.ts
@@ -29,7 +29,7 @@
 
 import { useEffect } from "react";
 
-import { getAudioCtx, unlockAudio } from "@/lib/audio/audio-engine";
+import { getAudioCtx, unlockAudio, isAudioContextRunning } from "@/lib/audio/audio-engine";
 import {
   getEffectiveBgmPath,
   useBgmOverrides,
@@ -320,48 +320,69 @@ function startBgm(key: BgmEventKey | null, path: string): void {
 
 let retryListenersAttached = false;
 
-function attemptRetry(): void {
-  // Issue #198: 本関数は click/touchstart/keydown の user gesture 経由で呼ばれる。
-  // GainNode 経由再生は AudioContext が running でないと音が destination に届かない
-  // ため、ここで AudioContext を resume する (user gesture 内なので確実に成功する)。
-  void unlockAudio();
+async function attemptRetry(): Promise<void> {
+  // Issue #213: 本関数は click/touchstart/touchend/keydown の user gesture 経由で
+  // 呼ばれる。GainNode 経由再生 (Issue #198) は AudioContext が running でないと
+  // 音が destination に届かないため、resume 完了を await してから play() する。
+  //
+  // 旧実装は `void unlockAudio()` で resume を投げっぱなしにし、完了前に
+  // audio.play() を呼んでいた。iOS Safari では play() 自体は resolve するが
+  // AudioContext が suspended のままで GainNode 経由が無音になり、しかも
+  // play().then() で detachRetryListeners() してしまうため「無音なのに二度と
+  // リトライされない」状態に陥っていた (本 Issue の主原因 2)。
+  //
+  // await チェーンは同一 user gesture タスク内に留まるため iOS Safari の
+  // autoplay policy 上も play() は許可される (= ctx.resume() → audio.play()
+  // の標準 unlock パターン)。
+  await unlockAudio();
   if (!currentAudio) return;
-  // 既に再生中なら user gesture リトライ待ちは不要だが、AudioContext が
-  // suspended のまま無音だった可能性があるので unlockAudio は実行済み。listener 撤去。
+  // 既に再生中。ただし AudioContext が suspended のまま無音だった可能性が
+  // あり unlockAudio は実行済み。running 確定時のみ listener 撤去し、
+  // suspended の間は次の gesture でリトライを継続する (Issue #213)。
   if (!currentAudio.paused) {
-    detachRetryListeners();
+    if (isAudioContextRunning()) detachRetryListeners();
     return;
   }
   const audio = currentAudio;
   const targetVol = isMuted ? 0 : BGM_VOLUME;
   const playPromise = audio.play();
   if (playPromise && typeof playPromise.then === "function") {
-    playPromise
-      .then(() => {
-        if (currentAudio === audio) {
-          fadeVolume(audio, getEffectiveVolume(audio), targetVol, FADE_DURATION_MS);
-        }
+    try {
+      await playPromise;
+      if (currentAudio === audio) {
+        fadeVolume(audio, getEffectiveVolume(audio), targetVol, FADE_DURATION_MS);
+      }
+      // Issue #213: play() 成功でも AudioContext が running でなければ
+      // GainNode 経由で無音。running 確定時のみ listener 撤去し、suspended の
+      // 間は次の gesture でリトライを継続する。
+      if (isAudioContextRunning()) {
         detachRetryListeners();
-      })
-      .catch(() => {
-        // まだ block されている → listener 保持 (次の gesture で再試行)
-      });
+      }
+    } catch {
+      // まだ block されている → listener 保持 (次の gesture で再試行)
+    }
   } else {
-    // 旧ブラウザ: play が undefined を返す。再生開始したと仮定。
+    // 旧ブラウザ: play が undefined を返す (AudioContext gating なしの直接
+    // 再生)。再生開始したと仮定し従来通り無条件 detach。
     fadeVolume(audio, getEffectiveVolume(audio), targetVol, FADE_DURATION_MS);
     detachRetryListeners();
   }
 }
 
 function onUserGesture(): void {
-  attemptRetry();
+  void attemptRetry();
 }
 
 function attachRetryListeners(): void {
   if (retryListenersAttached) return;
   retryListenersAttached = true;
+  // Issue #213: iOS Safari は非インタラクティブ要素 (ホーム画面の背景 div /
+  // テキスト / 余白) で click を発火しない。touchstart はスクロール意図とも
+  // 解釈されジェスチャー特権が弱いため、確実にタップを拾える touchend も併用
+  // する (= ホーム画面の任意箇所タップで BGM リトライを起動できるようにする)。
   window.addEventListener("click", onUserGesture);
   window.addEventListener("touchstart", onUserGesture);
+  window.addEventListener("touchend", onUserGesture);
   window.addEventListener("keydown", onUserGesture);
 }
 
@@ -370,6 +391,7 @@ function detachRetryListeners(): void {
   retryListenersAttached = false;
   window.removeEventListener("click", onUserGesture);
   window.removeEventListener("touchstart", onUserGesture);
+  window.removeEventListener("touchend", onUserGesture);
   window.removeEventListener("keydown", onUserGesture);
 }
 

--- a/src/lib/audio/audio-engine.ts
+++ b/src/lib/audio/audio-engine.ts
@@ -67,6 +67,16 @@ export function getAudioCtx(): AudioContext | null {
   return ensureCtx();
 }
 
+// Issue #213: AudioContext が running (= GainNode 経由で音が destination に届く
+// 状態) かを副作用なしで判定する。ensureCtx() と違い AudioContext を生成しない
+// (未生成なら false)。use-bgm.ts の attemptRetry が「play() 成功でも AudioContext
+// が suspended なら GainNode 経由で無音」を検知し、running 確定まで user gesture
+// リトライ listener を保持し続けるために参照する。isRunning 判定 (iOS Safari の
+// "interrupted" を running 扱いしない) を audio-engine 内に一元化する。
+export function isAudioContextRunning(): boolean {
+  return audioCtx != null && isRunning(audioCtx.state);
+}
+
 // =====================
 // unlock (resume) 制御
 // =====================
@@ -96,8 +106,13 @@ function attachUnlockRetry(): void {
     }
     detachUnlockRetry();
   };
+  // Issue #213: iOS Safari は非インタラクティブ要素 (背景 div/テキスト/余白) で
+  // click を発火しない。touchstart はスクロール意図とも解釈されジェスチャー特権が
+  // 弱いため、確実にタップを拾える touchend も併用する (= ホーム画面の任意箇所
+  // タップで AudioContext を unlock できるようにする)。
   window.addEventListener("click", onGesture);
   window.addEventListener("touchstart", onGesture);
+  window.addEventListener("touchend", onGesture);
   window.addEventListener("keydown", onGesture);
   unlockRetryHandler = onGesture;
 }
@@ -110,6 +125,7 @@ function detachUnlockRetry(): void {
   if (typeof window !== "undefined" && unlockRetryHandler) {
     window.removeEventListener("click", unlockRetryHandler);
     window.removeEventListener("touchstart", unlockRetryHandler);
+    window.removeEventListener("touchend", unlockRetryHandler);
     window.removeEventListener("keydown", unlockRetryHandler);
   }
   unlockRetryHandler = null;


### PR DESCRIPTION
Closes #213

## Summary

モバイル Safari でホーム画面の任意箇所 (ボタン以外) をタップしても BGM が流れ始めないバグを修正しました。実機 Safari で解消確認済み。

## 原因 (git 履歴 + 静的解析で確証済み)

真因は Issue #198 の GainNode 化 (PR #199、2026-05-10 マージ)。Issue #193 PR1d は BGM コードを一切変更しておらず無関係 (PR1d 全 19 変更ファイルに BGM/audio/page 関連皆無、`5abfe08` は PR1d 着手の 2 日前に main 入りと git 履歴で確定)。

GainNode 経由再生は「AudioContext が running でないと音が destination に届かない」制約を持ち込み、iOS Safari の既存弱点 2 点と組み合わさって顕在化:

1. iOS Safari は非インタラクティブ要素 (ホーム画面の div/テキスト/余白) で click を発火しない → window の click リスナーに届かない (Chrome は発火するため流れる)
2. `attemptRetry()` が `void unlockAudio()` を await せず `audio.play()` を呼ぶ → resume 完了前に play() resolve → GainNode 経由で無音のまま `detachRetryListeners()` でリスナー撤去 → 二度とリトライされない

## 修正 (4 点)

1. [use-bgm.ts](src/hooks/use-bgm.ts) `attemptRetry` を async 化し `await unlockAudio()` 後に `audio.play()` (AudioContext running 確定後に再生、iOS Safari 標準 unlock パターン)
2. [use-bgm.ts](src/hooks/use-bgm.ts) play() 成功でも `isAudioContextRunning()` が false の間は `detachRetryListeners()` せず次の user gesture でリトライ継続
3. [use-bgm.ts](src/hooks/use-bgm.ts) `attachRetryListeners`/`detachRetryListeners` に `touchend` 追加 (非インタラクティブ要素タップを確実に拾う)
4. [audio-engine.ts](src/lib/audio/audio-engine.ts) `attachUnlockRetry`/`detachUnlockRetry` に `touchend` 追加 + `isAudioContextRunning()` 新規 export (isRunning 判定を一元化)

## Test plan

- [x] lint: 0 errors (22 warnings 既存)
- [x] typecheck: 既存環境問題 2 件のみ (\`@testing-library/react\`、main HEAD でも同様)
- [x] test:ci: 369/369 tests passed (BGM/audio 関連 43 tests green = 回帰なし)
- [x] build: exit 0
- [x] 実機モバイル Safari: ホーム画面任意箇所タップで BGM 再生開始を確認 (解消済み)