### PR TITLE
AI: double_move super-action 内部探索 (#193-PR1d-3)

### DIFF
--- a/docs/plans/issue-193-pr1d.md
+++ b/docs/plans/issue-193-pr1d.md
@@ -1969,6 +1969,27 @@ PR1d-1 実装第 1 次反映後の第 2 次レビューで指摘された 2 件 
 
 ---
 
+### PR1d-3 実装 設計判断反映 (2 件ユーザー確認済 + 実装ギャップ ZZ)
+
+PR1d-3 実装中、計画書 PR1d-3 詳細 (L948-1259) の擬似コードと PR1d-2 で確立した設計 (production ホットパス touch せず、engine.ts root で `evaluateAction` 浅評価 = depth=0) の整合性が問題となり、ユーザーに 2 件の設計判断を確認:
+
+| # | 設計判断 | ユーザー確定 | 反映内容 |
+|---|---------|------------|---------|
+| **判断 1** | super-action 内部探索の深さ (計画書 L1060-1122 は案 A=negamax 深読み、PR1d-2 evaluateAction は depth=0) | **案 B (depth=0 簡易評価)** | `searchDoubleMoveSuperAction` は 2 手指し組合せを局所探索し 2 手指し後を depth=0 評価。計画書 L1060-1122 の negamax 深読み + local αβ は案 A 前提のため本実装と乖離 (negamax 呼出なし、αβ は depth=0 で単純 max に縮約)。性能配慮で 1 手目を `DOUBLE_MOVE_TOP_K=10` 常時絞り (計画書 L1254「+30% 超過時のみ・デフォルト無効」は案 A 前提) |
+| **判断 2** | cardDigest doubleMoveActive (計画書 L1124-1170、L1141 `cardState.doubleMove?.player`) | **案 B (コミット 3 スキップ)** | `CardGameState` に `doubleMove` フィールドが存在せず (reducer state 側、AI 側は `AiTurnState.doubleMove` 独立管理)、production root では engine.ts が `doubleMove:null` 固定で AiTurnState 構築のため root スカラー cardDigest の doubleMoveActive は常に無意味化。コミット 3 (cards/digest.ts 拡張 + `DOUBLE_MOVE_ACTIVE_VALUE` + `MANA_FAST_BONUS` 供給差、計画書 L1124-1210) は全てスキップ。二手指しの価値は super-action 探索の局所評価が直接捕捉。将来 reducer の doubleMove を route.ts 経由で AI に渡す統合時に再検討 |
+
+**実装ギャップ (擬似コードと実コードの差異、ZZ 記録)**:
+
+- `ApplyActionResult.turnEnded` は PR1a で既存 (計画書 L980-989「turn/types.ts に追加」は不要、turn/types.ts 変更なし)
+- `CurrentRules` は `class ... implements TurnRules` (計画書 L995 等の `const CurrentRules: TurnRules = {}` と差異)
+- `AiTurnState.doubleMove` の player キーは `.active` (計画書 L1002-1021 等の `.player` と差異)
+- action-generator.ts は double_move 候補生成のため変更不要 (`targeting:none` を PR1d-2 の `enumerateTargets` case "none" が既に対応、計画書 L971「double_move 候補追加」は実態と差異)
+- PR1d-2 実装ギャップ (本コミットで併記): action-generator.ts シグネチャ `(state, player, variant)` (計画書 L707 `(state, player)`)、`isInCheck` は `@/lib/shogi/moves` 由来 (計画書 `@/lib/shogi/check`)、`targeting:"ownPiece"` を `"square"` と同枝統合、`isValidCardTargetSquare` 4 引数、production 統合は engine.ts root 経路 + evaluateAction 方式 (計画書 search.ts negamax 統合とは別アプローチ、振る舞いキープ優先)
+
+PR1d-3 はコミット 1 (applyAction 二手指し制御、`52a05ed`) + コミット 2 (super-action 内部探索、`a79bbe5`) の 2 コミットで完結 (コミット 3 スキップ)。`double-move-search.test.ts` 13 ケース green、関連 fixture 回帰なし。
+
+---
+
 ## 補足: メタ計画 md (本セッションの作業計画) との関係
 
 本計画 md (`docs/plans/issue-193-pr1d.md`) は、Claude Code ローカル plan ディレクトリ (`~/.claude/plans/issue-193-issue-pr-calm-hammock.md`) に保存されたメタ計画 md に基づいて作成された。メタ計画 md はリポジトリ外で保存され、本リポジトリにはコミットされない (= 引き継ぎ・記録用のみ)。

--- a/src/lib/shogi/ai/__tests__/double-move-search.test.ts
+++ b/src/lib/shogi/ai/__tests__/double-move-search.test.ts
@@ -1,0 +1,118 @@
+// Issue #193 / PR1d-3: double_move super-action 探索の data integrity 検証。
+//
+// 設計意図:
+// - コミット 1: CurrentRules.applyAction の二手指し制御 (turnEnded / doubleMove 遷移)
+// - コミット 2: search.ts super-action 内部探索 (player 反転禁止 / α/β 継承 /
+//   DOUBLE_MOVE_TOP_K フォールバック) ← 本コミットでは未追加
+//
+// 計画 md `docs/plans/issue-193-pr1d.md` PR1d-3 詳細 / 検証計画 参照。
+
+import { describe, it, expect } from "vitest";
+import { CurrentRules } from "../turn/current-rules";
+import { createInitialCardState } from "@/lib/shogi/cards/state";
+import { createInitialGameState } from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { getFullLegalMoves } from "@/lib/shogi/moves";
+import type { AiTurnState, TurnAction } from "../turn/types";
+
+const TEST_DECK = [
+  { defId: "double_move" as const, count: 4 },
+  { defId: "pawn_return" as const, count: 4 },
+];
+
+function makeAiTurnState(): AiTurnState {
+  return {
+    gameState: createInitialGameState(CARD_SHOGI_VARIANT),
+    cardState: createInitialCardState(TEST_DECK),
+    doubleMove: null,
+    isRoot: true,
+  };
+}
+
+function firstLegalMove(state: AiTurnState): TurnAction {
+  const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+  return { kind: "move", move: moves[0] };
+}
+
+describe("CurrentRules.applyAction 二手指し制御 (PR1d-3 コミット 1)", () => {
+  const rules = new CurrentRules(CARD_SHOGI_VARIANT);
+
+  it("通常 move (doubleMove === null) は turnEnded=true / doubleMove=null", () => {
+    const state = makeAiTurnState();
+    const result = rules.applyAction(state, firstLegalMove(state));
+    expect(result.turnEnded).toBe(true);
+    expect(result.next.doubleMove).toBeNull();
+  });
+
+  it("二手指し 1 手目 (movesLeft=2) は turnEnded=false / movesLeft 1 に減算", () => {
+    const state = makeAiTurnState();
+    state.doubleMove = { active: "sente", movesLeft: 2 };
+    const result = rules.applyAction(state, firstLegalMove(state));
+    expect(result.turnEnded).toBe(false);
+    expect(result.next.doubleMove).toEqual({ active: "sente", movesLeft: 1 });
+  });
+
+  it("二手指し 2 手目 (movesLeft=1) は turnEnded=true / doubleMove リセット", () => {
+    const state = makeAiTurnState();
+    state.doubleMove = { active: "sente", movesLeft: 1 };
+    const result = rules.applyAction(state, firstLegalMove(state));
+    expect(result.turnEnded).toBe(true);
+    expect(result.next.doubleMove).toBeNull();
+  });
+
+  it('playCard "double_move" は turnEnded=false / doubleMove={active,movesLeft:2} / 盤面不変', () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-dm1",
+      defId: "double_move",
+      target: undefined,
+    };
+    const result = rules.applyAction(state, action);
+    expect(result.turnEnded).toBe(false);
+    expect(result.next.doubleMove).toEqual({ active: "sente", movesLeft: 2 });
+    // targeting:none = 盤面不変 (gameState 参照が同一)
+    expect(result.next.gameState).toBe(state.gameState);
+  });
+
+  it('playCard "double_move" の active は gameState.currentPlayer に追従 (gote 手番)', () => {
+    const state = makeAiTurnState();
+    state.gameState = { ...state.gameState, currentPlayer: "gote" };
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-dm2",
+      defId: "double_move",
+      target: undefined,
+    };
+    const result = rules.applyAction(state, action);
+    expect(result.next.doubleMove).toEqual({ active: "gote", movesLeft: 2 });
+  });
+
+  it('playCard "double_move" 以外 (pawn_return) は throw (PR3 で実装予定)', () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "test-pr1",
+      defId: "pawn_return",
+      target: { kind: "square", row: 6, col: 0 },
+    };
+    expect(() => rules.applyAction(state, action)).toThrow(/PR3/);
+  });
+
+  it("draw は throw (PR3 で実装予定、evaluateAction が直接処理)", () => {
+    const state = makeAiTurnState();
+    expect(() => rules.applyAction(state, { kind: "draw" })).toThrow(/PR3/);
+  });
+
+  it("二手指し 1 手目適用後の state を再投入すると 2 手目で正しく終了する", () => {
+    const state = makeAiTurnState();
+    state.doubleMove = { active: "sente", movesLeft: 2 };
+    // 1 手目
+    const r1 = rules.applyAction(state, firstLegalMove(state));
+    expect(r1.turnEnded).toBe(false);
+    // 1 手目適用後の state で 2 手目
+    const r2 = rules.applyAction(r1.next, firstLegalMove(r1.next));
+    expect(r2.turnEnded).toBe(true);
+    expect(r2.next.doubleMove).toBeNull();
+  });
+});

--- a/src/lib/shogi/ai/__tests__/double-move-search.test.ts
+++ b/src/lib/shogi/ai/__tests__/double-move-search.test.ts
@@ -9,6 +9,8 @@
 
 import { describe, it, expect } from "vitest";
 import { CurrentRules } from "../turn/current-rules";
+import { evaluateAction } from "../search";
+import { getCardActions } from "../turn/action-generator";
 import { createInitialCardState } from "@/lib/shogi/cards/state";
 import { createInitialGameState } from "@/lib/shogi/board";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
@@ -114,5 +116,71 @@ describe("CurrentRules.applyAction 二手指し制御 (PR1d-3 コミット 1)", 
     const r2 = rules.applyAction(r1.next, firstLegalMove(r1.next));
     expect(r2.turnEnded).toBe(true);
     expect(r2.next.doubleMove).toBeNull();
+  });
+});
+
+describe("searchDoubleMoveSuperAction (PR1d-3 コミット 2、evaluateAction 経由)", () => {
+  it("double_move の evaluateAction は有限スコアを返す (super-action 探索が機能、NEGATIVE_INFINITY でない)", () => {
+    const state = makeAiTurnState();
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "dm",
+      defId: "double_move",
+      target: undefined,
+    };
+    const score = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
+    expect(Number.isFinite(score)).toBe(true);
+    expect(score).not.toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("double_move スコアは move スコアと同じ player 視点で比較可能 (両方有限)", () => {
+    const state = makeAiTurnState();
+    const dmAction: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "dm",
+      defId: "double_move",
+      target: undefined,
+    };
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    const mvAction: TurnAction = { kind: "move", move: moves[0] };
+    const dmScore = evaluateAction(state, dmAction, "sente", CARD_SHOGI_VARIANT);
+    const mvScore = evaluateAction(state, mvAction, "sente", CARD_SHOGI_VARIANT);
+    expect(Number.isFinite(dmScore)).toBe(true);
+    expect(Number.isFinite(mvScore)).toBe(true);
+  });
+
+  it("gote 視点でも double_move は有限スコア (player 符号整合)", () => {
+    const state = makeAiTurnState();
+    state.gameState = { ...state.gameState, currentPlayer: "gote" };
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: "dm",
+      defId: "double_move",
+      target: undefined,
+    };
+    const score = evaluateAction(state, action, "gote", CARD_SHOGI_VARIANT);
+    expect(Number.isFinite(score)).toBe(true);
+  });
+
+  it("getCardActions が double_move を候補に含む (マナ 5 以上 + 手札保有時)", () => {
+    const state = makeAiTurnState();
+    state.cardState.mana.sente = 10;
+    state.cardState.hand.sente = [{ instanceId: "dm1", defId: "double_move" }];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    const hasDoubleMove = actions.some(
+      (a) => a.kind === "playCard" && a.defId === "double_move",
+    );
+    expect(hasDoubleMove).toBe(true);
+  });
+
+  it("マナ不足 (5 未満) では double_move は候補に含まれない (BEGIN_PLAY_CARD 項目 4)", () => {
+    const state = makeAiTurnState();
+    state.cardState.mana.sente = 4; // double_move cost 5 未満
+    state.cardState.hand.sente = [{ instanceId: "dm1", defId: "double_move" }];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    const hasDoubleMove = actions.some(
+      (a) => a.kind === "playCard" && a.defId === "double_move",
+    );
+    expect(hasDoubleMove).toBe(false);
   });
 });

--- a/src/lib/shogi/ai/cards/heuristics.ts
+++ b/src/lib/shogi/ai/cards/heuristics.ts
@@ -33,6 +33,19 @@ export const HAND_VALUE_DECAY = 3.0;
 export const MANA_DELTA_COEFFICIENT = 10;
 export const DRAW_PROGRESS_COEFFICIENT = 3;
 
-// PR1d-3 で追加予定 (Phase 0 で枠だけ確保、V-1 反映で DOUBLE_MOVE_ACTIVE_VALUE 追加も明示):
-// export const DOUBLE_MOVE_TOP_K = 10;             // bench で +30% 超過時のフォールバック上限手数
-// export const DOUBLE_MOVE_ACTIVE_VALUE = 200;     // V-1 反映: 二手指し継続中の cardDigest 評価値 (cp、bench で調整)
+// PR1d-3 (判断 1 = 案 B「depth=0 簡易評価」採用):
+//   ・DOUBLE_MOVE_TOP_K: super-action 内部探索の 1 手目候補上限。案 B では 2 手指し
+//     組合せ (1 手目 × 全 2 手目) を depth=0 で全評価するため計算量は O(K × ~80)。
+//     計画 md L1254 は「+30% 超過時のみ発動・デフォルト無効」だが、それは案 A
+//     (negamax 深読み + αβ pruning) 前提の試算。案 B は depth=0 全探索で αβ
+//     pruning が効かないため、PR1d-3 初版から常時 K=10 に絞り 1 手目を heuristic
+//     順 (scoreMoveForOrdering) 上位に限定する (ZZ 反映: 案 B 採用に伴う性能調整)。
+export const DOUBLE_MOVE_TOP_K = 10;
+
+// 判断 2 = 案 B でコミット 3 (cardDigest doubleMoveActive) はスキップ確定のため
+// DOUBLE_MOVE_ACTIVE_VALUE は導入しない。理由: CardGameState に doubleMove
+// フィールドが無く、production root では engine.ts が doubleMove:null 固定で
+// AiTurnState を構築するため root スカラー cardDigest の doubleMoveActive は
+// 常に無意味化する。二手指しの価値は super-action 探索の局所評価が直接捕捉する。
+// 将来 reducer の doubleMove を route.ts 経由で AI に渡す統合時に再検討
+// (計画 md PR1d-3 コミット 3 セクションに ZZ 反映)。

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -7,7 +7,8 @@ import { getSearchLegalMoves } from "./legal-moves";
 import { applyMoveForSearch } from "../board";
 import { evaluate, scoreMoveForOrdering } from "./evaluate";
 import { simulateCardEffect } from "../cards/effects";
-import { DRAW_VALUE_BONUS } from "./cards/heuristics";
+import { DRAW_VALUE_BONUS, DOUBLE_MOVE_TOP_K } from "./cards/heuristics";
+import { CurrentRules } from "./turn/current-rules";
 import type { AiTurnState, TurnAction } from "./turn/types";
 import {
   computeHash,
@@ -703,12 +704,15 @@ export function findBestMove(
 // - move: applyMoveForSearch 後の局面で evaluate (= 既存 root 評価と同じ depth=0 評価)
 // - draw: 局面は変わらず、cardDigest も root スカラー固定のため evaluate 値は同じ。
 //   ドローを促進するため DRAW_VALUE_BONUS を加算 (heuristics.ts の名前付き定数)
-// - playCard: simulateCardEffect で仮想 GameState 遷移後の局面で evaluate。
-//   simulateCardEffect が null を返すカード (target なしカード mana_up/no_promote/check_break/double_move 等)
-//   は PR1d-2 範囲外のため Number.NEGATIVE_INFINITY を返して候補から除外
+// - playCard (通常カード): simulateCardEffect で仮想 GameState 遷移後の局面で evaluate。
+//   simulateCardEffect が null を返す target なしカード (mana_up/no_promote/check_break)
+//   は PR1d-3 範囲外のため Number.NEGATIVE_INFINITY を返して候補から除外
+// - playCard "double_move": PR1d-3 で searchDoubleMoveSuperAction (2 手指し組合せの
+//   depth=0 局所探索、判断 1 = 案 B) に委譲
 //
-// 注: depth=0 評価のため、move の深く読んだスコア (findBestMove 反復深化結果) との直接比較は
-// 不公平。コミット 3 (engine.ts 統合) で move のスコア比較経路を調整する想定。
+// 注: depth=0 評価のため、move の深く読んだスコア (findBestMove 反復深化結果) との
+// 直接比較は不公平だが、engine.ts root 経路 (PR1d-2) で move も evaluateAction で
+// 再評価して比較基準を統一済 (= 公平化済)。
 export function evaluateAction(
   state: AiTurnState,
   action: TurnAction,
@@ -729,6 +733,12 @@ export function evaluateAction(
       return signed + DRAW_VALUE_BONUS;
     }
     case "playCard": {
+      // PR1d-3 (判断 1 = 案 B): double_move は super-action 内部探索で 2 手指しの
+      // 最良組合せを depth=0 評価 (simulateCardEffect は targeting:none で null を
+      // 返すため、専用経路で扱う)。
+      if (action.defId === "double_move") {
+        return searchDoubleMoveSuperAction(state, player, variant, ctx);
+      }
       const nextGameState = simulateCardEffect(
         state.gameState,
         player,
@@ -736,11 +746,86 @@ export function evaluateAction(
         action.target ?? null,
       );
       if (!nextGameState) {
-        // simulateCardEffect が null を返すカード (target なしカード) は PR1d-2 範囲外
+        // simulateCardEffect が null を返すその他の target なしカード
+        // (mana_up / no_promote / check_break) は PR1d-3 範囲外
         return Number.NEGATIVE_INFINITY;
       }
       const raw = evaluate(nextGameState, variant, cardDigest);
       return player === "sente" ? raw : -raw;
     }
   }
+}
+
+// Issue #193 / PR1d-3: double_move (二手指し) を 1 つの super-action として扱う
+// 内部探索 (判断 1 = 案 B「depth=0 簡易評価」採用)。
+//
+// 設計:
+// - double_move は「同一プレイヤーが 2 ply 連続で指す」特殊機構。super-action 内部で
+//   1 手目選択 → applyAction(turnEnded=false) → 2 手目選択 → applyAction(turnEnded=true)
+//   → 2 手指し後の局面を depth=0 評価 (= PR1d-2 evaluateAction の depth=0 と公平)
+// - player 反転禁止: 二手指し中は同一プレイヤーが連続するため negamax の符号反転や
+//   player 反転を行わない (turnEnded フラグで構造的に保証、不変条件を assert)
+// - 性能配慮 (案 B は depth=0 全探索で αβ pruning が効かない): 1 手目候補を
+//   scoreMoveForOrdering 順上位 DOUBLE_MOVE_TOP_K 手に常時絞る (heuristics.ts の ZZ 反映)
+// - cardDigest は ctx?.cardDigest (W-1 root スカラー方式) を使用、未渡時は加算 skip
+//
+// 計画 md L1060-1122 の擬似コードは案 A (negamax 深読み) 前提。本実装は案 B
+// (depth=0) のため negamax 呼出なし・local αβ も depth=0 では単純 max に縮約
+// (ZZ 反映)。double_move の「2 手分動ける」価値は組合せ探索が直接捕捉する。
+function searchDoubleMoveSuperAction(
+  state: AiTurnState,
+  player: Player,
+  variant: RuleVariant,
+  ctx?: SearchContext,
+): number {
+  const cardDigest = ctx?.cardDigest;
+  const rules = new CurrentRules(variant);
+
+  // Step 1: double_move カード適用 (doubleMove フラグ ON、turnEnded=false)
+  const afterCard = rules.applyAction(state, {
+    kind: "playCard",
+    cardInstanceId: "", // super-action 内部探索では instanceId 不問
+    defId: "double_move",
+  }).next;
+
+  // Step 2: 1 手目候補生成 (move-only)。性能配慮で heuristic 上位 K 手に絞る。
+  const firstMovesAll = getSearchLegalMoves(afterCard.gameState, player, variant);
+  if (firstMovesAll.length === 0) return NEG_INF; // 1 手目なし = 二手指し不成立で負
+  const firstMoves =
+    firstMovesAll.length > DOUBLE_MOVE_TOP_K
+      ? [...firstMovesAll]
+          .sort((a, b) => scoreMoveForOrdering(b) - scoreMoveForOrdering(a))
+          .slice(0, DOUBLE_MOVE_TOP_K)
+      : firstMovesAll;
+
+  let bestScore = NEG_INF;
+  // Step 3: 各 1 手目 × 全 2 手目を局所探索、2 手指し後を depth=0 評価
+  for (const firstMove of firstMoves) {
+    const afterFirst = rules.applyAction(afterCard, { kind: "move", move: firstMove });
+    // 不変条件: 二手指し 1 手目は turnEnded=false (= player 反転禁止の構造的保証)
+    if (afterFirst.turnEnded) {
+      throw new Error(
+        "Invariant violation: double_move 1 手目で turnEnded が true (player 反転禁止が破れている)",
+      );
+    }
+    const secondMoves = getSearchLegalMoves(afterFirst.next.gameState, player, variant);
+    if (secondMoves.length === 0) continue; // 2 手目なしはこの 1 手目をスキップ
+    for (const secondMove of secondMoves) {
+      const afterSecond = rules.applyAction(afterFirst.next, {
+        kind: "move",
+        move: secondMove,
+      });
+      // 不変条件: 二手指し 2 手目で turnEnded=true (= ターン終了、通常フローに戻る)
+      if (!afterSecond.turnEnded) {
+        throw new Error(
+          "Invariant violation: double_move 2 手目で turnEnded が false",
+        );
+      }
+      // 案 B: 2 手指し後の局面を depth=0 評価 (player 視点、PR1d-2 evaluateAction と整合)
+      const raw = evaluate(afterSecond.next.gameState, variant, cardDigest);
+      const score = player === "sente" ? raw : -raw;
+      if (score > bestScore) bestScore = score;
+    }
+  }
+  return bestScore;
 }

--- a/src/lib/shogi/ai/turn/current-rules.ts
+++ b/src/lib/shogi/ai/turn/current-rules.ts
@@ -68,29 +68,67 @@ export class CurrentRules implements TurnRules {
     return actions;
   }
 
-  // PR1d-2 コミット 2 段階での実装方針 (ZZ-5 後続対応):
-  // move 以外 (draw / playCard) の applyAction は引き続き throw 維持。
-  // 理由: PR1d-2 では search.ts の evaluateAction (新規) が simulateCardEffect 等を
-  // 直接呼んで playCard / draw の評価値を算出する設計に確定したため、applyAction 経由の
-  // 状態遷移は不要 (= reducer ロジックを AI 側で二重実装するリスクを回避)。
-  // production 探索パスは依然として findBestMove (search.ts) → getSearchLegalMoves 直接呼出で、
-  // CurrentRules.applyAction は呼ばれず throw 到達せず。
-  // 将来 PR3 (カード深読み探索) で applyAction(draw / playCard) が必要になった時点で実装する。
+  // PR1d-3: applyAction に二手指し (double_move) 制御を実装。
+  //
+  // 実装範囲 (PR1d-3 スコープ):
+  // - move: 二手指し中なら turnEnded / doubleMove 遷移を制御
+  //   ・doubleMove.movesLeft === 2 → 1 手目: movesLeft を 1 に減算、ターン継続 (turnEnded=false)
+  //   ・doubleMove.movesLeft === 1 → 2 手目: doubleMove リセット、ターン終了 (turnEnded=true)
+  //   ・doubleMove === null → 通常 1 手: ターン終了 (turnEnded=true、= PR1d-2 までの振る舞いキープ)
+  // - playCard "double_move": doubleMove フラグをセットしてターン継続 (turnEnded=false)。
+  //   盤面不変 (targeting:none)。super-action 内部探索 (search.ts) が連鎖呼出する。
+  //
+  // throw 維持 (PR3 カード深読み探索で実装予定):
+  // - draw / playCard "double_move" 以外: evaluateAction (search.ts) が simulateCardEffect 等を
+  //   直接呼んで評価値を算出する設計のため applyAction 経由は不要。super-action 探索でも
+  //   double_move 以外の playCard / draw は連鎖呼出しないため到達しない。
   applyAction(state: AiTurnState, action: TurnAction): ApplyActionResult {
     if (action.kind === "move") {
       const nextGameState = applyMoveForSearch(state.gameState, action.move);
+      const dm = state.doubleMove;
+      // 二手指し遷移: movesLeft 2 → 1 (ターン継続) / 1 → null (ターン終了) / null は通常終了
+      let nextDoubleMove = dm;
+      let turnEnded = true;
+      if (dm !== null && dm.movesLeft === 2) {
+        nextDoubleMove = { active: dm.active, movesLeft: 1 };
+        turnEnded = false;
+      } else if (dm !== null && dm.movesLeft === 1) {
+        nextDoubleMove = null;
+        turnEnded = true;
+      }
       return {
         next: {
           gameState: nextGameState,
           cardState: state.cardState,
-          doubleMove: state.doubleMove,
+          doubleMove: nextDoubleMove,
         },
         events: [],
-        turnEnded: true,
+        turnEnded,
       };
     }
+
+    if (action.kind === "playCard" && action.defId === "double_move") {
+      // double_move カード使用直後。盤面は不変 (targeting:none = 盤面に作用しない)、
+      // doubleMove フラグをセットしてターン継続 (turnEnded=false)。active は現在の
+      // 手番プレイヤー (= 二手指しを開始するプレイヤー)。
+      // 注: cost 5 マナ消費は AI 探索では cardDigest 側で扱う設計のため、ここでは
+      // cardState を変更しない (近似、計画 md PR1d-3 コミット 3 / 設計確認で精緻化予定)。
+      const player = state.gameState.currentPlayer;
+      return {
+        next: {
+          gameState: state.gameState,
+          cardState: state.cardState,
+          doubleMove: { active: player, movesLeft: 2 },
+        },
+        events: [],
+        turnEnded: false,
+      };
+    }
+
     throw new Error(
-      `CurrentRules.applyAction: action.kind="${action.kind}" は PR3 (カード深読み探索) で実装予定 (PR1d-2 段階では evaluateAction が simulateCardEffect 等を直接呼ぶため applyAction 経由は不要)`,
+      `CurrentRules.applyAction: action.kind="${action.kind}"${
+        action.kind === "playCard" ? ` defId="${action.defId}"` : ""
+      } は PR3 (カード深読み探索) で実装予定 (PR1d-3 段階では move の二手指し制御と playCard "double_move" のみ実装、その他 playCard / draw は evaluateAction が simulateCardEffect 等を直接呼ぶため applyAction 経由は不要)`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Issue #193 PR1d-3: double_move (二手指し) を 1 つの super-action として扱う AI 内部探索を実装。同一プレイヤーが 2 ply 連続で指す特殊機構を、計画書 PR1d-3 詳細に沿って評価可能にしました。

設計判断 2 件はユーザー確認のもと案 B を採用 (詳細は計画書 [L1970 付近](docs/plans/issue-193-pr1d.md) の ZZ 反映)。

## 設計判断 (ユーザー確認済、案 B 採用)

- **判断 1 = 案 B (depth=0 簡易評価)**: `searchDoubleMoveSuperAction` は 2 手指し組合せを局所探索し 2 手指し後を depth=0 評価。PR1d-2 `evaluateAction` の depth=0 と公平。計画書 L1060-1122 の negamax 深読み (案 A) とは乖離 → ZZ 反映
- **判断 2 = 案 B (コミット 3 スキップ)**: `CardGameState` に `doubleMove` フィールドが無く production root では常に null のため、cardDigest `doubleMoveActive` 拡張 (コミット 3 全体) をスキップ → ZZ 反映

## 主な変更

- [current-rules.ts](src/lib/shogi/ai/turn/current-rules.ts) `applyAction` に二手指し制御 (move の turnEnded/doubleMove 遷移 + playCard "double_move" 分岐)
- [search.ts](src/lib/shogi/ai/search.ts) `searchDoubleMoveSuperAction` 新規 (player 反転禁止を turnEnded 不変条件 assert で構造的保証、1 手目 `DOUBLE_MOVE_TOP_K=10` 絞り) + evaluateAction double_move 分岐
- [heuristics.ts](src/lib/shogi/ai/cards/heuristics.ts) `DOUBLE_MOVE_TOP_K=10` 有効化
- [double-move-search.test.ts](src/lib/shogi/ai/__tests__/double-move-search.test.ts) 新規 13 ケース

## 振る舞いキープ

- production 探索ホットパス (negamax/findBestMove) は不変。double_move を選ばない限り従来通り
- card-shogi 以外 / cardState 未渡時は影響なし
- **UI 統合は別 PR (Phase 4) のスコープ**: 本 PR は AI 探索エンジン内部の評価のみ。`FindBestMoveResult.action` は上位フック (use-ai-request.ts / use-card-shogi-game.ts) で未参照のため、production 対局では引き続き move のみ実行 (= 振る舞い完全キープ)

## Test plan

- [x] lint: 0 errors (22 warnings 既存)
- [x] typecheck: 既存環境問題 2 件のみ (\`@testing-library/react\`、main HEAD でも同様)
- [x] test:ci: 382/382 tests passed (新規 13 + 回帰なし)
- [x] build: exit 0

## 参照

- Issue #193 (集約 Issue)
- [docs/plans/issue-193-pr1d.md](docs/plans/issue-193-pr1d.md) PR1d-3 詳細 (L948-1259) + 設計判断 ZZ 反映