### PR TITLE
fix: #220 二手指し中の王手崩しトラップ誤発動を修正

### DIFF
--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -829,6 +829,128 @@ describe("reducer / 王手崩しトラップ (check_break)", () => {
   });
 });
 
+// ===== 二手指し × 王手崩し (Issue #220) =====
+
+describe("reducer / 二手指し × 王手崩し (Issue #220)", () => {
+  // sente: 玉[8][4] / 飛[5][3]、gote: 玉[2][4]、gote が check_break セット中。
+  // sente が二手指し中 (movesLeft=2)。一手目で飛を [5][3]→[5][4] に動かすと
+  // 列4で gote 玉に王手 (間の [4][4]/[3][4] は空)。盤はほぼ空なので詰みではない。
+  function makeDoubleMoveCheckBreakState(): CardShogiGameStateInternal {
+    const gameState: GameState = {
+      ...createInitialGameState(CARD_SHOGI_VARIANT),
+      board: Array.from({ length: 9 }, () => Array(9).fill(null)),
+      hand: { sente: {}, gote: {} },
+      currentPlayer: "sente",
+    };
+    gameState.board[8][4] = { type: "king", owner: "sente" };
+    gameState.board[2][4] = { type: "king", owner: "gote" };
+    gameState.board[5][3] = { type: "rook", owner: "sente" };
+    const cardState = makeInitialCardState({
+      trap: {
+        sente: null,
+        gote: { instanceId: "trap-1", defId: "check_break", owner: "gote" },
+      },
+    });
+    const snapshot = {
+      gameState,
+      cardState,
+      eventLog: [] as GameEvent[],
+    };
+    return {
+      ...makeInitialState(gameState, cardState),
+      doubleMove: {
+        active: "sente",
+        movesLeft: 2,
+        mateInOneAvailable: false,
+        cardInstance: card("dm-1", "double_move"),
+        cardCost: 6,
+        preFirstMoveState: snapshot,
+        preCardState: snapshot,
+      },
+    };
+  }
+
+  const firstMoveCheck = {
+    type: "move" as const,
+    player: "sente" as const,
+    piece: "rook",
+    from: { row: 5, col: 3 },
+    to: { row: 5, col: 4 },
+  };
+
+  it("一手目で王手しても check_break は発動しない (中間局面のため遅延 / 情報リークなし)", () => {
+    const state = makeDoubleMoveCheckBreakState();
+    const next = reducer(state, { type: "MAKE_MOVE", move: firstMoveCheck });
+
+    // トラップ未消費 (隠し情報維持) / 発動演出なし / イベントなし
+    expect(next.cardState.trap.gote).not.toBeNull();
+    expect(next.cardState.trap.gote?.defId).toBe("check_break");
+    expect(next.isCheckBreakAnimating).toBe(false);
+    expect(next.eventLog.some((e) => e.kind === "trapTriggerEvent")).toBe(false);
+    // 飛は盤上に残り、gote 持ち駒化されていない
+    expect(next.gameState.board[5][4]).toEqual({ type: "rook", owner: "sente" });
+    expect(next.gameState.hand.gote.rook).toBeUndefined();
+    // 二手指しは継続 (movesLeft 2→1、currentPlayer は active=sente に戻る)
+    expect(next.doubleMove?.movesLeft).toBe(1);
+    expect(next.gameState.currentPlayer).toBe("sente");
+  });
+
+  it("二手指し完了 (二手目) で最終局面が王手なら check_break が発動する", () => {
+    const afterFirst = reducer(makeDoubleMoveCheckBreakState(), {
+      type: "MAKE_MOVE",
+      move: firstMoveCheck,
+    });
+    // 二手目: gote の王手を解除しない手 (sente 玉を動かすだけ)
+    const secondMoveKeepCheck = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "king",
+      from: { row: 8, col: 4 },
+      to: { row: 7, col: 4 },
+    };
+    const next = reducer(afterFirst, {
+      type: "MAKE_MOVE",
+      move: secondMoveKeepCheck,
+    });
+
+    // 最終局面が王手 → トラップ発動 (王手駒=飛を gote 持ち駒へ)
+    expect(next.cardState.trap.gote).toBeNull();
+    expect(next.gameState.hand.gote.rook).toBe(1);
+    expect(next.isCheckBreakAnimating).toBe(true);
+    const trapEvent = next.eventLog.find((e) => e.kind === "trapTriggerEvent");
+    expect(trapEvent?.kind === "trapTriggerEvent" && trapEvent.reason).toBe(
+      "check_declared",
+    );
+    expect(next.doubleMove).toBeNull();
+  });
+
+  it("一手目で王手 → 二手目で王手解除 → check_break は発動しない", () => {
+    const afterFirst = reducer(makeDoubleMoveCheckBreakState(), {
+      type: "MAKE_MOVE",
+      move: firstMoveCheck,
+    });
+    // 二手目: 王手していた飛を [5][4]→[5][3] に戻し王手解除
+    const secondMoveResolve = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "rook",
+      from: { row: 5, col: 4 },
+      to: { row: 5, col: 3 },
+    };
+    const next = reducer(afterFirst, {
+      type: "MAKE_MOVE",
+      move: secondMoveResolve,
+    });
+
+    // 最終局面が非王手 → トラップ未発動 (隠し情報維持)
+    expect(next.cardState.trap.gote).not.toBeNull();
+    expect(next.cardState.trap.gote?.defId).toBe("check_break");
+    expect(next.isCheckBreakAnimating).toBe(false);
+    expect(next.eventLog.some((e) => e.kind === "trapTriggerEvent")).toBe(false);
+    expect(next.doubleMove).toBeNull();
+  });
+});
+
 // ===== 自動ドロー (#130) =====
 
 describe("reducer / 自動ドロー (#130)", () => {

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -320,7 +320,20 @@ function makeMoveWithEffects(
   let postTrapGameState = nextGameState;
   let triggeredCheckBreak = false;
   const opponentTrapPostMove = cardStateNext.trap[opponent];
+  // Issue #220: 二手指しの一手目 (double_move_first) は中間局面。トラップは
+  // ターン完了 (二手目 / 通常手) の最終局面で判定すべきで、中間で発動すると
+  // 相手トラップ種別が露見し、一手目キャンセルで戻せてしまう。よって
+  // double_move_first では原則スキップ (= 二手目 makeMoveWithEffects の最終
+  // 局面で判定 → ユーザー要望どおりターン完了後に発動)。
+  // 唯一の例外: 一手目だけで詰みが成立し二手指しがそこで終了する稀ケースは、
+  // ターンが事実上そこで終わるため発動を維持する (王手崩しは詰みを崩せる
+  // 必要があり、未発動で偽の詰み判定にしないため。MAKE_MOVE 1手目分岐の
+  // gameOver 経路と整合)。
+  const deferCheckBreak =
+    mode === "double_move_first" &&
+    evaluateGameEnd(nextGameState, CARD_SHOGI_VARIANT).status === "active";
   if (
+    !deferCheckBreak &&
     opponentTrapPostMove &&
     opponentTrapPostMove.defId === "check_break" &&
     isInCheck(nextGameState, opponent, CARD_SHOGI_VARIANT)


### PR DESCRIPTION
## Summary
二手指し(double_move)の一手目で相手玉に王手すると、相手 check_break トラップが中間局面で即発動していた問題を修正。一手目発動で相手トラップ種別が露見し、一手目キャンセルで戻して安全に探れてしまう不具合。

### 原因
`makeMoveWithEffects` の check_break 発動判定が `mode`(double_move_first/second/normal)に関係なく走るため、二手指し一手目の中間局面でも発動していた。

### 対策
check_break 判定を mode で gate。`double_move_first`(一手目=中間局面)は原則スキップし、二手目(`double_move_second`)/ 通常手の最終局面でのみ判定 → ユーザー要望どおり二手指し完了後に発動。トラップ未消費のままなのでキャンセルでも隠し情報維持。
例外: 一手目だけで詰みが成立し二手指しがそこで終了する稀ケースのみ発動維持(王手崩しは詰みを崩せる必要があり、未発動で偽の詰み判定にしないため)。
normal / double_move_second は不変のためデグレなし。

## Test plan
- reducer.test.ts に受け入れ条件3シナリオ追加(一手目未発動 / 二手目完了で発動 / 二手目で解除→未発動)
- lint: 0 error / typecheck: 既存2件のみ / test:ci: 405 passed(新規3件含む、デグレなし) / build: OK

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)