### PR TITLE
feat: #222 演出の発生順序を共通ルールで直列化

### DIFF
--- a/src/components/game/board-overlay.tsx
+++ b/src/components/game/board-overlay.tsx
@@ -6,6 +6,12 @@ import {
   PLAY_POP_IN_MS,
   PLAY_HOLD_MS,
   PLAY_FADE_OUT_MS,
+  CHECK_OVERLAY_FADE_IN_MS,
+  CHECK_OVERLAY_HOLD_MS,
+  CHECK_OVERLAY_FADE_OUT_MS,
+  TRAP_TRIGGER_OVERLAY_FADE_IN_MS,
+  TRAP_TRIGGER_OVERLAY_HOLD_MS,
+  TRAP_TRIGGER_OVERLAY_FADE_OUT_MS,
 } from "./card-shogi/animation-constants";
 
 // trap_set: 相手 (AI) がトラップを設置したときの汎用通知。トラップは隠し情報
@@ -42,9 +48,9 @@ const OVERLAY_CONFIG: Record<OverlayEvent, OverlayConfig> = {
   },
   check: {
     text: "王手",
-    fadeIn: 100,
-    hold: 1000,
-    fadeOut: 500,
+    fadeIn: CHECK_OVERLAY_FADE_IN_MS,
+    hold: CHECK_OVERLAY_HOLD_MS,
+    fadeOut: CHECK_OVERLAY_FADE_OUT_MS,
     className: "text-white",
   },
   resign: {
@@ -63,9 +69,9 @@ const OVERLAY_CONFIG: Record<OverlayEvent, OverlayConfig> = {
   },
   trap_trigger: {
     text: "トラップ発動！",
-    fadeIn: 200,
-    hold: 1500,
-    fadeOut: 600,
+    fadeIn: TRAP_TRIGGER_OVERLAY_FADE_IN_MS,
+    hold: TRAP_TRIGGER_OVERLAY_HOLD_MS,
+    fadeOut: TRAP_TRIGGER_OVERLAY_FADE_OUT_MS,
     className: "text-purple-100",
   },
   // 相手トラップ設置の汎用通知。種別を伏せた控えめな表示で、長さは通常カード

--- a/src/components/game/card-shogi/__tests__/animation-steps.test.ts
+++ b/src/components/game/card-shogi/__tests__/animation-steps.test.ts
@@ -1,0 +1,191 @@
+// Issue #222: deriveAnimationSteps の単体テスト。
+// 「カード使用 → 王手 → トラップ → ドロー」の共通順序へ正しく並べ替えられること、
+// 王手崩しセレモニー時に王手段が二重化しないこと、装飾イベント単体では空になることを検証する。
+
+import { describe, it, expect } from "vitest";
+import { deriveAnimationSteps } from "../animation-steps";
+import type { CardId, GameEvent } from "@/lib/shogi/cards/types";
+import type { Move } from "@/lib/shogi/types";
+
+// ----- イベント fixture ヘルパ (テスト可読性のため最小フィールドのみ) -----
+
+const sampleMove: Move = {
+  type: "move",
+  piece: "rook",
+  from: { row: 7, col: 7 },
+  to: { row: 2, col: 7 },
+  player: "sente",
+  promote: false,
+};
+
+function moveEvent(): GameEvent {
+  return { kind: "moveEvent", move: sampleMove, at: 1 };
+}
+function manaChargeEvent(): GameEvent {
+  return { kind: "manaChargeEvent", player: "sente", amount: 1, reason: "turn", at: 2 };
+}
+function cardPlayEvent(defId: CardId = "mana_up"): GameEvent {
+  return {
+    kind: "cardPlayEvent",
+    player: "sente",
+    instance: { instanceId: "c1", defId },
+    at: 3,
+  };
+}
+function trapSetEvent(): GameEvent {
+  return {
+    kind: "trapSetEvent",
+    player: "sente",
+    instance: { instanceId: "t1", defId: "check_break", owner: "sente" },
+    at: 4,
+  };
+}
+function checkBreakTrigger(captured = 1): GameEvent {
+  return {
+    kind: "trapTriggerEvent",
+    player: "gote",
+    instance: { instanceId: "t1", defId: "check_break", owner: "gote" },
+    reason: "check_declared",
+    capturedPieces: Array.from({ length: captured }, (_, i) => ({
+      row: i,
+      col: 0,
+      pieceType: "pawn",
+      originalPieceType: "pawn",
+      originalOwner: "sente" as const,
+    })),
+    at: 5,
+  };
+}
+function simpleTrapTrigger(): GameEvent {
+  // no_promote 等の即時オーバーレイ型 (capturedPieces 無し)。
+  return {
+    kind: "trapTriggerEvent",
+    player: "gote",
+    instance: { instanceId: "t2", defId: "no_promote", owner: "gote" },
+    reason: "promotion_declared",
+    at: 6,
+  };
+}
+function drawEvent(source: "manual" | "auto" = "auto"): GameEvent {
+  return {
+    kind: "drawEvent",
+    player: "sente",
+    instance: { instanceId: "d1", defId: "mana_up" },
+    source,
+    at: 7,
+  };
+}
+
+describe("deriveAnimationSteps", () => {
+  it("装飾イベント (move / manaCharge) のみ・王手なしなら空配列", () => {
+    expect(
+      deriveAnimationSteps([moveEvent(), manaChargeEvent()], { showCheck: false }),
+    ).toEqual([]);
+  });
+
+  it("空イベントなら空配列", () => {
+    expect(deriveAnimationSteps([], { showCheck: false })).toEqual([]);
+  });
+
+  it("駒移動で王手 → check ステップのみ", () => {
+    const steps = deriveAnimationSteps([moveEvent(), manaChargeEvent()], {
+      showCheck: true,
+    });
+    expect(steps.map((s) => s.kind)).toEqual(["check"]);
+  });
+
+  it("カード使用のみ → cardUse ステップ", () => {
+    const steps = deriveAnimationSteps([cardPlayEvent(), manaChargeEvent()], {
+      showCheck: false,
+    });
+    expect(steps.map((s) => s.kind)).toEqual(["cardUse"]);
+  });
+
+  it("トラップ設置 (trapSetEvent) も cardUse 扱い", () => {
+    const steps = deriveAnimationSteps([trapSetEvent()], { showCheck: false });
+    expect(steps.map((s) => s.kind)).toEqual(["cardUse"]);
+  });
+
+  it("カード使用 + 王手 → cardUse → check の順", () => {
+    const steps = deriveAnimationSteps([cardPlayEvent(), moveEvent()], {
+      showCheck: true,
+    });
+    expect(steps.map((s) => s.kind)).toEqual(["cardUse", "check"]);
+  });
+
+  it("即時トラップ + 王手 → check → trap の順 (セレモニーでないので王手は出す)", () => {
+    const steps = deriveAnimationSteps([moveEvent(), simpleTrapTrigger()], {
+      showCheck: true,
+    });
+    expect(steps.map((s) => s.kind)).toEqual(["check", "trap"]);
+  });
+
+  it("王手崩しセレモニーは王手段を内包 → 独立 check ステップを抑制", () => {
+    const steps = deriveAnimationSteps([moveEvent(), checkBreakTrigger()], {
+      showCheck: true,
+    });
+    // check は出さず trap のみ
+    expect(steps.map((s) => s.kind)).toEqual(["trap"]);
+  });
+
+  it("capturedPieces 無しの check_break は即時扱い → 王手は抑制しない", () => {
+    const ev: GameEvent = {
+      kind: "trapTriggerEvent",
+      player: "gote",
+      instance: { instanceId: "t1", defId: "check_break", owner: "gote" },
+      reason: "check_declared",
+      at: 5,
+    };
+    const steps = deriveAnimationSteps([moveEvent(), ev], { showCheck: true });
+    expect(steps.map((s) => s.kind)).toEqual(["check", "trap"]);
+  });
+
+  it("二手指し 2 手目相当: cardPlay + move + manaCharge + 王手崩し → cardUse → trap", () => {
+    const steps = deriveAnimationSteps(
+      [cardPlayEvent(), moveEvent(), manaChargeEvent(), checkBreakTrigger()],
+      { showCheck: true },
+    );
+    expect(steps.map((s) => s.kind)).toEqual(["cardUse", "trap"]);
+  });
+
+  it("全部入り (cardPlay + move + manaCharge + 王手崩し + 自動ドロー) → cardUse → trap → draw", () => {
+    const steps = deriveAnimationSteps(
+      [cardPlayEvent(), moveEvent(), manaChargeEvent(), checkBreakTrigger(), drawEvent("auto")],
+      { showCheck: true },
+    );
+    expect(steps.map((s) => s.kind)).toEqual(["cardUse", "trap", "draw"]);
+  });
+
+  it("通常手 + 即時トラップ + 自動ドロー + 王手 → check → trap → draw", () => {
+    const steps = deriveAnimationSteps(
+      [moveEvent(), manaChargeEvent(), simpleTrapTrigger(), drawEvent("auto")],
+      { showCheck: true },
+    );
+    expect(steps.map((s) => s.kind)).toEqual(["check", "trap", "draw"]);
+  });
+
+  it("ドロー演出は常に最後 (出現順を保持)", () => {
+    const steps = deriveAnimationSteps([drawEvent("manual"), manaChargeEvent()], {
+      showCheck: false,
+    });
+    expect(steps.map((s) => s.kind)).toEqual(["draw"]);
+    const drawStep = steps[0];
+    expect(drawStep.kind === "draw" && drawStep.event.source).toBe("manual");
+  });
+
+  it("ステップは元イベントへの参照を保持する", () => {
+    const cp = cardPlayEvent();
+    const steps = deriveAnimationSteps([cp], { showCheck: false });
+    expect(steps[0].kind === "cardUse" && steps[0].event).toBe(cp);
+  });
+
+  it("複数トラップ発動は出現順に並ぶ", () => {
+    const t1 = simpleTrapTrigger();
+    const t2 = checkBreakTrigger();
+    const steps = deriveAnimationSteps([t1, t2], { showCheck: false });
+    // どちらも trap。check_break が混ざるが showCheck=false なので check は元々無し
+    expect(steps.map((s) => s.kind)).toEqual(["trap", "trap"]);
+    expect(steps[0].kind === "trap" && steps[0].event).toBe(t1);
+    expect(steps[1].kind === "trap" && steps[1].event).toBe(t2);
+  });
+});

--- a/src/components/game/card-shogi/animation-constants.ts
+++ b/src/components/game/card-shogi/animation-constants.ts
@@ -72,16 +72,21 @@ export const MANA_GAUGE_SEGMENT_DURATION_S = 2.4;
 // ステップを timer 駆動で前進させるため、board-overlay.tsx の OVERLAY_CONFIG と
 // 尺を共有する (単一情報源)。従来 board-overlay と王手崩しセレモニー (1600 / 2300
 // リテラル) に同じ数値が散在していたのを集約する。
-// 王手オーバーレイ ("王手")。
+// 王手オーバーレイ ("王手")。Issue #222: 演出直列化でテンポ悪化を抑えるため尺を
+// 短縮 (旧 100/1000/500=1600 → 100/700/300=1100)。2 文字表示には十分な可読時間で、
+// 単純な opacity 遷移のみ (CSS keyframe 結合なし) のため安全に短縮できる。
 export const CHECK_OVERLAY_FADE_IN_MS = 100;
-export const CHECK_OVERLAY_HOLD_MS = 1000;
-export const CHECK_OVERLAY_FADE_OUT_MS = 500;
+export const CHECK_OVERLAY_HOLD_MS = 700;
+export const CHECK_OVERLAY_FADE_OUT_MS = 300;
 export const CHECK_OVERLAY_TOTAL_MS =
   CHECK_OVERLAY_FADE_IN_MS + CHECK_OVERLAY_HOLD_MS + CHECK_OVERLAY_FADE_OUT_MS;
-// トラップ発動オーバーレイ ("トラップ発動！")。
+// トラップ発動オーバーレイ ("トラップ発動！")。Issue #222: 同じく短縮 (旧
+// 200/1500/600=2300 → 200/1400/400=2000)。ただし overlay の CSS 演出
+// (trap-trigger-flash 1.6s) と王手崩しのゴーストヒット (ghost-trap-hit 1.5s) を
+// 途中で切らないよう、TOTAL は >=2000ms を保つ (fadeIn+hold=1600 >= flash 1.6s)。
 export const TRAP_TRIGGER_OVERLAY_FADE_IN_MS = 200;
-export const TRAP_TRIGGER_OVERLAY_HOLD_MS = 1500;
-export const TRAP_TRIGGER_OVERLAY_FADE_OUT_MS = 600;
+export const TRAP_TRIGGER_OVERLAY_HOLD_MS = 1400;
+export const TRAP_TRIGGER_OVERLAY_FADE_OUT_MS = 400;
 export const TRAP_TRIGGER_OVERLAY_TOTAL_MS =
   TRAP_TRIGGER_OVERLAY_FADE_IN_MS +
   TRAP_TRIGGER_OVERLAY_HOLD_MS +

--- a/src/components/game/card-shogi/animation-constants.ts
+++ b/src/components/game/card-shogi/animation-constants.ts
@@ -67,6 +67,26 @@ export const FAST_MOVE_OFFSET_BELOW_PIECE_PX = 4;
 // マナ増減セグメントのフェード時間。
 export const MANA_GAUGE_SEGMENT_DURATION_S = 2.4;
 
+// ===== Board Overlay 中央テキスト演出 (board-overlay.tsx) =====
+// Issue #222: 演出直列化オーケストレータが「王手」「トラップ発動」の中央オーバーレイ
+// ステップを timer 駆動で前進させるため、board-overlay.tsx の OVERLAY_CONFIG と
+// 尺を共有する (単一情報源)。従来 board-overlay と王手崩しセレモニー (1600 / 2300
+// リテラル) に同じ数値が散在していたのを集約する。
+// 王手オーバーレイ ("王手")。
+export const CHECK_OVERLAY_FADE_IN_MS = 100;
+export const CHECK_OVERLAY_HOLD_MS = 1000;
+export const CHECK_OVERLAY_FADE_OUT_MS = 500;
+export const CHECK_OVERLAY_TOTAL_MS =
+  CHECK_OVERLAY_FADE_IN_MS + CHECK_OVERLAY_HOLD_MS + CHECK_OVERLAY_FADE_OUT_MS;
+// トラップ発動オーバーレイ ("トラップ発動！")。
+export const TRAP_TRIGGER_OVERLAY_FADE_IN_MS = 200;
+export const TRAP_TRIGGER_OVERLAY_HOLD_MS = 1500;
+export const TRAP_TRIGGER_OVERLAY_FADE_OUT_MS = 600;
+export const TRAP_TRIGGER_OVERLAY_TOTAL_MS =
+  TRAP_TRIGGER_OVERLAY_FADE_IN_MS +
+  TRAP_TRIGGER_OVERLAY_HOLD_MS +
+  TRAP_TRIGGER_OVERLAY_FADE_OUT_MS;
+
 // ===== Auto Draw Ceremony (#130) =====
 // 経過手数による自動ドロー専用の演出パラメータ。
 // 既存 manual draw (DRAW_*) とは色味・前段 (Burst+Trail) が異なる。

--- a/src/components/game/card-shogi/animation-steps.ts
+++ b/src/components/game/card-shogi/animation-steps.ts
@@ -1,0 +1,110 @@
+// Issue #222: カード将棋の演出を共通ルールで直列化するための純粋関数。
+//
+// 背景:
+// reducer は 1 ターン分のイベント (cardPlayEvent / moveEvent / manaChargeEvent /
+// trapTriggerEvent / drawEvent) を 1 回の更新でまとめて eventLog へ積む。従来は
+// それらを差分監視 useEffect が 1 ループで即時・並行発火していたため、複数の
+// 大きな演出 (カード使用中央 / 王手 / トラップ発動 / 山札ドロー) が重なって
+// 再生され、何が起きているか分かりにくかった。
+//
+// 本関数は「新規イベント列」を受け取り、ユーザー確定の共通順序
+//   (1) カード使用 → (2) 王手 → (3) トラップ発動 → (4) 山札ドロー
+// に並べ替えた「演出ステップ列」を返す。実際の DOMRect 解決・SFX・state 反映
+// (= 副作用) は呼び出し側オーケストレータがステップを 1 つずつ activate する
+// 時点で行う。本関数はあくまで「どの演出をどの順で出すか」だけを決める純粋関数で、
+// ai-action-bridge.ts と同じ「純粋関数 + 単体テスト」方針で品質を担保する。
+//
+// 設計上の判断:
+// - 並び順は手番側 (自分/相手) に依らず常に同一のため、playerColor は引数に取らない
+//   (自分側か相手 AI 側かの分岐は activate 時の rect / queue 選択でのみ必要)。
+// - 王手にはイベントが存在せず gameState から isInCheck で導出される。呼び出し側が
+//   過渡的自玉王手 (二手指し 1 手目) 等の抑制を適用済みの最終真偽値 showCheck を
+//   渡す。これにより本関数は純粋・テスト可能なまま王手を正しい位置へ差し込める。
+// - 王手崩しセレモニー (check_break trapTrigger) は内部で「王手 → トラップ」の
+//   2 段を含むため、別途 check ステップを出すと王手演出が二重になる。セレモニーが
+//   ある場合は独立 check ステップを抑制する。
+
+import type { GameEvent } from "@/lib/shogi/cards/types";
+
+// 直列化対象の「大きな 4 演出」。軽量装飾 (マナ浮遊 / 早指しバッジ / 移動 SE 等) は
+// 直列化せず各ステップに付随して即時発火する (ユーザー確定方針: テンポ最適化)。
+export type AnimationStep =
+  | {
+      kind: "cardUse";
+      // カード使用 (通常カード) もしくはトラップ設置。どちらも「カードを使う」演出。
+      event: Extract<GameEvent, { kind: "cardPlayEvent" } | { kind: "trapSetEvent" }>;
+    }
+  | { kind: "check" }
+  | {
+      kind: "trap";
+      // トラップ「発動」(王手崩しセレモニー / no_promote 即時オーバーレイ等)。
+      event: Extract<GameEvent, { kind: "trapTriggerEvent" }>;
+    }
+  | {
+      kind: "draw";
+      event: Extract<GameEvent, { kind: "drawEvent" }>;
+    };
+
+export interface DeriveAnimationStepsContext {
+  // このイベントバッチの結果、王手演出を出すべきか。呼び出し側が gameState から
+  // isInCheck で判定し、二手指し 1 手目の過渡的自玉王手等の抑制も適用済みの
+  // 最終真偽値を渡す。
+  showCheck: boolean;
+}
+
+// 王手崩しセレモニー (王手 → トラップ発動 → 駒フライトの 3 段演出) を伴う
+// trapTrigger かどうか。capturedPieces が無い場合は即時オーバーレイのみ (= 王手段を
+// 内包しない) なので、独立 check ステップは抑制しない。
+function isCheckBreakCeremony(
+  ev: Extract<GameEvent, { kind: "trapTriggerEvent" }>,
+): boolean {
+  return ev.instance.defId === "check_break" && (ev.capturedPieces?.length ?? 0) > 0;
+}
+
+/**
+ * 新規イベント列を共通順序 (カード使用 → 王手 → トラップ → ドロー) の演出ステップ列へ変換する。
+ *
+ * @param events eventLog の差分 (今回新たに積まれたイベント) の配列
+ * @param ctx    王手表示可否などイベントから導出できない文脈
+ * @returns 再生順に並んだ演出ステップ列。対象演出が無いイベント (moveEvent /
+ *          manaChargeEvent 単体) のみの場合は空配列。
+ */
+export function deriveAnimationSteps(
+  events: GameEvent[],
+  ctx: DeriveAnimationStepsContext,
+): AnimationStep[] {
+  const steps: AnimationStep[] = [];
+
+  // (1) カード使用 / トラップ設置 — 出現順 (通常は 1 バッチに高々 1 件)。
+  for (const ev of events) {
+    if (ev.kind === "cardPlayEvent" || ev.kind === "trapSetEvent") {
+      steps.push({ kind: "cardUse", event: ev });
+    }
+  }
+
+  const trapTriggers = events.filter(
+    (ev): ev is Extract<GameEvent, { kind: "trapTriggerEvent" }> =>
+      ev.kind === "trapTriggerEvent",
+  );
+  const hasCheckBreakCeremony = trapTriggers.some(isCheckBreakCeremony);
+
+  // (2) 王手 — 王手崩しセレモニーが王手段を内包する場合は独立ステップを出さない。
+  if (ctx.showCheck && !hasCheckBreakCeremony) {
+    steps.push({ kind: "check" });
+  }
+
+  // (3) トラップ発動 — 出現順。
+  for (const ev of trapTriggers) {
+    steps.push({ kind: "trap", event: ev });
+  }
+
+  // (4) 山札ドロー — 出現順。自動ドローは applyTurnEndEffects がバッチ末尾に積むため
+  //     常に最後に来る (手動ドローと自動ドローが同一バッチに同居することはない)。
+  for (const ev of events) {
+    if (ev.kind === "drawEvent") {
+      steps.push({ kind: "draw", event: ev });
+    }
+  }
+
+  return steps;
+}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -49,7 +49,7 @@ import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import { getVariantById } from "@/lib/shogi/variants/index";
 import type { Difficulty, GameConfig, GameState, Move, Player, Position } from "@/lib/shogi/types";
 import type { CommentaryEvent } from "@/app/actions/commentary";
-import type { CardGameState, CardInstance } from "@/lib/shogi/cards/types";
+import type { CardGameState, CardInstance, GameEvent } from "@/lib/shogi/cards/types";
 import { CARD_DEFS, CARD_USE_CONDITIONS, DRAW_COST } from "@/lib/shogi/cards/definitions";
 import { isValidCardTargetSquare, canEscapeCheckWithCard, hasSameKindTrapPlaced } from "@/lib/shogi/cards/effects";
 import type { CardId } from "@/lib/shogi/cards/types";
@@ -63,7 +63,13 @@ import { CardPlayDialog, CardTargetingNotice } from "./card-play-dialog";
 import { DoubleMoveNotice } from "./double-move-notice";
 import { ForbiddenMateDialog } from "./forbidden-mate-dialog";
 import { DrawFlightCard } from "./draw-flight-card";
-import { DRAW_FADE_IN_MS, PLAY_TOTAL_MS } from "./animation-constants";
+import {
+  DRAW_FADE_IN_MS,
+  PLAY_TOTAL_MS,
+  CHECK_OVERLAY_TOTAL_MS,
+  TRAP_TRIGGER_OVERLAY_TOTAL_MS,
+} from "./animation-constants";
+import { deriveAnimationSteps, type AnimationStep } from "./animation-steps";
 import { AutoDrawBurst } from "./auto-draw-burst";
 import { CardPlayFlight } from "./card-play-flight";
 import { PieceFlight, type PieceFlightSpec } from "./piece-flight";
@@ -120,6 +126,28 @@ const NOOP_PIECE_CLICK: (pieceType: string) => void = () => {};
 // 毎レンダー [] を new するとメモ化が無効化されるため、フラグメンテーション回避。
 const EMPTY_POSITIONS: Position[] = [];
 const EMPTY_STRINGS: string[] = [];
+
+// Issue #222: 各演出ステップの保険タイムアウト (ms)。component の onComplete が
+// 来なくてもキューが前進し手番ロックが解除されるよう、実際の演出尺より十分長い値を
+// 置く。completeStep は先頭一致時のみ pop、COMMIT_* 系はロック未設定なら no-op の
+// ため、本タイマーが万一誤発火しても二重実行されず安全 (#217 系ハング再発防止)。
+const CARD_USE_STEP_FALLBACK_MS = 6000;
+const CHECK_BREAK_STEP_FALLBACK_MS = 8000;
+const DRAW_STEP_FALLBACK_MS = 6000;
+
+// Issue #222: イベントバッチの「手番主体」を導出する。駒移動 / カード使用 /
+// トラップ設置の最後の主体を採用する (trapTriggerEvent.player はトラップ所有者 =
+// 相手なので採用しない)。王手表示可否 (showCheck) で「相手玉が王手か」を判定する
+// 際の基準側を決めるために使う。move/card いずれも無いバッチ (自動ドロー単体等) は
+// null を返し、その場合は新たな王手演出を出さない。
+function deriveBatchActor(events: GameEvent[]): Player | null {
+  let actor: Player | null = null;
+  for (const ev of events) {
+    if (ev.kind === "moveEvent") actor = ev.move.player;
+    else if (ev.kind === "cardPlayEvent" || ev.kind === "trapSetEvent") actor = ev.player;
+  }
+  return actor;
+}
 
 export function CardShogiGame({
   initialGameState,
@@ -261,6 +289,15 @@ export function CardShogiGame({
     hideTargets: FlightHideTarget[];
     pendingFlightCount: number;
   } | null>(null);
+  // Issue #222: 演出直列化オーケストレータのキュー。reducer が 1 ターン分の
+  // イベントをまとめて eventLog へ積むため、従来は差分監視で各演出が即時・並行
+  // 発火し重なっていた。本キューに「カード使用→王手→トラップ→ドロー」の順で
+  // ステップを積み、先頭 1 件のみを activate して、完了で pop して次へ進める。
+  // これにより 4 種の大きな演出が必ず 1 つずつ完了してから次が再生される。
+  const [animationQueue, setAnimationQueue] = useState<AnimationStep[]>([]);
+  // 現在 activate 済みの先頭ステップ参照。再レンダー (gameState 変化等) での
+  // 二重 activate を防ぐガードに使う (object 参照一致で判定)。
+  const activeStepRef = useRef<AnimationStep | null>(null);
   // Issue #82 (二手指し): 2手目で禁止された詰み手をクリックされたときに表示する案内ダイアログ。
   const [forbiddenMateDialogOpen, setForbiddenMateDialogOpen] = useState(false);
   const router = useRouter();
@@ -455,12 +492,15 @@ export function CardShogiGame({
     } else {
       playSfx("piece_move");
     }
-    if (displayInCheck) {
+    // Issue #222: 通常プレイ中の王手演出は eventLog 監視のキュー
+    // (deriveAnimationSteps) が「カード使用→王手→トラップ→ドロー」の共通順序で
+    // 担う。ここでは詰み時のみ、従来の「王手→詰み」を保つため王手→詰みを発火する
+    // (詰みは終局で applyTurnEndEffects が走らずキューに乗らないため、キュー外で扱う)。
+    // 詰みは必ず王手中なので displayInCheck で gate せず status のみで判定する。
+    if (gameState.status === "checkmate") {
       playSfx("check");
       setOverlayEvent({ event: "check", key: Date.now() });
-    }
-    // 詰み: Issue #79 で王手 SFX (check) と分離した専用 checkmate SFX を再生。
-    if (gameState.status === "checkmate") {
+      // Issue #79 で王手 SFX (check) と分離した専用 checkmate SFX を 1000ms 後に再生。
       setTimeout(() => playSfx("checkmate"), 1000);
       setTimeout(() => setOverlayEvent({ event: "checkmate", key: Date.now() }), 1000);
     }
@@ -623,297 +663,150 @@ export function CardShogiGame({
     setDrawerOpen(false);
   }, [cachePendingCardRect, confirmPlayCard, playSfx]);
 
-  // カードイベント由来の SE 再生・画面演出・マナ浮遊テキストを eventLog の差分監視で発火
-  useEffect(() => {
-    if (!isReady) return;
-    const startIdx = lastEventIndexRef.current;
-    const newEvents = eventLog.slice(startIdx);
-    for (let i = 0; i < newEvents.length; i++) {
-      const ev = newEvents[i];
-      const absoluteIdx = startIdx + i;
-      switch (ev.kind) {
-        case "drawEvent": {
-          // Issue #130: source 別の挙動分岐。
-          // - SFX: 自分は即時、相手は 100ms 遅延 (連鎖時に重なり防止)
-          // - 演出キュー: 自分のドローのみ push (相手ドローは中央演出を出さない)
-          // - manaFlight: 手動ドロー (= マナ消費あり) のときのみ
-          // - aria-live: auto のとき (sente/gote 両方)「自動ドローしました」を 1500ms debounce で通知
-          //
-          // 【重要なロックバグ修正】
-          // 相手 (AI) 側の auto-draw でも reducer は isDrawing=true を立てる
-          // (applyTurnEndEffects の発火対象は player に依存しない)。
-          // 自分側 (isSelf=true) と異なり drawFlightQueue に push しないため、
-          // DrawFlightCard の onComplete → finalizeDraw が呼ばれず、isDrawing が
-          // 永続する。次に自分の手番が回ってきても selectSquare / drawCard /
-          // beginPlayCard の全ガードが効いて操作完全ロックという重大バグが
-          // 発生する。相手側ドローでも一定の視覚的待ち時間 (~600ms) を確保した上で
-          // 必ず finalizeDraw を呼んで isDrawing をクリアする。
-          const source = ev.source ?? "manual";
-          const isSelf = ev.player === playerColor;
-          if (isSelf) {
-            // Issue #79: 手動ドロー (山札クリック) と自動ドロー (relay) を別 SFX に分離。
-            playSfx(source === "auto" ? "card_auto_draw" : "card_draw");
-            // 中央表示タイミング (T=DRAW_FADE_IN_MS = 500ms) で
-            // レア度別 draw_card_open SE を発火。default 未割当なら playSfx 内で skip。
-            const rarity = CARD_DEFS[ev.instance.defId].rarity;
-            scheduleTimer(
-              () => playSfx(`draw_card_open_${rarity}` as never),
-              DRAW_FADE_IN_MS,
-            );
-            setDrawFlightQueue((q) => [
-              ...q,
-              { card: ev.instance, source, key: nextFlightKey() },
-            ]);
-          } else {
-            // Issue #193 / card-apply: 相手 (AI) ドローも自分と同じ
-            // 山札→中央→手札フライトを再生する (中央でも裏面のまま=何を
-            // 引いたかは見せない)。開始 SE は自分側と同じ
-            // (auto=card_auto_draw / manual=card_draw)。中央到達時
-            // (T=DRAW_FADE_IN_MS) の開封 SE も自分側と同じタイミングで鳴らす
-            // が、相手側はレア度別キー (draw_card_open_${rarity}) ではなく
-            // レア度非依存の固定キー draw_card_open_common を使う。理由:
-            // 中央でも裏面で札を伏せる方針のため、dev サウンドチューナーで
-            // レア度別に音を差し替えられた場合に耳でレア度が漏れるのを防ぐ。
-            // finalizeDraw はフライト完了 (handleOpponentDrawFlightComplete)
-            // で呼ぶ。DrawFlightInner 側に保険タイマーがあるため、タブ非
-            // アクティブでも isDrawing ロックは解除される。
-            playSfx(source === "auto" ? "card_auto_draw" : "card_draw");
-            scheduleTimer(
-              () => playSfx("draw_card_open_common"),
-              DRAW_FADE_IN_MS,
-            );
-            setOpponentDrawFlightQueue((q) => [
-              ...q,
-              { card: ev.instance, source, key: nextFlightKey() },
-            ]);
-          }
-          if (source === "manual" && isSelf) {
-            triggerManaFlight(-DRAW_COST, getDeckRect());
-          }
-          if (source === "auto") {
-            // 連続発火時 (sente auto → gote auto) は古いタイマーを cancel して
-            // 新しい 1500ms 計測を開始 (重複読み上げ防止)
-            if (liveMessageTimerRef.current !== null) {
-              window.clearTimeout(liveMessageTimerRef.current);
-              timersRef.current.delete(liveMessageTimerRef.current);
-            }
-            setAutoDrawLiveMessage("自動ドローしました");
-            liveMessageTimerRef.current = scheduleTimer(() => {
-              setAutoDrawLiveMessage("");
-              liveMessageTimerRef.current = null;
-            }, 1500);
-          }
-          break;
-        }
-        case "cardPlayEvent": {
-          playSfx("card_play");
+  // Issue #222: 演出ステップを 1 件消化したらキュー先頭を pop する。
+  // 「先頭が当該ステップのときだけ」pop することで、component の onComplete と
+  // 保険タイマーの両方から呼ばれても二重 pop しない (冪等)。pop により先頭が
+  // 次ステップ (別 object) に変わると driver effect が次を activate する。
+  const completeStep = useCallback((step: AnimationStep) => {
+    setAnimationQueue((q) => (q[0] === step ? q.slice(1) : q));
+  }, []);
+
+  // Issue #222: キュー先頭ステップを activate (実際の演出を起動) する。DOMRect
+  // 解決・SFX・state 反映といった副作用はすべてここで行う (順序決定は純粋関数
+  // deriveAnimationSteps が担う)。完了経路はステップ種別ごとに異なるが、いずれにも
+  // 保険タイマーを張り、完了通知が来なくてもキューが前進する (#217 系の手番永久
+  // ロック再発防止)。completeStep / COMMIT_* は冪等なので保険が誤発火しても安全。
+  const activateStep = useCallback(
+    (step: AnimationStep) => {
+      switch (step.kind) {
+        case "cardUse": {
+          const ev = step.event;
           const def = CARD_DEFS[ev.instance.defId];
-          if (def.cost > 0) {
-            // Issue #193 / card-apply: 自分はキャッシュした使用カード位置を
-            // 起点にできるが、相手 (AI) は手札が裏面で個別カード DOM が無く
-            // getOriginRect が自分の手札へフォールバックしてしまう。相手の
-            // マナ消費表示は相手手札エリア (getAiHandRect) を起点にする。
-            triggerManaFlight(
-              -def.cost,
-              ev.player === playerColor
-                ? getOriginRect(ev.instance.instanceId)
-                : getAiHandRect(),
-            );
-          }
-          // Issue #82: 駒移動カード(歩戻し/駒戻し/二歩指し)は handleSquareClick 内で
-          // flushSync により先回り発火済み。ここでは:
-          //  - pendingPieceFlightRef に新規駒種(toRect=null)ケースだけが残っている →
-          //    適用後の DOM から toRect を補完して発火
-          //  - それ以外(駒移動なしカード / 既に発火済み)→ 中央カード演出を即発火
-          if (ev.player === playerColor) {
-            const cardInstance = ev.instance;
-            const pending = pendingPieceFlightRef.current;
-            if (pending && pending.toRect === null) {
-              // 新規駒種: 適用後の DOM から to rect を取る
-              pendingPieceFlightRef.current = null;
-              const toRect = findVisibleCapturedPieceRect(playerColor, pending.pieceType);
-              if (toRect) {
-                pieceFlightKeyRef.current += 1;
-                // Issue #79: 駒フライト演出 SFX (default = 刀剣・投げナイフ)。
-                playSfx("piece_flight");
-                setPieceFlight({
-                  spec: {
-                    pieceType: pending.pieceType,
-                    owner: playerColor,
-                    fromX: pending.fromRect.left + pending.fromRect.width / 2,
-                    fromY: pending.fromRect.top + pending.fromRect.height / 2,
-                    toX: toRect.left + toRect.width / 2,
-                    toY: toRect.top + toRect.height / 2,
-                  },
-                  key: pieceFlightKeyRef.current,
-                  hideTarget: { kind: "captured", player: playerColor, pieceType: pending.pieceType },
-                });
-                pendingPlayFlightRef.current = { card: cardInstance, isTrap: false };
-              } else {
-                // 取得失敗 → 中央カード演出のみ
+          // カード消費マナの浮遊表示 (自分=使用カード位置 / 相手=相手手札エリア)。
+          const manaOrigin =
+            ev.player === playerColor
+              ? getOriginRect(ev.instance.instanceId)
+              : getAiHandRect();
+          if (ev.kind === "cardPlayEvent") {
+            playSfx("card_play");
+            if (def.cost > 0) triggerManaFlight(-def.cost, manaOrigin);
+            if (ev.player === playerColor) {
+              // Issue #82: 駒移動カードは handleSquareClick 内で flushSync 先回り
+              // 発火済み。ここでは pendingPieceFlightRef の新規駒種 (toRect=null)
+              // を適用後 DOM から補完するか、駒移動なしカードの中央演出を出す。
+              const cardInstance = ev.instance;
+              const pending = pendingPieceFlightRef.current;
+              if (pending && pending.toRect === null) {
+                pendingPieceFlightRef.current = null;
+                const toRect = findVisibleCapturedPieceRect(playerColor, pending.pieceType);
+                if (toRect) {
+                  pieceFlightKeyRef.current += 1;
+                  playSfx("piece_flight");
+                  setPieceFlight({
+                    spec: {
+                      pieceType: pending.pieceType,
+                      owner: playerColor,
+                      fromX: pending.fromRect.left + pending.fromRect.width / 2,
+                      fromY: pending.fromRect.top + pending.fromRect.height / 2,
+                      toX: toRect.left + toRect.width / 2,
+                      toY: toRect.top + toRect.height / 2,
+                    },
+                    key: pieceFlightKeyRef.current,
+                    hideTarget: { kind: "captured", player: playerColor, pieceType: pending.pieceType },
+                  });
+                  pendingPlayFlightRef.current = { card: cardInstance, isTrap: false };
+                } else {
+                  playFlightKeyRef.current += 1;
+                  playSfx("card_use_animation");
+                  setPlayFlight({ card: cardInstance, key: playFlightKeyRef.current, isTrap: false });
+                }
+              } else if (!pendingPlayFlightRef.current) {
+                // 駒フライト未発火 (駒移動なしカード or 二歩指し) → 中央カード演出。
+                // 王手演出は本ステップでは出さず、後続の check ステップに委譲する
+                // (Issue #222: カード使用 → 王手 の順を共通化)。
                 playFlightKeyRef.current += 1;
-                // Issue #79 派生: カード使用演出 SFX
                 playSfx("card_use_animation");
                 setPlayFlight({ card: cardInstance, key: playFlightKeyRef.current, isTrap: false });
               }
-            } else if (!pendingPlayFlightRef.current) {
-              // 駒フライト未発火 (= 駒移動なしカード or 二歩指し) → 中央カード演出を即発火
-              //
-              // Issue #173: 二歩指し (double_pawn) は moveCount を増やさないため
-              // moveCount useEffect 経由で王手 SFX/演出が発火しない。中央カード演出
-              // より前にここで発火する。
-              // 二手指し (double_move) は moveEvent と paired で moveCount が動くため
-              // moveCount useEffect 側で既に発火済み → effectId で gate して二重発火を回避。
-              if (def.effectId === "double_pawn") {
-                const opponentColor: Player =
-                  playerColor === "sente" ? "gote" : "sente";
-                if (
-                  gameState.status === "active" &&
-                  isInCheck(gameState, opponentColor, CARD_SHOGI_VARIANT)
-                ) {
-                  playSfx("check");
-                  setOverlayEvent({ event: "check", key: Date.now() });
+            } else {
+              // 相手 (AI) のカード使用。駒戻し/歩戻し (returnedPiece あり) は
+              // 盤上→持ち駒の駒フライト → 完了後に中央カード演出 (handlePieceFlightComplete
+              // → handlePlayFlightComplete) を再現する。
+              const rp = ev.returnedPiece;
+              let opponentPieceFlightFired = false;
+              if (rp) {
+                const fromRect = getBoardSquareRect(rp.row, rp.col);
+                const toRect = findVisibleCapturedPieceRect(aiColor, rp.pieceType);
+                if (fromRect && toRect) {
+                  pieceFlightKeyRef.current += 1;
+                  playSfx("piece_flight");
+                  setPieceFlight({
+                    spec: {
+                      pieceType: rp.pieceType,
+                      owner: aiColor,
+                      fromX: fromRect.left + fromRect.width / 2,
+                      fromY: fromRect.top + fromRect.height / 2,
+                      toX: toRect.left + toRect.width / 2,
+                      toY: toRect.top + toRect.height / 2,
+                    },
+                    key: pieceFlightKeyRef.current,
+                    hideTarget: { kind: "captured", player: aiColor, pieceType: rp.pieceType },
+                  });
+                  pendingPlayFlightRef.current = { card: ev.instance, isTrap: false };
+                  opponentPieceFlightFired = true;
                 }
               }
-              playFlightKeyRef.current += 1;
-              // Issue #79 派生: カード使用演出 SFX
-              playSfx("card_use_animation");
-              setPlayFlight({ card: cardInstance, key: playFlightKeyRef.current, isTrap: false });
+              if (!opponentPieceFlightFired) {
+                playFlightKeyRef.current += 1;
+                playSfx("card_use_animation");
+                setPlayFlight({ card: ev.instance, key: playFlightKeyRef.current, isTrap: false });
+              }
             }
           } else {
-            // Issue #193 / card-apply: 相手 (AI) のカード使用。自分が使った
-            // ときと同じ体験にするため、駒戻し/歩戻し (returnedPiece あり) は
-            // 「盤上 → 持ち駒の駒フライト → 完了後に中央カード演出 → finalize」
-            // を再現する。人間は handleSquareClick で適用前に fromRect を
-            // 捕捉するが、AI は適用後にしか介入できないため、reducer が
-            // cardPlayEvent に載せた returnedPiece (元位置 + unpromote 駒種)
-            // から復元する。駒フライト完了 (handlePieceFlightComplete) が
-            // pendingPlayFlightRef から中央カード演出を発火し、その onComplete
-            // (handlePlayFlightComplete) が finalizePlayCard → COMMIT_PLAY_CARD
-            // を呼んで手番を進める。この経路が無いと演出も COMMIT も発生せず
-            // 手番が永久ロックする (相手ドローで finalizeDraw を明示予約して
-            // いるのと同じ構造の対策)。
-            const rp = ev.returnedPiece;
-            let opponentPieceFlightFired = false;
-            if (rp) {
-              const fromRect = getBoardSquareRect(rp.row, rp.col);
-              const toRect = findVisibleCapturedPieceRect(aiColor, rp.pieceType);
-              if (fromRect && toRect) {
-                pieceFlightKeyRef.current += 1;
-                playSfx("piece_flight");
-                setPieceFlight({
-                  spec: {
-                    pieceType: rp.pieceType,
-                    owner: aiColor,
-                    fromX: fromRect.left + fromRect.width / 2,
-                    fromY: fromRect.top + fromRect.height / 2,
-                    toX: toRect.left + toRect.width / 2,
-                    toY: toRect.top + toRect.height / 2,
-                  },
-                  key: pieceFlightKeyRef.current,
-                  hideTarget: { kind: "captured", player: aiColor, pieceType: rp.pieceType },
-                });
-                pendingPlayFlightRef.current = { card: ev.instance, isTrap: false };
-                opponentPieceFlightFired = true;
-              }
-            }
-            if (!opponentPieceFlightFired) {
-              // 駒移動なしカード (mana_up 等) / rect 取得失敗フォールバック。
-              // 二歩指し (double_pawn) は moveCount を増やさず moveCount
-              // useEffect 経由の王手演出が出ないため、相手 (AI) の二歩指しで
-              // 自玉が王手になるケースをここで補う (自分側分岐 712-722 と対称)。
-              if (def.effectId === "double_pawn") {
-                const checkedSide: Player =
-                  ev.player === "sente" ? "gote" : "sente";
-                if (
-                  gameState.status === "active" &&
-                  isInCheck(gameState, checkedSide, CARD_SHOGI_VARIANT)
-                ) {
-                  playSfx("check");
-                  setOverlayEvent({ event: "check", key: Date.now() });
-                }
-              }
+            // trapSetEvent: トラップ設置。
+            playSfx("trap_set");
+            if (def.cost > 0) triggerManaFlight(-def.cost, manaOrigin);
+            if (ev.player === playerColor) {
+              // 自分のトラップ設置は中央へカード本体を表示 (CardPlayFlight)。
               playFlightKeyRef.current += 1;
-              playSfx("card_use_animation");
               setPlayFlight({
-                card: ev.instance,
+                card: { instanceId: ev.instance.instanceId, defId: ev.instance.defId },
                 key: playFlightKeyRef.current,
-                isTrap: false,
+                isTrap: true,
               });
+            } else {
+              // 相手 (AI) のトラップ設置は隠し情報なので種別を伏せた汎用オーバー
+              // レイのみ。中央カード演出を出さないため尺 (PLAY_TOTAL_MS) で
+              // finalizePlayCard + pop を予約する。
+              setOverlayEvent({ event: "trap_set", key: Date.now() });
+              scheduleTimer(() => {
+                finalizePlayCard();
+                completeStep(step);
+              }, PLAY_TOTAL_MS);
             }
           }
+          // 保険: 通常カード/自トラップは handlePlayFlightComplete、相手トラップは
+          // 上記タイマーで finalize+pop する。万一いずれも来なくても回収する。
+          scheduleTimer(() => {
+            finalizePlayCard();
+            completeStep(step);
+          }, CARD_USE_STEP_FALLBACK_MS);
           break;
         }
-        case "manaChargeEvent":
-          // ターン由来の自動チャージは駒移動 SE と被るため、カード由来のみ鳴らす
-          if (ev.reason === "card") playSfx("mana_charge");
-          // Issue #77: マナ加算を起点 UI 付近に表示
-          if (ev.reason === "turn") {
-            // 直前の同 player の moveEvent を遡って探し、移動先マスに表示
-            let moveTo: { row: number; col: number } | null = null;
-            for (let j = absoluteIdx - 1; j >= 0; j--) {
-              const m = eventLog[j];
-              if (m.kind === "moveEvent" && m.move.player === ev.player) {
-                moveTo = m.move.to;
-                break;
-              }
-            }
-            const rect = moveTo ? getBoardSquareRect(moveTo.row, moveTo.col) : null;
-            triggerManaFlight(ev.amount, rect);
-            if (ev.fastMove) triggerFastMoveBadge(rect);
-          } else {
-            // カード由来 (マナUP等): 直前に使用したカードの位置 (なければ手札中央)
-            triggerManaFlight(ev.amount, getOriginRect());
-          }
-          break;
-        case "trapSetEvent": {
-          // Issue #79: トラップセットは固有 SE (旧 card_play 流用は廃止)
-          playSfx("trap_set");
-          const def = CARD_DEFS[ev.instance.defId];
-          if (def.cost > 0) {
-            // Issue #193 / card-apply: 自分はキャッシュした使用カード位置を
-            // 起点にできるが、相手 (AI) は手札が裏面で個別カード DOM が無く
-            // getOriginRect が自分の手札へフォールバックしてしまう。相手の
-            // マナ消費表示は相手手札エリア (getAiHandRect) を起点にする。
-            triggerManaFlight(
-              -def.cost,
-              ev.player === playerColor
-                ? getOriginRect(ev.instance.instanceId)
-                : getAiHandRect(),
-            );
-          }
-          // Issue #106: トラップセット時も中央へカード本体を表示
-          // CardInstance に詰め直し (TrapInstance.owner は CardView 側で参照しないため捨てる)
-          if (ev.player === playerColor) {
-            playFlightKeyRef.current += 1;
-            setPlayFlight({
-              card: { instanceId: ev.instance.instanceId, defId: ev.instance.defId },
-              key: playFlightKeyRef.current,
-              isTrap: true,
-            });
-          } else {
-            // Issue #193 / card-apply: 相手 (AI) のトラップ設置。トラップは
-            // 相手から見えない隠し情報なのでカード本体は出さず、種別を伏せた
-            // 汎用オーバーレイのみ表示する (ユーザー選択: 種別を隠して汎用演出)。
-            // 中央カード演出 (CardPlayFlight) を出さないため、相手ドローと同様に
-            // finalizePlayCard を明示予約しないと isPlayingCard が永続ロック
-            // する。オーバーレイ尺 (= 通常カード演出と同じ PLAY_TOTAL_MS) に
-            // 合わせて COMMIT_PLAY_CARD を発火させる。
-            setOverlayEvent({ event: "trap_set", key: Date.now() });
-            scheduleTimer(() => finalizePlayCard(), PLAY_TOTAL_MS);
-          }
+        case "check": {
+          // 王手中央オーバーレイ。ロックを持たない短尺演出のため、尺経過で pop する。
+          playSfx("check");
+          setOverlayEvent({ event: "check", key: Date.now() });
+          scheduleTimer(() => completeStep(step), CHECK_OVERLAY_TOTAL_MS);
           break;
         }
-        case "trapTriggerEvent": {
+        case "trap": {
+          const ev = step.event;
           const trapDef = CARD_DEFS[ev.instance.defId];
-          // Issue #82 (王手崩し): 王手 → トラップ発動 → 駒フライト の3段演出
+          // Issue #82 (王手崩し): 王手 → トラップ発動 → 駒フライト の3段演出。
           if (trapDef.id === "check_break" && ev.capturedPieces && ev.capturedPieces.length > 0) {
             const trapOwner = ev.player;
             const captures = ev.capturedPieces;
-            // reducer は適用済 (盤上から駒除去・持ち駒に追加) なので、
-            // 王手中央表示+トラップ発動演出の間は元位置にゴースト駒を重ね描きする。
-            // fromRect: 元の盤面マス (空マスになっているがマス自体は存在)
-            // toRect: 持ち駒として既に追加されている表示位置 (hideTargets で隠す)
             const ghosts: Array<{ rect: DOMRect; pieceType: string; owner: Player }> = [];
             const flights: PieceFlightSpec[] = [];
             const hideTargets: FlightHideTarget[] = [];
@@ -940,53 +833,181 @@ export function CardShogiGame({
               });
               hideTargets.push({ kind: "captured", player: trapOwner, pieceType: cap.pieceType });
             }
-            // 演出ロックは reducer 側で isCheckBreakAnimating=true がセット済。
-            // ゴースト駒を盤面に重ね描きしつつ、持ち駒側はフライト着地まで隠す。
             pieceFlightKeyRef.current += captures.length;
             const flightKeyBase = pieceFlightKeyRef.current - captures.length + 1;
             setCheckBreakAnim({
               ghosts,
               hitActive: false,
-              flights: [],   // フライト発火前は空配列。ゴーストのみ表示。
+              flights: [], // フライト発火前は空配列。ゴーストのみ表示。
               flightKeyBase,
               hideTargets,
               pendingFlightCount: flights.length,
             });
-            // T=0: 王手中央表示 (1600ms = 100 fadeIn + 1000 hold + 500 fadeOut)
+            // T=0: 王手中央表示。
             playSfx("check");
             setOverlayEvent({ event: "check", key: Date.now() });
-            // T=1600: トラップ発動演出 (2300ms = 200 fadeIn + 1500 hold + 600 fadeOut)
-            //   + ゴースト駒へヒット演出 (紫フラッシュ + シェイク + 持続グロー)
-            window.setTimeout(() => {
+            // T=CHECK_OVERLAY_TOTAL: トラップ発動演出 + ゴースト駒ヒット演出。
+            scheduleTimer(() => {
               playSfx("trap_trigger");
-              setOverlayEvent({
-                event: "trap_trigger",
-                key: Date.now(),
-                trapName: trapDef.name,
-              });
+              setOverlayEvent({ event: "trap_trigger", key: Date.now(), trapName: trapDef.name });
               setCheckBreakAnim((prev) => (prev ? { ...prev, hitActive: true } : null));
-            }, 1600);
-            // T=3900: ゴーストを消し、駒フライト並行発火
-            window.setTimeout(() => {
-              // Issue #79: 駒フライト演出 SFX (王手崩し時)。
+            }, CHECK_OVERLAY_TOTAL_MS);
+            // T=CHECK_OVERLAY_TOTAL + TRAP_TRIGGER_OVERLAY_TOTAL: ゴースト消去 + 駒フライト発火。
+            // 完了は handleCheckBreakFlightComplete (全フライト着地で finalize+pop)。
+            scheduleTimer(() => {
               playSfx("piece_flight");
               setCheckBreakAnim((prev) => (prev ? { ...prev, ghosts: [], flights } : null));
-            }, 1600 + 2300);
-            break;
+            }, CHECK_OVERLAY_TOTAL_MS + TRAP_TRIGGER_OVERLAY_TOTAL_MS);
+            // 保険: フライトが 0 件 / onComplete 欠落でもロック解除 + pop する。
+            scheduleTimer(() => {
+              finalizeCheckBreak();
+              setCheckBreakAnim(null);
+              completeStep(step);
+            }, CHECK_BREAK_STEP_FALLBACK_MS);
+          } else {
+            // 既存トラップ (no_promote 等): 即時オーバーレイのみ。ロックなしのため
+            // 尺経過で pop する。
+            playSfx("trap_trigger");
+            setOverlayEvent({ event: "trap_trigger", key: Date.now(), trapName: trapDef.name });
+            scheduleTimer(() => completeStep(step), TRAP_TRIGGER_OVERLAY_TOTAL_MS);
           }
-          // 既存トラップ (no_promote 等): 即時オーバーレイ
-          playSfx("trap_trigger");
-          setOverlayEvent({
-            event: "trap_trigger",
-            key: Date.now(),
-            trapName: trapDef.name,
-          });
+          break;
+        }
+        case "draw": {
+          const ev = step.event;
+          const source = ev.source ?? "manual";
+          const isSelf = ev.player === playerColor;
+          if (isSelf) {
+            // Issue #79: 手動ドロー / 自動ドローを別 SFX に分離。中央到達
+            // (T=DRAW_FADE_IN_MS) でレア度別開封 SE。
+            playSfx(source === "auto" ? "card_auto_draw" : "card_draw");
+            const rarity = CARD_DEFS[ev.instance.defId].rarity;
+            scheduleTimer(() => playSfx(`draw_card_open_${rarity}` as never), DRAW_FADE_IN_MS);
+            setDrawFlightQueue((q) => [...q, { card: ev.instance, source, key: nextFlightKey() }]);
+          } else {
+            // 相手 (AI) ドローも同じ山札→中央→手札フライト (faceDown)。開封 SE は
+            // レア度非依存 (裏面で札を伏せるため耳でレア度が漏れないよう固定キー)。
+            playSfx(source === "auto" ? "card_auto_draw" : "card_draw");
+            scheduleTimer(() => playSfx("draw_card_open_common"), DRAW_FADE_IN_MS);
+            setOpponentDrawFlightQueue((q) => [...q, { card: ev.instance, source, key: nextFlightKey() }]);
+          }
+          if (source === "manual" && isSelf) {
+            triggerManaFlight(-DRAW_COST, getDeckRect());
+          }
+          if (source === "auto") {
+            // aria-live で自動ドローを通知 (連続発火時は最新のみ 1500ms 維持)。
+            if (liveMessageTimerRef.current !== null) {
+              window.clearTimeout(liveMessageTimerRef.current);
+              timersRef.current.delete(liveMessageTimerRef.current);
+            }
+            setAutoDrawLiveMessage("自動ドローしました");
+            liveMessageTimerRef.current = scheduleTimer(() => {
+              setAutoDrawLiveMessage("");
+              liveMessageTimerRef.current = null;
+            }, 1500);
+          }
+          // 完了は handleDrawFlightComplete / handleOpponentDrawFlightComplete
+          // (finalizeDraw + pop)。保険: onComplete 欠落でもロック解除 + pop する。
+          scheduleTimer(() => {
+            finalizeDraw();
+            completeStep(step);
+          }, DRAW_STEP_FALLBACK_MS);
           break;
         }
       }
-    }
+    },
+    [
+      playerColor,
+      aiColor,
+      playSfx,
+      triggerManaFlight,
+      getOriginRect,
+      getAiHandRect,
+      getDeckRect,
+      getBoardSquareRect,
+      findVisibleCapturedPieceRect,
+      scheduleTimer,
+      nextFlightKey,
+      finalizePlayCard,
+      finalizeDraw,
+      finalizeCheckBreak,
+      completeStep,
+    ],
+  );
+
+  // Issue #222: eventLog の差分を監視し、(1) 直列化しない軽量装飾 (マナ浮遊 /
+  // 早指しバッジ) を即時発火、(2) 大きな 4 演出を共通順序 (カード使用→王手→
+  // トラップ→ドロー) のステップ列に変換してキューへ積む。実際の演出起動は driver
+  // effect → activateStep が 1 件ずつ行う。
+  useEffect(() => {
+    if (!isReady) return;
+    const startIdx = lastEventIndexRef.current;
+    const newEvents = eventLog.slice(startIdx);
     lastEventIndexRef.current = eventLog.length;
-  }, [eventLog, isReady, playSfx, playerColor, triggerManaFlight, triggerFastMoveBadge, getDeckRect, getOriginRect, getAiHandRect, getBoardSquareRect, findVisibleCapturedPieceRect, scheduleTimer, nextFlightKey, finalizePlayCard, gameState]);
+    if (newEvents.length === 0) return;
+
+    // (1) 装飾: マナ浮遊 (ターン由来=移動先 / カード由来=カード位置) と早指しバッジ。
+    for (let i = 0; i < newEvents.length; i++) {
+      const ev = newEvents[i];
+      if (ev.kind !== "manaChargeEvent") continue;
+      if (ev.reason === "card") playSfx("mana_charge");
+      if (ev.reason === "turn") {
+        const absoluteIdx = startIdx + i;
+        let moveTo: { row: number; col: number } | null = null;
+        for (let j = absoluteIdx - 1; j >= 0; j--) {
+          const m = eventLog[j];
+          if (m.kind === "moveEvent" && m.move.player === ev.player) {
+            moveTo = m.move.to;
+            break;
+          }
+        }
+        const rect = moveTo ? getBoardSquareRect(moveTo.row, moveTo.col) : null;
+        triggerManaFlight(ev.amount, rect);
+        if (ev.fastMove) triggerFastMoveBadge(rect);
+      } else {
+        triggerManaFlight(ev.amount, getOriginRect());
+      }
+    }
+
+    // (2) 王手表示可否: バッチの手番主体 (actor) の相手玉が、適用後局面で王手かを
+    // 判定する。二手指し 1 手目の過渡状態 (movesLeft===1) は 2 手目で必ず解消される
+    // ため抑制する。詰みは終局演出を moveCount effect が担うためここでは出さない。
+    const actor = deriveBatchActor(newEvents);
+    let showCheck = false;
+    if (actor !== null && gameState.status === "active") {
+      const checkedSide: Player = actor === "sente" ? "gote" : "sente";
+      const inDoubleMoveMidway = doubleMove !== null && doubleMove.movesLeft === 1;
+      showCheck = !inDoubleMoveMidway && isInCheck(gameState, checkedSide, CARD_SHOGI_VARIANT);
+    }
+
+    const steps = deriveAnimationSteps(newEvents, { showCheck });
+    if (steps.length > 0) setAnimationQueue((q) => [...q, ...steps]);
+  }, [
+    eventLog,
+    isReady,
+    playSfx,
+    triggerManaFlight,
+    triggerFastMoveBadge,
+    getBoardSquareRect,
+    getOriginRect,
+    gameState,
+    doubleMove,
+  ]);
+
+  // Issue #222: 演出キューの driver。先頭 1 件のみを activate し、完了 (completeStep)
+  // で pop されると先頭が次ステップ (別 object) に変わり本 effect が次を activate する。
+  // activeStepRef で「同一先頭の二重 activate」を防ぐ (gameState 等の再レンダーで
+  // 再実行されても activate 済み先頭は再起動しない)。
+  useEffect(() => {
+    const head = animationQueue[0] ?? null;
+    if (!head) {
+      activeStepRef.current = null;
+      return;
+    }
+    if (activeStepRef.current === head) return;
+    activeStepRef.current = head;
+    activateStep(head);
+  }, [animationQueue, activateStep]);
 
   // Issue #78 / #82: 演出中(ドロー / カード使用 / 王手崩しトラップ)は盤面・手札・カード操作・背景クリックをロックする
   const handleSquareClick = useCallback(
@@ -1164,16 +1185,9 @@ export function CardShogiGame({
   const handlePieceFlightComplete = useCallback(() => {
     setPieceFlight(null);
 
-    const opponentColor: Player =
-      gameState.currentPlayer === "sente" ? "gote" : "sente";
-    if (
-      gameState.status === "active" &&
-      isInCheck(gameState, opponentColor, CARD_SHOGI_VARIANT)
-    ) {
-      playSfx("check");
-      setOverlayEvent({ event: "check", key: Date.now() });
-    }
-
+    // Issue #222: 王手演出は cardUse ステップの後続 check ステップが担うため、
+    // ここでは出さない (カード使用 → 王手 の順を共通化)。本ハンドラは cardUse
+    // ステップ内部の遷移 (駒フライト → 中央カード演出) なのでキューは pop しない。
     const pendingPlay = pendingPlayFlightRef.current;
     if (pendingPlay) {
       playFlightKeyRef.current += 1;
@@ -1189,15 +1203,20 @@ export function CardShogiGame({
       });
       pendingPlayFlightRef.current = null;
     } else {
-      // 中央カード演出が予約されていない異常系: 直接 finalize
+      // 中央カード演出が予約されていない異常系: 直接 finalize + キュー pop。
       finalizePlayCard();
+      const step = activeStepRef.current;
+      if (step) completeStep(step);
     }
-  }, [finalizePlayCard, gameState, playSfx]);
+  }, [finalizePlayCard, playSfx, completeStep]);
 
   const handlePlayFlightComplete = useCallback(() => {
     setPlayFlight(null);
     finalizePlayCard();
-  }, [finalizePlayCard]);
+    // Issue #222: cardUse ステップ完了 → キュー pop して次演出へ。
+    const step = activeStepRef.current;
+    if (step) completeStep(step);
+  }, [finalizePlayCard, completeStep]);
 
   // ドロー演出完了: queue から先頭を pop し、currentPlayer を相手に渡し、
   // 手札の対象カードを一瞬フラッシュさせる。
@@ -1244,7 +1263,10 @@ export function CardShogiGame({
         });
       });
     }
-  }, [currentDrawFlight, finalizeDraw, scheduleTimer, playSfx]);
+    // Issue #222: draw ステップ完了 → キュー pop して次演出へ。
+    const step = activeStepRef.current;
+    if (step) completeStep(step);
+  }, [currentDrawFlight, finalizeDraw, scheduleTimer, playSfx, completeStep]);
 
   // Issue #193 / card-apply: 相手 (AI) ドローフライト完了。queue 先頭を pop し、
   // finalizeDraw で COMMIT_DRAW (isDrawing 解除 + 手番交代) を実行。完了 SE は
@@ -1254,7 +1276,10 @@ export function CardShogiGame({
     setOpponentDrawFlightQueue((q) => q.slice(1));
     finalizeDraw();
     playSfx("card_to_hand");
-  }, [finalizeDraw, playSfx]);
+    // Issue #222: 相手ドローステップ完了 → キュー pop して次演出へ。
+    const step = activeStepRef.current;
+    if (step) completeStep(step);
+  }, [finalizeDraw, playSfx, completeStep]);
 
   // ----- レイアウト用ヘルパ -----
 
@@ -1330,13 +1355,15 @@ export function CardShogiGame({
       if (!prev) return null;
       const next = prev.pendingFlightCount - 1;
       if (next <= 0) {
-        // すべて完了 → finalize
+        // すべて完了 → finalize + Issue #222: trap ステップ完了でキュー pop。
         finalizeCheckBreak();
+        const step = activeStepRef.current;
+        if (step) completeStep(step);
         return null;
       }
       return { ...prev, pendingFlightCount: next };
     });
-  }, [finalizeCheckBreak]);
+  }, [finalizeCheckBreak, completeStep]);
 
   // 山札からのドロー可否 (Issue #82: pendingCard 中もドロー禁止に統一)
   // 二手指し中もドロー禁止 (Issue #82)

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -278,13 +278,19 @@ export function CardShogiGame({
   // ghosts: 王手中央表示+トラップ発動演出の間、reducer は既に駒を盤上から除去
   //   しているため、駒の元位置に「ゴースト駒」を絶対配置で重ね描きする。
   //   フライト開始時にクリア。
-  // hitActive: トラップ発動タイミング (T=1600) で true に切り替わり、
-  //   ゴースト駒に紫フラッシュ+シェイク+グローのヒット演出を付与する。
+  // hitActive: トラップ発動タイミングで true に切り替わり、ゴースト駒に紫フラッシュ
+  //   +シェイク+グローのヒット演出を付与する。
   // flights: 値ありになったらフライト開始。pendingFlightCount=0 で finalize。
+  // stagedFlights: Issue #222 修正 — ゴーストカバー (駒を消さないための覆い) は
+  //   捕獲された瞬間 (バッチ到着時 prepareCheckBreakCover) に設定し、実際の駒フライト
+  //   発火は trap ステップの最終フェーズまで保留する。そのため発火予定のフライト spec を
+  //   ここに退避しておき、フライトフェーズで flights へ移す。二手指し等でカード使用演出が
+  //   先行しても、その間ゴーストが駒を覆い続け「対象駒が一瞬消える」不具合を防ぐ。
   const [checkBreakAnim, setCheckBreakAnim] = useState<{
     ghosts: Array<{ rect: DOMRect; pieceType: string; owner: Player }>;
     hitActive: boolean;
     flights: PieceFlightSpec[];
+    stagedFlights: PieceFlightSpec[];
     flightKeyBase: number;
     hideTargets: FlightHideTarget[];
     pendingFlightCount: number;
@@ -671,6 +677,50 @@ export function CardShogiGame({
     setAnimationQueue((q) => (q[0] === step ? q.slice(1) : q));
   }, []);
 
+  // Issue #222 修正: 王手崩しの「ゴーストカバー」をバッチ到着時に即設定する。
+  // reducer は王手していた駒を捕獲して盤上から即削除するため、トラップ演出ステップまで
+  // ゴースト設定を遅らせると、その手前 (二手指しのカード使用演出など) の間だけ対象駒が
+  // 盤上から消えて見える。捕獲された瞬間にゴースト (元位置の駒) と持ち駒側の隠蔽を
+  // 設定し、駒を切れ目なく覆う。実際の駒フライト発火は trap ステップ最終フェーズで
+  // stagedFlights から行う。
+  const prepareCheckBreakCover = useCallback(
+    (ev: Extract<GameEvent, { kind: "trapTriggerEvent" }>) => {
+      const trapOwner = ev.player;
+      const captures = ev.capturedPieces ?? [];
+      const ghosts: Array<{ rect: DOMRect; pieceType: string; owner: Player }> = [];
+      const flights: PieceFlightSpec[] = [];
+      const hideTargets: FlightHideTarget[] = [];
+      for (const cap of captures) {
+        const fromRect = getBoardSquareRect(cap.row, cap.col);
+        const toRect = findVisibleCapturedPieceRect(trapOwner, cap.pieceType);
+        if (!fromRect) continue;
+        ghosts.push({
+          rect: fromRect,
+          pieceType: cap.originalPieceType,
+          owner: cap.originalOwner,
+        });
+        const fromX = fromRect.left + fromRect.width / 2;
+        const fromY = fromRect.top + fromRect.height / 2;
+        const toX = toRect ? toRect.left + toRect.width / 2 : fromX;
+        const toY = toRect ? toRect.top + toRect.height / 2 : fromY;
+        flights.push({ pieceType: cap.pieceType, owner: trapOwner, fromX, fromY, toX, toY });
+        hideTargets.push({ kind: "captured", player: trapOwner, pieceType: cap.pieceType });
+      }
+      pieceFlightKeyRef.current += captures.length;
+      const flightKeyBase = pieceFlightKeyRef.current - captures.length + 1;
+      setCheckBreakAnim({
+        ghosts,
+        hitActive: false,
+        flights: [], // フライト発火前は空。ゴーストのみ表示。
+        stagedFlights: flights, // trap ステップ最終フェーズで flights へ移す。
+        flightKeyBase,
+        hideTargets,
+        pendingFlightCount: flights.length,
+      });
+    },
+    [getBoardSquareRect, findVisibleCapturedPieceRect],
+  );
+
   // Issue #222: キュー先頭ステップを activate (実際の演出を起動) する。DOMRect
   // 解決・SFX・state 反映といった副作用はすべてここで行う (順序決定は純粋関数
   // deriveAnimationSteps が担う)。完了経路はステップ種別ごとに異なるが、いずれにも
@@ -804,45 +854,10 @@ export function CardShogiGame({
           const ev = step.event;
           const trapDef = CARD_DEFS[ev.instance.defId];
           // Issue #82 (王手崩し): 王手 → トラップ発動 → 駒フライト の3段演出。
+          // Issue #222 修正: ゴーストカバー (ghosts/hideTargets/stagedFlights) は
+          // バッチ到着時 prepareCheckBreakCover で設定済 (カード使用演出が先行しても
+          // その間 駒を覆い続ける)。本ステップは尺に沿った演出進行のみを担う。
           if (trapDef.id === "check_break" && ev.capturedPieces && ev.capturedPieces.length > 0) {
-            const trapOwner = ev.player;
-            const captures = ev.capturedPieces;
-            const ghosts: Array<{ rect: DOMRect; pieceType: string; owner: Player }> = [];
-            const flights: PieceFlightSpec[] = [];
-            const hideTargets: FlightHideTarget[] = [];
-            for (const cap of captures) {
-              const fromRect = getBoardSquareRect(cap.row, cap.col);
-              const toRect = findVisibleCapturedPieceRect(trapOwner, cap.pieceType);
-              if (!fromRect) continue;
-              ghosts.push({
-                rect: fromRect,
-                pieceType: cap.originalPieceType,
-                owner: cap.originalOwner,
-              });
-              const fromX = fromRect.left + fromRect.width / 2;
-              const fromY = fromRect.top + fromRect.height / 2;
-              const toX = toRect ? toRect.left + toRect.width / 2 : fromX;
-              const toY = toRect ? toRect.top + toRect.height / 2 : fromY;
-              flights.push({
-                pieceType: cap.pieceType,
-                owner: trapOwner,
-                fromX,
-                fromY,
-                toX,
-                toY,
-              });
-              hideTargets.push({ kind: "captured", player: trapOwner, pieceType: cap.pieceType });
-            }
-            pieceFlightKeyRef.current += captures.length;
-            const flightKeyBase = pieceFlightKeyRef.current - captures.length + 1;
-            setCheckBreakAnim({
-              ghosts,
-              hitActive: false,
-              flights: [], // フライト発火前は空配列。ゴーストのみ表示。
-              flightKeyBase,
-              hideTargets,
-              pendingFlightCount: flights.length,
-            });
             // T=0: 王手中央表示。
             playSfx("check");
             setOverlayEvent({ event: "check", key: Date.now() });
@@ -852,11 +867,14 @@ export function CardShogiGame({
               setOverlayEvent({ event: "trap_trigger", key: Date.now(), trapName: trapDef.name });
               setCheckBreakAnim((prev) => (prev ? { ...prev, hitActive: true } : null));
             }, CHECK_OVERLAY_TOTAL_MS);
-            // T=CHECK_OVERLAY_TOTAL + TRAP_TRIGGER_OVERLAY_TOTAL: ゴースト消去 + 駒フライト発火。
-            // 完了は handleCheckBreakFlightComplete (全フライト着地で finalize+pop)。
+            // T=CHECK_OVERLAY_TOTAL + TRAP_TRIGGER_OVERLAY_TOTAL: ゴースト消去 + 駒フライト発火
+            // (stagedFlights を flights へ移す)。完了は handleCheckBreakFlightComplete
+            // (全フライト着地で finalize+pop)。
             scheduleTimer(() => {
               playSfx("piece_flight");
-              setCheckBreakAnim((prev) => (prev ? { ...prev, ghosts: [], flights } : null));
+              setCheckBreakAnim((prev) =>
+                prev ? { ...prev, ghosts: [], flights: prev.stagedFlights } : null,
+              );
             }, CHECK_OVERLAY_TOTAL_MS + TRAP_TRIGGER_OVERLAY_TOTAL_MS);
             // 保険: フライトが 0 件 / onComplete 欠落でもロック解除 + pop する。
             scheduleTimer(() => {
@@ -969,7 +987,20 @@ export function CardShogiGame({
       }
     }
 
-    // (2) 王手表示可否: バッチの手番主体 (actor) の相手玉が、適用後局面で王手かを
+    // (2) 王手崩しのゴーストカバーをバッチ到着時に即設定する (Issue #222 修正)。
+    // 捕獲された駒が、後続のカード使用演出 (二手指し) の間に盤上から消えて見える
+    // 不具合を防ぐ。実際のトラップ演出進行は trap ステップが担う。
+    for (const ev of newEvents) {
+      if (
+        ev.kind === "trapTriggerEvent" &&
+        ev.instance.defId === "check_break" &&
+        (ev.capturedPieces?.length ?? 0) > 0
+      ) {
+        prepareCheckBreakCover(ev);
+      }
+    }
+
+    // (3) 王手表示可否: バッチの手番主体 (actor) の相手玉が、適用後局面で王手かを
     // 判定する。二手指し 1 手目の過渡状態 (movesLeft===1) は 2 手目で必ず解消される
     // ため抑制する。詰みは終局演出を moveCount effect が担うためここでは出さない。
     const actor = deriveBatchActor(newEvents);
@@ -990,6 +1021,7 @@ export function CardShogiGame({
     triggerFastMoveBadge,
     getBoardSquareRect,
     getOriginRect,
+    prepareCheckBreakCover,
     gameState,
     doubleMove,
   ]);

--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -951,6 +951,114 @@ describe("reducer / 二手指し × 王手崩し (Issue #220)", () => {
   });
 });
 
+// ===== 二手指し一手目が形式上詰みでも check_break は暴発しない (#222 検証修正) =====
+
+describe("reducer / 二手指し一手目が形式上詰みでも check_break 暴発しない (#222)", () => {
+  // gote 玉[0][0] を隅に追い込んだ詰み形。sente 金[2][1] が脱出マス [1][0]/[1][1] を、
+  // 二手指し一手目の 飛 [5][8]→[0][8] が行0 (王手) を抑える = トラップ未考慮なら「詰み」。
+  // ただし gote が check_break セット中なので真の詰みではない (トラップが飛を奪い解除する)。
+  function makeMateLikeFirstMoveState(withTrap: boolean): CardShogiGameStateInternal {
+    const gameState: GameState = {
+      ...createInitialGameState(CARD_SHOGI_VARIANT),
+      board: Array.from({ length: 9 }, () => Array(9).fill(null)),
+      hand: { sente: {}, gote: {} },
+      currentPlayer: "sente",
+    };
+    gameState.board[0][0] = { type: "king", owner: "gote" };
+    gameState.board[8][4] = { type: "king", owner: "sente" };
+    gameState.board[2][1] = { type: "gold", owner: "sente" };
+    gameState.board[5][8] = { type: "rook", owner: "sente" };
+    const cardState = makeInitialCardState({
+      trap: {
+        sente: null,
+        gote: withTrap
+          ? { instanceId: "trap-1", defId: "check_break", owner: "gote" }
+          : null,
+      },
+    });
+    const snapshot = {
+      gameState,
+      cardState,
+      eventLog: [] as GameEvent[],
+    };
+    return {
+      ...makeInitialState(gameState, cardState),
+      doubleMove: {
+        active: "sente",
+        movesLeft: 2,
+        mateInOneAvailable: false,
+        cardInstance: card("dm-1", "double_move"),
+        cardCost: 6,
+        preFirstMoveState: snapshot,
+        preCardState: snapshot,
+      },
+    };
+  }
+
+  // 一手目: 飛 [5][8]→[0][8]。行0 で gote 玉に王手 (トラップ未考慮なら詰み)。
+  const firstMoveMate = {
+    type: "move" as const,
+    player: "sente" as const,
+    piece: "rook",
+    from: { row: 5, col: 8 },
+    to: { row: 0, col: 8 },
+  };
+
+  it("一手目が形式上詰みでも check_break は発動せず、中間局面 active で二手指しが継続する", () => {
+    const next = reducer(makeMateLikeFirstMoveState(true), {
+      type: "MAKE_MOVE",
+      move: firstMoveMate,
+    });
+    // トラップ未発動 (隠し情報維持) / 飛は盤上に残り gote 持ち駒化されない
+    expect(next.cardState.trap.gote?.defId).toBe("check_break");
+    expect(next.isCheckBreakAnimating).toBe(false);
+    expect(next.eventLog.some((e) => e.kind === "trapTriggerEvent")).toBe(false);
+    expect(next.gameState.board[0][8]).toEqual({ type: "rook", owner: "sente" });
+    expect(next.gameState.hand.gote.rook).toBeUndefined();
+    // 偽の詰みで終局させず、中間局面 active として二手目を継続できる
+    expect(next.gameState.status).toBe("active");
+    expect(next.doubleMove?.movesLeft).toBe(1);
+    expect(next.gameState.currentPlayer).toBe("sente");
+  });
+
+  it("二手目完了後、最終局面で王手している駒が check_break の対象になる", () => {
+    const afterFirst = reducer(makeMateLikeFirstMoveState(true), {
+      type: "MAKE_MOVE",
+      move: firstMoveMate,
+    });
+    // 二手目: 王手している飛を [0][8]→[0][1] に寄せ、引き続き王手 (最終局面の王手駒)。
+    const secondMove = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "rook",
+      from: { row: 0, col: 8 },
+      to: { row: 0, col: 1 },
+    };
+    const next = reducer(afterFirst, { type: "MAKE_MOVE", move: secondMove });
+
+    // 最終局面の王手駒 (飛 [0][1]) が奪われる
+    expect(next.cardState.trap.gote).toBeNull();
+    expect(next.gameState.hand.gote.rook).toBe(1);
+    expect(next.isCheckBreakAnimating).toBe(true);
+    const trapEvent = next.eventLog.find((e) => e.kind === "trapTriggerEvent");
+    const cap =
+      trapEvent?.kind === "trapTriggerEvent" ? trapEvent.capturedPieces?.[0] : undefined;
+    // 一手目の位置 [0][8] ではなく、二手目後の最終位置 [0][1] の駒が対象
+    expect(cap?.row).toBe(0);
+    expect(cap?.col).toBe(1);
+    expect(next.doubleMove).toBeNull();
+  });
+
+  it("回帰: check_break トラップが無ければ一手目の詰みでそのまま終局する", () => {
+    const next = reducer(makeMateLikeFirstMoveState(false), {
+      type: "MAKE_MOVE",
+      move: firstMoveMate,
+    });
+    expect(next.gameState.status).toBe("checkmate");
+    expect(next.doubleMove).toBeNull();
+  });
+});
+
 // ===== 自動ドロー (#130) =====
 
 describe("reducer / 自動ドロー (#130)", () => {

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -320,24 +320,19 @@ function makeMoveWithEffects(
   let postTrapGameState = nextGameState;
   let triggeredCheckBreak = false;
   const opponentTrapPostMove = cardStateNext.trap[opponent];
-  // Issue #220: 二手指しの一手目 (double_move_first) は中間局面。トラップは
-  // ターン完了 (二手目 / 通常手) の最終局面で判定すべきで、中間で発動すると
-  // 相手トラップ種別が露見し、一手目キャンセルで戻せてしまう。よって
-  // double_move_first では原則スキップ (= 二手目 makeMoveWithEffects の最終
-  // 局面で判定 → ユーザー要望どおりターン完了後に発動)。
-  // 唯一の例外: 一手目だけで詰みが成立し二手指しがそこで終了する稀ケースは、
-  // ターンが事実上そこで終わるため発動を維持する (王手崩しは詰みを崩せる
-  // 必要があり、未発動で偽の詰み判定にしないため。MAKE_MOVE 1手目分岐の
-  // gameOver 経路と整合)。
-  const deferCheckBreak =
-    mode === "double_move_first" &&
-    evaluateGameEnd(nextGameState, CARD_SHOGI_VARIANT).status === "active";
-  if (
-    !deferCheckBreak &&
-    opponentTrapPostMove &&
+  // この手の結果、相手の check_break トラップが発動条件 (相手玉が王手中) を満たすか。
+  const wouldTriggerCheckBreak =
+    !!opponentTrapPostMove &&
     opponentTrapPostMove.defId === "check_break" &&
-    isInCheck(nextGameState, opponent, CARD_SHOGI_VARIANT)
-  ) {
+    isInCheck(nextGameState, opponent, CARD_SHOGI_VARIANT);
+  // Issue #220 / #222 検証修正: 二手指しの一手目 (double_move_first) は中間局面。
+  // トラップはターン完了 (二手目) の最終局面でのみ発動すべきで、一手目では常に保留する。
+  // 旧実装は「一手目が (トラップ未考慮の盤面で) 詰みなら例外的に発動」していたが、
+  // check_break トラップがセットされている限り真の詰みは成立しない (トラップが王手駒を
+  // 奪い王手を解除するため)。よって一手目発動は誤りで、二手目を指す前にトラップが暴発し、
+  // 最終局面で王手している駒ではなく一手目の駒が奪われる不具合になっていた (検証で判明)。
+  const deferCheckBreak = mode === "double_move_first";
+  if (!deferCheckBreak && wouldTriggerCheckBreak) {
     const result = applyCheckBreak(nextGameState, opponent);
     if (result) {
       postTrapGameState = result.gameState;
@@ -365,6 +360,13 @@ function makeMoveWithEffects(
 
   // 5. ゲーム終了判定 + 移動イベントログ
   const evaluated = evaluateGameEnd(postTrapGameState, CARD_SHOGI_VARIANT);
+  // Issue #220 / #222 検証修正: 二手指し一手目で check_break を保留した場合、形式上の
+  // 詰み (トラップ未適用の盤面) は真の終局ではない (ターン完了後にトラップが王手を解除
+  // する)。中間局面として active を維持し二手目を継続させる。これがないと MAKE_MOVE 側
+  // gameOver 判定が偽の詰みで二手指しを打ち切り、二手目を指せなくなる。
+  // (nextGameState は applyMove 直後で status="active"。evaluateGameEnd を通す前の値。)
+  const resultGameState =
+    deferCheckBreak && wouldTriggerCheckBreak ? nextGameState : evaluated;
   events.push({ kind: "moveEvent", move: finalMove, at: Date.now() });
 
   // 6. マナチャージ + lastTurnStartedAt クリア (mode で挙動を切替)
@@ -415,7 +417,7 @@ function makeMoveWithEffects(
   // mode === "double_move_first": どちらもしない (ターン継続中のため)
 
   return {
-    gameState: evaluated,
+    gameState: resultGameState,
     cardState: cardStateNext,
     events,
     finalMove,


### PR DESCRIPTION
## Summary
カード将棋で「カード使用 / 王手 / トラップ発動 / 山札ドロー」の大きな演出が eventLog から即時・並行発火して重なり、何が起きているか分かりにくかった問題を、共通順序 **「カード使用 → 王手 → トラップ → ドロー」** で 1 つずつ完了を待って再生する直列オーケストレータに集約した (Issue #222)。

### 変更の柱
- **純粋関数 `deriveAnimationSteps`** (新規): イベント列を共通順序の演出ステップ列へ並べ替える。順序決定のみを担い、ユニットテストで品質担保 (ai-action-bridge.ts と同方針)。
- **キュー駆動オーケストレータ** (`card-shogi-game.tsx`): 先頭 1 件のみ activate し、完了で pop → 次へ。王手判定を従来 4 箇所分散から `showCheck` に一元化。各ステップに保険タイマー + 冪等 `completeStep`/`COMMIT_*` で手番永久ロック (#217 系) を防止。
- **尺最適化 + 定数集約**: 王手/トラップ発動オーバーレイ尺を `animation-constants.ts` に集約し `board-overlay.tsx` と共有 (単一情報源)。直列化のテンポ悪化を抑えるため王手 1600→1100ms / トラップ 2300→2000ms に短縮 (CSS アニメの下限は維持)。

### 派生で発見・対応した内容 (AGENTS.md ルール2)
動作検証中に見つかった王手崩し関連の 2 件を本ブランチに同居 (ユーザー承認済み):
1. **演出**: 二手指し+王手崩しで、カード使用演出の間だけ捕獲対象駒が盤上から消える不具合。ゴーストカバーを捕獲発生時 (バッチ到着時) に即設定するよう修正。
2. **reducer ロジック (#220 関連)**: 二手指し一手目を「(王手崩し無視で) 王手兼詰み」にすると一手目時点で王手崩しが暴発し一手目の駒が奪われる不具合。`deferCheckBreak` の「一手目詰みなら例外発動」分岐を撤廃し、一手目は常に保留 + 中間局面 `active` 維持で二手目を継続 → 最終局面の王手駒のみ対象になるよう修正。

## Test plan
- `npm run lint`: 0 errors (警告は既存ベースラインのみ、旧 eventLog 効果の aiColor 警告は解消)
- `npm run typecheck`: 既知の @testing-library 2 件のみ (本変更起因の新規エラーなし)
- `npm run test:ci`: 423 passed / 6 skipped (新規 18 件追加: deriveAnimationSteps 15 + reducer 3。失敗 2 ファイルは既知の環境問題)
- `npm run build`: Compiled successfully
- Vercel プレビューで実機検証: 4 演出の直列再生 / 二手指し+王手崩し+自動ドローの順序 / カード使用中も対象駒が消えない / 二手指し一手目で暴発しない / 手番が固まらない / 観戦モード — すべてユーザー確認済み

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
