### PR TITLE
fix: #226 観戦(CPU対CPU)のもう1局がユーザ対CPUになるバグを修正

### DIFF
--- a/src/app/spectate/page.tsx
+++ b/src/app/spectate/page.tsx
@@ -73,7 +73,10 @@ export default function SpectatePage() {
   // AI 自動応手 useEffect が両プレイヤー (gameState.currentPlayer) を駆動する。
   if (game) {
     return (
+      // Issue #226: gameId を key にして「もう1局」時 (game 差替え) に CardShogiGame を
+      // 再マウントし、useCardShogiGame の初期 state を新しい揮発ゲームで作り直す。
       <CardShogiGame
+        key={game.gameId}
         initialGameState={game.initialState}
         initialCardState={game.initialCardState}
         gameId={game.gameId}
@@ -87,6 +90,11 @@ export default function SpectatePage() {
           spectatorMode: true,
           difficultyB: characterB.difficulty,
           characterIdB: characterIdB,
+        }}
+        // Issue #226: 観戦の「もう1局」は同じ2キャラの CPU 対 CPU を揮発再生成する
+        // (handleStart と同一処理。DB リマッチではなくページ内で新ゲームに差替え)。
+        onSpectatorRematch={() => {
+          void handleStart();
         }}
       />
     );

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -107,6 +107,11 @@ interface CardShogiGameProps {
   // Issue #79 (PR 1.7): dev page 等で BGM を抑止したい時に false。
   // default true: 通常対局画面では gameState.status から bgm_game / bgm_game_over を再生
   enableBgm?: boolean;
+  // Issue #226: 観戦 (CPU vs CPU) モードの「もう1局」コールバック。観戦は揮発生成
+  // (createSpectatorGameState) でページ内描画されるため、通常対局の DB リマッチ
+  // (createGame → /game/[id] 遷移) ではなく、本コールバックで親 (/spectate) に
+  // 新しい揮発ゲームの再生成を委譲する。未指定 (通常対局) 時は従来の DB リマッチ。
+  onSpectatorRematch?: () => void;
 }
 
 function shouldPlayJumpSfx(move: Move): boolean {
@@ -157,6 +162,7 @@ export function CardShogiGame({
   debugInitialUi,
   debugDisableServerEffects = false,
   enableBgm = true,
+  onSpectatorRematch,
 }: CardShogiGameProps) {
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
@@ -340,13 +346,29 @@ export function CardShogiGame({
   const handlePlayAgain = useCallback(() => {
     // Issue #79 派生: forward 遷移 SFX (新規対局画面へ router.push する forward 系)
     playSfx("nav_forward");
+    // Issue #226: 観戦 (CPU vs CPU) は揮発生成・ページ内描画のため、通常対局の DB
+    // リマッチ (createGame → /game/[id] 遷移) を使うと「ユーザ対 CPU」になってしまう。
+    // 観戦時は親 (/spectate) の揮発再生成コールバックに委譲し、同じ 2 キャラの CPU 対
+    // CPU を再開する (キャラ・難易度は gameConfig 経由で維持)。
+    if (spectatorMode && onSpectatorRematch) {
+      onSpectatorRematch();
+      return;
+    }
     void rematch({
       difficulty: gameConfig.difficulty,
       playerColor: gameConfig.playerColor,
       characterId: gameConfig.characterId,
       variantId: "card-shogi",
     });
-  }, [gameConfig.difficulty, gameConfig.playerColor, gameConfig.characterId, rematch, playSfx]);
+  }, [
+    spectatorMode,
+    onSpectatorRematch,
+    gameConfig.difficulty,
+    gameConfig.playerColor,
+    gameConfig.characterId,
+    rematch,
+    playSfx,
+  ]);
 
   const handleComment = useCallback((event: string) => {
     setCommentEvent(event as CommentaryEvent);


### PR DESCRIPTION
## Summary
CPU vs CPU 観戦で詰み後「もう1局」を押すと、CPU 同士でなくユーザ対 CPU の通常対局が始まるバグを修正。

原因: 観戦は `createSpectatorGameState` で揮発生成 (DB なし)・/spectate ページ内描画されるのに対し、`handlePlayAgain` が `rematch()` → `/api/create-game` → `createGame` (DB=ユーザ対CPU) → `/game/[id]` 遷移という別経路を呼び、`spectatorMode` を引き継がなかったため。

### 変更
- `CardShogiGame` に `onSpectatorRematch` コールバック prop を追加。`spectatorMode` かつ本コールバックがある場合、`handlePlayAgain` は DB リマッチではなくコールバックを呼ぶ。
- /spectate ページが `onSpectatorRematch` で `handleStart` (`createSpectatorGameState` + `setGame`) を再実行し、同じ 2 キャラ (gameConfig 経由) の CPU 対 CPU を揮発再生成。`CardShogiGame` に `key={game.gameId}` を付与し、新 gameId で再マウントして初期 state を作り直す。
- 通常対局 (ユーザ対 CPU) のもう1局は従来の DB リマッチ経路のまま影響なし。

## Test plan
- `npm run lint`: 0 errors
- `npm run typecheck`: 既知の @testing-library 2件のみ
- `npm run test:ci`: 434 passed / 6 skipped
- `npm run build`: Compiled successfully
- Vercel 実機: 観戦の「もう1局」が CPU 対 CPU で再開 (同キャラ維持)・通常対局のもう1局は従来通り をユーザー確認済み

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
