### PR TITLE
feat: #225 詰み時に玉へ赤い斬撃演出を追加 (両variant・永続表示)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -317,6 +317,34 @@
   animation: ghost-slash 1.5s ease-out forwards;
 }
 
+/* Issue #225: 詰み時、負けた側の玉への被弾フラッシュ。王手崩しの ghost-trap-hit と
+ * 異なり (1) 紫でなく赤系 (詰めの決着色) (2) インパクト後は通常状態へ戻し持続グローを
+ * 残さない (残すのは赤い斬撃のみ)。0-280ms で衝撃 + 振動 → 100% で完全に通常へ。 */
+@keyframes checkmate-king-hit {
+  0%   { filter: brightness(1); transform: rotate(0deg) scale(1); }
+  7%   { filter: drop-shadow(0 0 24px rgba(239, 68, 68, 0.95)) brightness(1.6); transform: rotate(-5deg) scale(1.1); }
+  14%  { filter: drop-shadow(0 0 20px rgba(239, 68, 68, 0.9)) brightness(1.4); transform: rotate(4deg) scale(1.07); }
+  28%  { filter: drop-shadow(0 0 12px rgba(239, 68, 68, 0.6)) brightness(1.2); transform: rotate(-2deg) scale(1.03); }
+  100% { filter: brightness(1); transform: rotate(0deg) scale(1); }
+}
+.checkmate-king-hit {
+  animation: checkmate-king-hit 0.8s ease-out forwards;
+}
+
+/* Issue #225: 詰み時の赤い斬撃。王手崩しの ghost-slash と異なり、描画後フェード
+ * させず opacity 1 のまま残し続ける (玉に斬られた跡を永続表示)。0-120ms で
+ * 右上→左下に高速描画 → 以降は赤グローを保ったまま静止。 */
+@keyframes ghost-slash-draw-persist {
+  0%   { stroke-dasharray: 0 200; opacity: 1; filter: drop-shadow(0 0 14px rgba(239, 68, 68, 1)) brightness(1.4); }
+  8%   { stroke-dasharray: 200 0; opacity: 1; filter: drop-shadow(0 0 14px rgba(239, 68, 68, 1)) brightness(1.4); }
+  30%  { stroke-dasharray: 200 0; opacity: 1; filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.85)) brightness(1.1); }
+  100% { stroke-dasharray: 200 0; opacity: 1; filter: drop-shadow(0 0 6px rgba(239, 68, 68, 0.75)); }
+}
+.ghost-slash-line-persist {
+  stroke-dasharray: 0 200;
+  animation: ghost-slash-draw-persist 0.6s ease-out forwards;
+}
+
 /* カード将棋: ドロー演出完了時に手札の対象カードがふわっと光る (Issue #78) */
 @keyframes hand-card-flash {
   0%   { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -21,6 +21,7 @@ import { CardShogiHistory } from "./card-shogi-history";
 import { GameControls, GAME_CONTROLS_HEIGHT } from "../game-controls";
 import { PromotionDialog } from "../promotion-dialog";
 import { BoardOverlay, type OverlayEvent } from "../board-overlay";
+import { KingSlashOverlay } from "../king-slash-overlay";
 import { AiErrorModal } from "../ai-error-modal";
 import { RematchErrorBanner } from "../rematch-error-banner";
 import { CharacterPanel } from "@/components/character/character-panel";
@@ -43,7 +44,7 @@ import { getShogiBoardCellSize } from "@/lib/shogi/board-layout";
 
 import { getCharacterById } from "@/data/characters";
 import { gameResultText } from "@/lib/shogi/notation";
-import { isInCheck } from "@/lib/shogi/moves";
+import { isInCheck, findKing } from "@/lib/shogi/moves";
 import { unpromotePieceType } from "@/lib/shogi/variants/standard";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import { getVariantById } from "@/lib/shogi/variants/index";
@@ -160,6 +161,12 @@ export function CardShogiGame({
 }: CardShogiGameProps) {
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
+  // Issue #225: 詰み時の玉への赤い斬撃演出 (負けた側の玉マスに重ねる)。null で非表示。
+  const [kingSlash, setKingSlash] = useState<{
+    rect: DOMRect;
+    owner: Player;
+    key: number;
+  } | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(() => Boolean(debugInitialUi?.drawerOpen));
   // Step S4 (Issue #107): モバイル/タブレットの終了カードを最小化できるように
   // する。閉じると盤面・持ち駒が見え、再度展開して「もう一局」「ホームへ」を
@@ -509,6 +516,16 @@ export function CardShogiGame({
       // Issue #79 で王手 SFX (check) と分離した専用 checkmate SFX を 1000ms 後に再生。
       setTimeout(() => playSfx("checkmate"), 1000);
       setTimeout(() => setOverlayEvent({ event: "checkmate", key: Date.now() }), 1000);
+      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を重ねる
+      // (王手崩しと同じ ghost-trap-hit + ghost-slash)。
+      const loser: Player = gameState.winner === "sente" ? "gote" : "sente";
+      setTimeout(() => {
+        const kingPos = findKing(gameState.board, loser, CARD_SHOGI_VARIANT.boardSize);
+        const rect = kingPos ? getBoardSquareRect(kingPos.row, kingPos.col) : null;
+        if (rect) setKingSlash({ rect, owner: loser, key: Date.now() });
+      }, 1000);
+      // 斬撃尺 (ghost-slash 1.5s) 経過後にクリアし、下の実盤の玉表示へ戻す。
+      setTimeout(() => setKingSlash(null), 2700);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameState.moveCount]);
@@ -2365,6 +2382,14 @@ export function CardShogiGame({
           </div>,
           document.body,
         )}
+
+      {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (王手崩しと同じ見た目) を重ねる */}
+      <KingSlashOverlay
+        rect={kingSlash?.rect ?? null}
+        kingOwner={kingSlash?.owner ?? null}
+        playerColor={playerColor}
+        animationKey={kingSlash?.key ?? 0}
+      />
 
       {/* Issue #77: マナ加減算の浮遊テキスト (起点 UI 付近に表示) */}
       <ManaFlightLayer items={manaFlights} onComplete={removeManaFlight} />

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -162,8 +162,9 @@ export function CardShogiGame({
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number; trapName?: string } | null>(null);
   // Issue #225: 詰み時の玉への赤い斬撃演出 (負けた側の玉マスに重ねる)。null で非表示。
+  // pos を保持し、矩形算出と resize 追従は KingSlashOverlay 側に委譲する (永続表示のため)。
   const [kingSlash, setKingSlash] = useState<{
-    rect: DOMRect;
+    pos: Position;
     owner: Player;
     key: number;
   } | null>(null);
@@ -516,16 +517,16 @@ export function CardShogiGame({
       // Issue #79 で王手 SFX (check) と分離した専用 checkmate SFX を 1000ms 後に再生。
       setTimeout(() => playSfx("checkmate"), 1000);
       setTimeout(() => setOverlayEvent({ event: "checkmate", key: Date.now() }), 1000);
-      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を重ねる
-      // (王手崩しと同じ ghost-trap-hit + ghost-slash)。
+      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を発火。
+      // 斬撃は演出後もフェードさせず永続表示する (クリアしない)。対局再開・離脱で解消。
       const loser: Player = gameState.winner === "sente" ? "gote" : "sente";
-      setTimeout(() => {
-        const kingPos = findKing(gameState.board, loser, CARD_SHOGI_VARIANT.boardSize);
-        const rect = kingPos ? getBoardSquareRect(kingPos.row, kingPos.col) : null;
-        if (rect) setKingSlash({ rect, owner: loser, key: Date.now() });
-      }, 1000);
-      // 斬撃尺 (ghost-slash 1.5s) 経過後にクリアし、下の実盤の玉表示へ戻す。
-      setTimeout(() => setKingSlash(null), 2700);
+      const kingPos = findKing(gameState.board, loser, CARD_SHOGI_VARIANT.boardSize);
+      if (kingPos) {
+        setTimeout(
+          () => setKingSlash({ pos: kingPos, owner: loser, key: Date.now() }),
+          1000,
+        );
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameState.moveCount]);
@@ -2383,11 +2384,12 @@ export function CardShogiGame({
           document.body,
         )}
 
-      {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (王手崩しと同じ見た目) を重ねる */}
+      {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (永続) を重ねる */}
       <KingSlashOverlay
-        rect={kingSlash?.rect ?? null}
+        kingPos={kingSlash?.pos ?? null}
         kingOwner={kingSlash?.owner ?? null}
         playerColor={playerColor}
+        getSquareRect={getBoardSquareRect}
         animationKey={kingSlash?.key ?? 0}
       />
 

--- a/src/components/game/king-slash-overlay.tsx
+++ b/src/components/game/king-slash-overlay.tsx
@@ -1,37 +1,61 @@
 "use client";
 
 // Issue #225: 詰み時、負けた側の玉へ「赤い斜線で斬られた」斬撃演出を重ねる共通
-// コンポーネント。王手崩し (#82) のゴースト被弾演出 (animate-ghost-trap-hit +
-// ghost-slash-line) と同じ見た目を、玉のマス上に重ねて再現する。
+// コンポーネント。王手崩し (#82) のゴースト被弾演出と同系統の見た目を玉マス上に重ねる。
 //
-// 詰み時は玉が盤上に残っているため、本オーバーレイは玉駒のコピーを玉マスに重ね描き
-// し、被弾フラッシュ + 赤い斬撃を走らせる (実盤の玉は ShogiBoard 内にあり外部から
-// アニメ付与できないため、上に同じ玉を重ねて演出する)。演出尺経過後は親が rect=null
-// にしてアンマウントし、下の実盤の玉が見える状態へ戻る。
+// 演出仕様 (検証フィードバック反映):
+// - 玉駒のコピーに被弾フラッシュ (checkmate-king-hit) を一度だけ走らせ、インパクト後は
+//   通常状態へ戻す (王手崩しのような持続グローは残さない)。
+// - 赤い斬撃 (ghost-slash-line-persist) は描画後フェードさせず opacity 1 のまま **永続表示**
+//   する (詰みの「斬られた跡」をずっと残す)。親は本オーバーレイをクリアせず、対局が
+//   再開・離脱するまで保持する。
+// - 永続表示のため、kingPos と getSquareRect から rect を算出し resize に追従する
+//   (モバイル回転等で盤レイアウトが変わっても玉マスへ追従)。
 //
 // 標準将棋 (shogi-game.tsx) ・カード将棋 (card-shogi-game.tsx) の両方で共用する。
 
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { ShogiPiece } from "./shogi-piece";
-import type { Player } from "@/lib/shogi/types";
+import type { Player, Position } from "@/lib/shogi/types";
 
 interface KingSlashOverlayProps {
-  // 詰んだ玉のマスの DOMRect。null で非表示 (アンマウント)。
-  rect: DOMRect | null;
+  // 詰んだ玉のマス。null で非表示。
+  kingPos: Position | null;
   // 負けた側 (斬られる玉の所有者)。
   kingOwner: Player | null;
   // 盤の向き (視点)。相手側の玉は ShogiPiece が回転表示する。
   playerColor: Player;
-  // 再発火用キー。もう1局等で同一参照を避け CSS アニメを再走させる。
+  // 玉マスの DOMRect を返す盤の getter (安定参照=useCallback 推奨)。
+  getSquareRect: (row: number, col: number) => DOMRect | null;
+  // 再発火用キー。もう1局等で同一参照を避け被弾フラッシュ + 斬撃描画を再走させる。
   animationKey: number;
 }
 
 export function KingSlashOverlay({
-  rect,
+  kingPos,
   kingOwner,
   playerColor,
+  getSquareRect,
   animationKey,
 }: KingSlashOverlayProps) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  // kingPos から rect を算出し resize に追従 (永続表示のためレイアウト変化へ対応)。
+  // 盤描画後に取得するため次フレームで計算する。全ての setRect を rAF / resize
+  // コールバック経由にし、effect 本体での同期 setState (cascading renders) を避ける。
+  // kingPos が null のときは rect=null で非表示。
+  useEffect(() => {
+    const compute = () =>
+      setRect(kingPos ? getSquareRect(kingPos.row, kingPos.col) : null);
+    const raf = requestAnimationFrame(compute);
+    window.addEventListener("resize", compute);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", compute);
+    };
+  }, [kingPos, getSquareRect]);
+
   if (!rect || !kingOwner || typeof document === "undefined") return null;
 
   return createPortal(
@@ -39,8 +63,10 @@ export function KingSlashOverlay({
     // 中央オーバーレイ (z-10、「詰み」表示) より下。玉マス上の局所演出。
     <div className="fixed inset-0 pointer-events-none z-[8]">
       <div
+        // animationKey 変化時のみ remount し被弾フラッシュ + 斬撃描画を再走。
+        // resize 時 (rect のみ変化) は同 key のため再描画のみで再アニメしない (跡を維持)。
         key={animationKey}
-        className="animate-ghost-trap-hit"
+        className="checkmate-king-hit"
         style={{
           position: "fixed",
           left: rect.left,
@@ -55,7 +81,7 @@ export function KingSlashOverlay({
           playerColor={playerColor}
           squareSize={rect.width}
         />
-        {/* 赤い斬撃 (右上→左下)。王手崩しと同じ ghost-slash アニメーション。 */}
+        {/* 赤い斬撃 (右上→左下)。描画後フェードせず opacity 1 のまま永続表示。 */}
         <svg
           viewBox={`0 0 ${rect.width} ${rect.height}`}
           preserveAspectRatio="none"
@@ -70,7 +96,7 @@ export function KingSlashOverlay({
             stroke="#ef4444"
             strokeWidth={Math.max(3, Math.min(5, rect.width * 0.12))}
             strokeLinecap="round"
-            className="ghost-slash-line"
+            className="ghost-slash-line-persist"
           />
         </svg>
       </div>

--- a/src/components/game/king-slash-overlay.tsx
+++ b/src/components/game/king-slash-overlay.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// Issue #225: 詰み時、負けた側の玉へ「赤い斜線で斬られた」斬撃演出を重ねる共通
+// コンポーネント。王手崩し (#82) のゴースト被弾演出 (animate-ghost-trap-hit +
+// ghost-slash-line) と同じ見た目を、玉のマス上に重ねて再現する。
+//
+// 詰み時は玉が盤上に残っているため、本オーバーレイは玉駒のコピーを玉マスに重ね描き
+// し、被弾フラッシュ + 赤い斬撃を走らせる (実盤の玉は ShogiBoard 内にあり外部から
+// アニメ付与できないため、上に同じ玉を重ねて演出する)。演出尺経過後は親が rect=null
+// にしてアンマウントし、下の実盤の玉が見える状態へ戻る。
+//
+// 標準将棋 (shogi-game.tsx) ・カード将棋 (card-shogi-game.tsx) の両方で共用する。
+
+import { createPortal } from "react-dom";
+import { ShogiPiece } from "./shogi-piece";
+import type { Player } from "@/lib/shogi/types";
+
+interface KingSlashOverlayProps {
+  // 詰んだ玉のマスの DOMRect。null で非表示 (アンマウント)。
+  rect: DOMRect | null;
+  // 負けた側 (斬られる玉の所有者)。
+  kingOwner: Player | null;
+  // 盤の向き (視点)。相手側の玉は ShogiPiece が回転表示する。
+  playerColor: Player;
+  // 再発火用キー。もう1局等で同一参照を避け CSS アニメを再走させる。
+  animationKey: number;
+}
+
+export function KingSlashOverlay({
+  rect,
+  kingOwner,
+  playerColor,
+  animationKey,
+}: KingSlashOverlayProps) {
+  if (!rect || !kingOwner || typeof document === "undefined") return null;
+
+  return createPortal(
+    // z-[8]: ShogiBoard 本体 (z-auto/0) ・王手崩しゴースト (z-[5]) より上、
+    // 中央オーバーレイ (z-10、「詰み」表示) より下。玉マス上の局所演出。
+    <div className="fixed inset-0 pointer-events-none z-[8]">
+      <div
+        key={animationKey}
+        className="animate-ghost-trap-hit"
+        style={{
+          position: "fixed",
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+          transformOrigin: "center center",
+        }}
+      >
+        <ShogiPiece
+          piece={{ type: "king", owner: kingOwner }}
+          playerColor={playerColor}
+          squareSize={rect.width}
+        />
+        {/* 赤い斬撃 (右上→左下)。王手崩しと同じ ghost-slash アニメーション。 */}
+        <svg
+          viewBox={`0 0 ${rect.width} ${rect.height}`}
+          preserveAspectRatio="none"
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          aria-hidden
+        >
+          <line
+            x1={rect.width}
+            y1="0"
+            x2="0"
+            y2={rect.height}
+            stroke="#ef4444"
+            strokeWidth={Math.max(3, Math.min(5, rect.width * 0.12))}
+            strokeLinecap="round"
+            className="ghost-slash-line"
+          />
+        </svg>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -5,7 +5,8 @@ import { useShogiGame } from "@/hooks/use-shogi-game";
 import { useSound } from "@/hooks/use-sound";
 import { useBgm } from "@/hooks/use-bgm";
 import { useBoardSize } from "@/hooks/use-board-size";
-import { ShogiBoard } from "./shogi-board";
+import { ShogiBoard, type ShogiBoardHandle } from "./shogi-board";
+import { KingSlashOverlay } from "./king-slash-overlay";
 import { CapturedPieces } from "./captured-pieces";
 import { MoveHistory } from "./move-history";
 import { GameControls } from "./game-controls";
@@ -23,7 +24,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { getCharacterById } from "@/data/characters";
 import { gameResultText } from "@/lib/shogi/notation";
-import { isInCheck } from "@/lib/shogi/moves";
+import { isInCheck, findKing } from "@/lib/shogi/moves";
 import { STANDARD_VARIANT } from "@/lib/shogi/variants/standard";
 import { getVariantById } from "@/lib/shogi/variants/index";
 import type { GameConfig, GameState, Difficulty, Move, Player } from "@/lib/shogi/types";
@@ -63,6 +64,14 @@ function shouldPlayJumpSfx(move: Move): boolean {
 export function ShogiGame({ initialGameState, gameId, gameConfig: serializableConfig }: ShogiGameProps) {
   const [commentEvent, setCommentEvent] = useState<CommentaryEvent | null>(null);
   const [overlayEvent, setOverlayEvent] = useState<{ event: OverlayEvent; key: number } | null>(null);
+  // Issue #225: 盤マス矩形取得用 ref (詰み時に玉マスへ斬撃演出を重ねるため)。
+  const boardRef = useRef<ShogiBoardHandle>(null);
+  // Issue #225: 詰み時の玉への赤い斬撃演出 (負けた側の玉マスに重ねる)。null で非表示。
+  const [kingSlash, setKingSlash] = useState<{
+    rect: DOMRect;
+    owner: Player;
+    key: number;
+  } | null>(null);
   // Issue #217: 旧 startTransition(async) は createGame 失敗時に永久ハング
   // していた。明示的 loading/error state を持つ共通フックに置換 (router.push は
   // フック内部で行うため本コンポーネントの useRouter は不要になった)。
@@ -188,6 +197,17 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
     if (gameState.status === "checkmate") {
       setTimeout(() => playSfx("checkmate"), 1000);
       setTimeout(() => setOverlayEvent({ event: "checkmate", key: Date.now() }), 1000);
+      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を重ねる。
+      const loser: Player = gameState.winner === "sente" ? "gote" : "sente";
+      setTimeout(() => {
+        const kingPos = findKing(gameState.board, loser, STANDARD_VARIANT.boardSize);
+        const rect = kingPos
+          ? boardRef.current?.getSquareRect(kingPos.row, kingPos.col) ?? null
+          : null;
+        if (rect) setKingSlash({ rect, owner: loser, key: Date.now() });
+      }, 1000);
+      // 斬撃尺 (ghost-slash 1.5s) 経過後にクリアし、下の実盤の玉表示へ戻す。
+      setTimeout(() => setKingSlash(null), 2700);
     }
   }, [gameState.moveCount]);
 
@@ -269,6 +289,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
           {/* 将棋盤 */}
           <div className="relative shrink-0 my-0.5">
             <ShogiBoard
+              ref={boardRef}
               board={gameState.board}
               currentPlayer={gameState.currentPlayer}
               playerColor={playerColor}
@@ -282,6 +303,13 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
               isMobile={isMobile}
             />
             <BoardOverlay key={overlayEvent?.key} event={overlayEvent?.event ?? null} />
+            {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出を重ねる */}
+            <KingSlashOverlay
+              rect={kingSlash?.rect ?? null}
+              kingOwner={kingSlash?.owner ?? null}
+              playerColor={playerColor}
+              animationKey={kingSlash?.key ?? 0}
+            />
           </div>
 
           {/* 先手（プレイヤー）の持ち駒 */}

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -27,7 +27,7 @@ import { gameResultText } from "@/lib/shogi/notation";
 import { isInCheck, findKing } from "@/lib/shogi/moves";
 import { STANDARD_VARIANT } from "@/lib/shogi/variants/standard";
 import { getVariantById } from "@/lib/shogi/variants/index";
-import type { GameConfig, GameState, Difficulty, Move, Player } from "@/lib/shogi/types";
+import type { GameConfig, GameState, Difficulty, Move, Player, Position } from "@/lib/shogi/types";
 import type { CommentaryEvent } from "@/app/actions/commentary";
 import { LoadingOverlay } from "@/components/loading-overlay";
 import { MaskedLink } from "@/components/navigation/masked-link";
@@ -67,11 +67,18 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
   // Issue #225: 盤マス矩形取得用 ref (詰み時に玉マスへ斬撃演出を重ねるため)。
   const boardRef = useRef<ShogiBoardHandle>(null);
   // Issue #225: 詰み時の玉への赤い斬撃演出 (負けた側の玉マスに重ねる)。null で非表示。
+  // pos を保持し、矩形算出と resize 追従は KingSlashOverlay 側に委譲する (永続表示のため)。
   const [kingSlash, setKingSlash] = useState<{
-    rect: DOMRect;
+    pos: Position;
     owner: Player;
     key: number;
   } | null>(null);
+  // KingSlashOverlay へ渡す安定参照の盤マス矩形 getter。
+  const getKingSquareRect = useCallback(
+    (row: number, col: number): DOMRect | null =>
+      boardRef.current?.getSquareRect(row, col) ?? null,
+    [],
+  );
   // Issue #217: 旧 startTransition(async) は createGame 失敗時に永久ハング
   // していた。明示的 loading/error state を持つ共通フックに置換 (router.push は
   // フック内部で行うため本コンポーネントの useRouter は不要になった)。
@@ -197,17 +204,16 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
     if (gameState.status === "checkmate") {
       setTimeout(() => playSfx("checkmate"), 1000);
       setTimeout(() => setOverlayEvent({ event: "checkmate", key: Date.now() }), 1000);
-      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を重ねる。
+      // Issue #225: 詰み表示と同タイミングで、負けた側の玉へ赤い斬撃演出を発火。
+      // 斬撃は演出後もフェードさせず永続表示する (クリアしない)。対局再開・離脱で解消。
       const loser: Player = gameState.winner === "sente" ? "gote" : "sente";
-      setTimeout(() => {
-        const kingPos = findKing(gameState.board, loser, STANDARD_VARIANT.boardSize);
-        const rect = kingPos
-          ? boardRef.current?.getSquareRect(kingPos.row, kingPos.col) ?? null
-          : null;
-        if (rect) setKingSlash({ rect, owner: loser, key: Date.now() });
-      }, 1000);
-      // 斬撃尺 (ghost-slash 1.5s) 経過後にクリアし、下の実盤の玉表示へ戻す。
-      setTimeout(() => setKingSlash(null), 2700);
+      const kingPos = findKing(gameState.board, loser, STANDARD_VARIANT.boardSize);
+      if (kingPos) {
+        setTimeout(
+          () => setKingSlash({ pos: kingPos, owner: loser, key: Date.now() }),
+          1000,
+        );
+      }
     }
   }, [gameState.moveCount]);
 
@@ -303,11 +309,12 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
               isMobile={isMobile}
             />
             <BoardOverlay key={overlayEvent?.key} event={overlayEvent?.event ?? null} />
-            {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出を重ねる */}
+            {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (永続) を重ねる */}
             <KingSlashOverlay
-              rect={kingSlash?.rect ?? null}
+              kingPos={kingSlash?.pos ?? null}
               kingOwner={kingSlash?.owner ?? null}
               playerColor={playerColor}
+              getSquareRect={getKingSquareRect}
               animationKey={kingSlash?.key ?? 0}
             />
           </div>


### PR DESCRIPTION
## Summary
詰み時、負けた側の玉へ「赤い斜線で斬られた」斬撃演出を追加する。王手崩し (#82) の被弾演出と同系統の見た目を玉マスに重ね、決着を視覚的に強調する。**標準将棋・カード将棋の両方**に適用。

検証フィードバックを反映し、**赤い斬撃は演出後もフェードさせず永続表示**する (詰みの「斬られた跡」をずっと残す)。

### 変更
- 共通コンポーネント `KingSlashOverlay` を新規作成。詰み時、玉駒コピーに被弾フラッシュ (`checkmate-king-hit`、赤系・インパクト後は通常へ戻す) + 赤い斬撃 (`ghost-slash-line-persist`、描画後 opacity 1 で静止) を玉マスへ重ねる。`createPortal` で描画。
- 永続表示のため、`kingPos` + `getSquareRect` から矩形を算出し **resize に追従** (モバイル回転等の盤レイアウト変化で玉マスへ追従)。`setRect` は rAF / resize コールバック経由とし effect 本体の同期 setState を回避。
- 両ゲームの moveCount 効果で詰み検知時、負けた側 (winner の逆) の玉位置 (`findKing`) を保持し、詰み表示と同じ +1000ms で発火。演出後はクリアせず永続化 (対局再開・離脱で解消)。標準将棋は `ShogiBoard` に ref を追加し `getSquareRect` を利用。
- 既存 CSS を踏襲しつつ詰み専用 keyframe を追加 (王手崩しの ghost-slash はフェードするため別物として追加)。

## Test plan
- `npm run lint`: 0 errors
- `npm run typecheck`: 既知の @testing-library 2件のみ
- `npm run test:ci`: 434 passed / 6 skipped
- `npm run build`: Compiled successfully
- Vercel 実機: 標準・カード将棋とも詰み時に玉へ赤い斬撃が表示され、演出後も赤い切り込みが残ることをユーザー確認済み
- main (#226 マージ済) を取り込み済み・競合なし・統合後も全チェック green

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
