### PR TITLE
fix: 王手崩しが開き王手で裏の駒も奪う不具合を修正

### DIFF
--- a/src/lib/shogi/cards/__tests__/effects.test.ts
+++ b/src/lib/shogi/cards/__tests__/effects.test.ts
@@ -870,22 +870,28 @@ describe("applyCheckBreak", () => {
     expect(state.hand.sente.pawn).toBeUndefined();
   });
 
-  it("ディスカバードチェック (ブロッカー除去で別の駒が王手露出) も反復で解消", () => {
+  it("開き王手 (ブロッカー除去で裏の駒が露出) → 直接の王手駒のみ回収し露出駒は対象外 (#229)", () => {
     const state = makeState();
     placeKing(state, "sente", { row: 4, col: 4 });
     placeKing(state, "gote", { row: 0, col: 0 });
-    // gote 飛車 (列 4 縦に通せるが gote 自分の歩で遮蔽されている)
+    // gote 飛車 (列 4 縦に通せるが gote 自分の歩で遮蔽されており、この時点では王手していない)
     place(state, { row: 0, col: 4 }, { type: "rook", owner: "gote" });
-    // gote 歩 (sente 玉の真上 = 王手駒)。これを除去すると後ろの飛車が露出して王手継続。
+    // gote 歩 (sente 玉の真上 = 直接の王手駒)。これが唯一の王手駒。
     place(state, { row: 3, col: 4 }, { type: "pawn", owner: "gote" });
     const result = applyCheckBreak(state, "sente");
     expect(result).not.toBeNull();
-    // 反復で歩 + 飛車 の 2 枚が回収される
-    expect(result!.capturedPieces).toHaveLength(2);
+    // 直接王手していた歩のみ回収。除去で露出するだけの飛車は対象外。
+    expect(result!.capturedPieces).toEqual([
+      { row: 3, col: 4, pieceType: "pawn", originalPieceType: "pawn", originalOwner: "gote" },
+    ]);
     expect(result!.gameState.hand.sente.pawn).toBe(1);
-    expect(result!.gameState.hand.sente.rook).toBe(1);
-    // 王手解除
-    expect(isInCheck(result!.gameState, "sente", CARD_SHOGI_VARIANT)).toBe(false);
+    expect(result!.gameState.hand.sente.rook).toBeUndefined();
+    // 歩は除去、飛車は盤上に残る
+    expect(result!.gameState.board[3][4]).toBeNull();
+    expect(result!.gameState.board[0][4]).toEqual({ type: "rook", owner: "gote" });
+    // 露出した飛車が玉に王手し続ける局面は正当な盤面として許容する
+    // (トラップ所有者は自分の手番で対処する)
+    expect(isInCheck(result!.gameState, "sente", CARD_SHOGI_VARIANT)).toBe(true);
   });
 });
 

--- a/src/lib/shogi/cards/effects.ts
+++ b/src/lib/shogi/cards/effects.ts
@@ -353,43 +353,41 @@ export function canEscapeCheckWithCard(
   return false;
 }
 
-// 王手崩し (#82): 自玉に王手をかけている相手駒すべてを盤上から除去し、
+// 王手崩し (#82): 自玉に王手をかけている相手駒を盤上から除去し、
 // player の持ち駒に unpromote した状態で加算する。両王手・複数王手にも対応。
 // 戻り値の capturedPieces は UI 演出 (各駒のフライト) で参照する適用前の位置情報。
 // 王手駒が 1 枚もない場合は null を返す (トリガーが空発火しないようガード)。
 //
-// 反復除去: ある駒を除去した結果、それを遮蔽していた裏にいた飛角等が新たに王手をかける
-// 「ディスカバードチェック」の可能性があるため、王手が解除されるまで繰り返す。
-// ループ上限は安全装置(理論上は数回で収束)。
+// 対象は「発動時点で直接玉に王手している駒」のみ (#229)。除去した結果に裏で
+// 遮蔽されていた飛角等が露出する「開き王手」は対象外 — 露出駒は元々この手で
+// 王手していたわけではないため、奪わずに盤上へ残す。露出駒が玉に王手し続ける
+// 局面は正当な盤面として許容し、トラップ所有者は自分の手番で対処する。
+// (本物の両王手 = 発動時点で複数駒が同時に玉を狙うケースは引き続き全て対象。)
 export function applyCheckBreak(
   state: GameState,
   player: Player,
 ): { gameState: GameState; capturedPieces: TrapCapturedPiece[] } | null {
-  const initial = getCheckingPieces(state, player, CARD_SHOGI_VARIANT);
-  if (initial.length === 0) return null;
+  const checking = getCheckingPieces(state, player, CARD_SHOGI_VARIANT);
+  if (checking.length === 0) return null;
 
   const newState = cloneGameState(state);
   const capturedPieces: TrapCapturedPiece[] = [];
-  for (let iter = 0; iter < 8; iter++) {
-    const checking = getCheckingPieces(newState, player, CARD_SHOGI_VARIANT);
-    if (checking.length === 0) break;
-    for (const pos of checking) {
-      const piece = newState.board[pos.row]?.[pos.col];
-      if (!piece) continue;
-      const handPieceType = unpromotePieceType(piece.type);
-      const originalPieceType = piece.type;
-      const originalOwner = piece.owner;
-      newState.board[pos.row][pos.col] = null;
-      const currentCount = newState.hand[player][handPieceType] ?? 0;
-      newState.hand[player][handPieceType] = currentCount + 1;
-      capturedPieces.push({
-        row: pos.row,
-        col: pos.col,
-        pieceType: handPieceType,
-        originalPieceType,
-        originalOwner,
-      });
-    }
+  for (const pos of checking) {
+    const piece = newState.board[pos.row]?.[pos.col];
+    if (!piece) continue;
+    const handPieceType = unpromotePieceType(piece.type);
+    const originalPieceType = piece.type;
+    const originalOwner = piece.owner;
+    newState.board[pos.row][pos.col] = null;
+    const currentCount = newState.hand[player][handPieceType] ?? 0;
+    newState.hand[player][handPieceType] = currentCount + 1;
+    capturedPieces.push({
+      row: pos.row,
+      col: pos.col,
+      pieceType: handPieceType,
+      originalPieceType,
+      originalOwner,
+    });
   }
   return { gameState: newState, capturedPieces };
 }


### PR DESCRIPTION
## Summary
カード将棋の王手崩し (check_break) で、直接王手している駒だけでなく、その後ろに遮蔽されていた飛角等 (開き王手で露出する駒) まで奪っていた不具合を修正する。

例: 玉の前に相手の歩・その後ろに相手の飛車という配置で歩が王手 → 旧実装は歩と飛車の両方を奪っていた。直接王手しているのは歩のみで、飛車は本来トラップの対象であってはならない。

### 原因
`applyCheckBreak` が「王手が解除されるまで」反復で `getCheckingPieces` を呼び直し駒を除去していたため、歩を除去した直後に裏の飛車が露出 (ディスカバードチェック) し、次の反復で飛車も回収されていた。

### 対策
反復ループを廃止し、発動時点の `getCheckingPieces` 結果 (=直接王手駒のみ) への**単一パス**に変更。
- 直接の王手駒のみを回収(露出駒は盤上に残す)
- 本物の両王手(発動時点で複数駒が同時に玉を狙う)は引き続き全て対象
- `getCheckingPieces` 呼び出しが最大 8 回 → 1 回に減り性能も改善
- ループ上限のマジックナンバー `8` を除去

露出駒が玉に王手し続ける局面は正当な盤面として許容し、トラップ所有者は自分の手番で対処する (テストも新仕様に書き換え)。

## Test plan
- `npm run lint`: 0 errors(21 件は既存 warning、変更ファイルに該当なし)
- `npm run typecheck`: クリーン
- `npm run test:ci`: 453 passed / 6 skipped
- `npm run build`: 成功
- Vercel 実機: 動作確認ユーザー済み

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)