### PR TITLE
feat: PR3-2 cardDigest 増分更新 API updateCardDigest 追加 (#193 epic)

### DIFF
--- a/src/lib/shogi/ai/__tests__/card-digest.test.ts
+++ b/src/lib/shogi/ai/__tests__/card-digest.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeCardDigest,
   evaluateCardDigest,
+  updateCardDigest,
   type CardDigest,
 } from "../cards/digest";
 import {
@@ -401,4 +402,301 @@ describe("PR3-1 manaAbsolute + 死にマナペナルティ", () => {
       evaluateCardDigest(computeCardDigest(cs), STANDARD_VARIANT),
     ).toBe(0);
   });
+});
+
+describe("PR3-2 updateCardDigest (増分更新)", () => {
+  // cardState の deep clone (各テストで mutate するため)
+  function clone(cs: ReturnType<typeof createInitialCardState>) {
+    return {
+      mana: { sente: cs.mana.sente, gote: cs.mana.gote },
+      manaCap: cs.manaCap,
+      hand: {
+        sente: [...cs.hand.sente],
+        gote: [...cs.hand.gote],
+      },
+      deck: {
+        sente: [...cs.deck.sente],
+        gote: [...cs.deck.gote],
+      },
+      graveyard: {
+        sente: [...cs.graveyard.sente],
+        gote: [...cs.graveyard.gote],
+      },
+      trap: { sente: cs.trap.sente, gote: cs.trap.gote },
+      pendingCard: cs.pendingCard,
+      lastTurnStartedAt: {
+        sente: cs.lastTurnStartedAt.sente,
+        gote: cs.lastTurnStartedAt.gote,
+      },
+      noPromoteMarks: {
+        sente: [...cs.noPromoteMarks.sente],
+        gote: [...cs.noPromoteMarks.gote],
+      },
+      drawProgress: {
+        sente: cs.drawProgress.sente,
+        gote: cs.drawProgress.gote,
+      },
+    };
+  }
+
+  it("変化なし (deep equal な cardState) → digest 全フィールド prev と同値", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated).toEqual(prev);
+    // 変化なしフィールドはオブジェクトを参照流用 (再生成なし) で性能寄与
+    expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
+    expect(updated.trapPresence).toBe(prev.trapPresence);
+  });
+
+  it("マナのみ変化 → manaDelta / manaAbsolute 更新、他は prev 流用", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.mana.sente = cs.mana.sente + 5;
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.manaDelta).toBe(csNew.mana.sente - csNew.mana.gote);
+    expect(updated.manaAbsolute).toEqual({ sente: csNew.mana.sente, gote: cs.mana.gote });
+    // 他フィールドは prev と reference equality
+    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.handValueDelta).toBe(prev.handValueDelta);
+    expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
+    expect(updated.noPromoteMarkCountDelta).toBe(prev.noPromoteMarkCountDelta);
+  });
+
+  it("手札増加 (draw 想定) → handValueDelta 更新、mana/trap は流用", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    const drawn = csNew.deck.sente.pop()!;
+    csNew.hand.sente.push(drawn);
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.handValueDelta).toBeGreaterThan(prev.handValueDelta);
+    // mana / trap / drawProgress / marks は変化なし
+    expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
+    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
+    expect(updated.noPromoteMarkCountDelta).toBe(prev.noPromoteMarkCountDelta);
+  });
+
+  it("トラップ設置 (gote: check_break) → trapPresence 更新", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.trap.gote = {
+      instanceId: "tg-1",
+      defId: "check_break",
+      owner: "gote",
+    };
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.trapPresence).toEqual({ sente: null, gote: "check_break" });
+    // 他は流用
+    expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
+    expect(updated.handValueDelta).toBe(prev.handValueDelta);
+  });
+
+  it("トラップ解除 (gote: check_break → null) → trapPresence 更新", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    cs.trap.gote = {
+      instanceId: "tg-1",
+      defId: "check_break",
+      owner: "gote",
+    };
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.trap.gote = null;
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.trapPresence).toEqual({ sente: null, gote: null });
+  });
+
+  it("noPromote マーク追加 → noPromoteMarkCountDelta 更新", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.noPromoteMarks.sente.push({ row: 6, col: 0 });
+    csNew.noPromoteMarks.sente.push({ row: 6, col: 1 });
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.noPromoteMarkCountDelta).toBe(2);
+  });
+
+  it("drawProgress 変化 → drawProgressDelta 更新、他流用", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.drawProgress.sente = 3;
+    csNew.drawProgress.gote = 1;
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.drawProgressDelta).toBe(2);
+    expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
+  });
+
+  it("複数フィールド同時変化 (playCard 想定: mana-2 + hand-1) も正しく更新", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.mana.sente = cs.mana.sente - 2;
+    csNew.hand.sente.pop(); // hand -1
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.manaDelta).toBe(csNew.mana.sente - csNew.mana.gote);
+    expect(updated.manaAbsolute).toEqual({ sente: csNew.mana.sente, gote: cs.mana.gote });
+    expect(updated.handValueDelta).toBeLessThan(prev.handValueDelta);
+    // 変化なしフィールドは流用
+    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
+  });
+
+  it("manaCap は常に prev 流用 (現状静的 MANA_CAP=20 固定)", () => {
+    const cs = createInitialCardState(SAMPLE_DECK);
+    const prev = computeCardDigest(cs);
+    const csNew = clone(cs);
+    csNew.mana.sente += 5; // 別フィールド変化
+    const updated = updateCardDigest(prev, cs, csNew);
+    expect(updated.manaCap).toBe(prev.manaCap);
+  });
+});
+
+describe("PR3-2 updateCardDigest 等価性 fixture (= computeCardDigest と byte-level 一致)", () => {
+  // cardState の deep clone (再利用)
+  function clone(cs: ReturnType<typeof createInitialCardState>) {
+    return {
+      mana: { sente: cs.mana.sente, gote: cs.mana.gote },
+      manaCap: cs.manaCap,
+      hand: {
+        sente: [...cs.hand.sente],
+        gote: [...cs.hand.gote],
+      },
+      deck: {
+        sente: [...cs.deck.sente],
+        gote: [...cs.deck.gote],
+      },
+      graveyard: {
+        sente: [...cs.graveyard.sente],
+        gote: [...cs.graveyard.gote],
+      },
+      trap: { sente: cs.trap.sente, gote: cs.trap.gote },
+      pendingCard: cs.pendingCard,
+      lastTurnStartedAt: {
+        sente: cs.lastTurnStartedAt.sente,
+        gote: cs.lastTurnStartedAt.gote,
+      },
+      noPromoteMarks: {
+        sente: [...cs.noPromoteMarks.sente],
+        gote: [...cs.noPromoteMarks.gote],
+      },
+      drawProgress: {
+        sente: cs.drawProgress.sente,
+        gote: cs.drawProgress.gote,
+      },
+    };
+  }
+
+  // 各遷移シナリオ: (label, mutate) で prev → new を生成し、
+  // updateCardDigest(computeCardDigest(prev), prev, new) === computeCardDigest(new)
+  // を全フィールドで toEqual 検証する。
+  const scenarios: {
+    label: string;
+    mutate: (cs: ReturnType<typeof clone>) => void;
+  }[] = [
+    {
+      label: "no-op (deep clone のみ)",
+      mutate: () => {},
+    },
+    {
+      label: "draw 想定 (mana-2 + hand+1 + drawProgress reset)",
+      mutate: (cs) => {
+        cs.mana.sente -= 2;
+        cs.hand.sente.push(cs.deck.sente.pop()!);
+        cs.drawProgress.sente = 0;
+      },
+    },
+    {
+      label: "playCard 想定 (mana-2 + hand-1)",
+      mutate: (cs) => {
+        cs.mana.gote -= 2;
+        cs.hand.gote.pop();
+      },
+    },
+    {
+      label: "トラップ設置 (sente: no_promote)",
+      mutate: (cs) => {
+        cs.mana.sente -= 3;
+        cs.hand.sente.pop();
+        cs.trap.sente = {
+          instanceId: "ts-1",
+          defId: "no_promote",
+          owner: "sente",
+        };
+      },
+    },
+    {
+      label: "トラップ発動 (gote: check_break → null + 持ち駒化は別フィールドで未反映)",
+      mutate: (cs) => {
+        cs.trap.gote = null;
+      },
+    },
+    {
+      label: "no_promote マーク追加 (両者)",
+      mutate: (cs) => {
+        cs.noPromoteMarks.sente.push({ row: 6, col: 0 });
+        cs.noPromoteMarks.gote.push({ row: 2, col: 8 });
+        cs.noPromoteMarks.gote.push({ row: 2, col: 7 });
+      },
+    },
+    {
+      label: "マナ上限到達 (両者 MANA_CAP)",
+      mutate: (cs) => {
+        cs.mana.sente = MANA_CAP;
+        cs.mana.gote = MANA_CAP;
+      },
+    },
+    {
+      label: "drawProgress 増加 (両者)",
+      mutate: (cs) => {
+        cs.drawProgress.sente = 4;
+        cs.drawProgress.gote = 2;
+      },
+    },
+    {
+      label: "複合: mana 変化 + hand 変化 + trap 設置 + マーク追加",
+      mutate: (cs) => {
+        cs.mana.sente -= 4;
+        cs.mana.gote += 2;
+        cs.hand.sente.push(cs.deck.sente.pop()!);
+        cs.hand.gote.pop();
+        cs.trap.sente = {
+          instanceId: "ts-x",
+          defId: "check_break",
+          owner: "sente",
+        };
+        cs.noPromoteMarks.gote.push({ row: 3, col: 4 });
+      },
+    },
+  ];
+
+  for (const sc of scenarios) {
+    it(`等価性: ${sc.label}`, () => {
+      // prev = ある程度成熟した cardState (初期 + 既存トラップ + マークあり) で出発し、
+      // sc.mutate で更にバリエーション。エッジを広く突くため。
+      const prev = createInitialCardState(SAMPLE_DECK);
+      prev.trap.gote = {
+        instanceId: "tg-base",
+        defId: "check_break",
+        owner: "gote",
+      };
+      prev.noPromoteMarks.sente.push({ row: 6, col: 4 });
+
+      const next = clone(prev);
+      sc.mutate(next);
+
+      const prevDigest = computeCardDigest(prev);
+      const updated = updateCardDigest(prevDigest, prev, next);
+      const recomputed = computeCardDigest(next);
+
+      // byte-level 一致 (各フィールドが厳密に同値)
+      expect(updated).toEqual(recomputed);
+      // 浮動小数点 (handValueDelta) も含めて完全一致を確認
+      expect(updated.handValueDelta).toBe(recomputed.handValueDelta);
+    });
+  }
 });

--- a/src/lib/shogi/ai/cards/digest.ts
+++ b/src/lib/shogi/ai/cards/digest.ts
@@ -146,3 +146,76 @@ function evaluateDeadManaPenalty(digest: CardDigest): number {
   const goteOverflow = Math.max(0, digest.manaAbsolute.gote - DEAD_MANA_THRESHOLD);
   return (goteOverflow - senteOverflow) * DEAD_MANA_PENALTY_COEF;
 }
+
+/**
+ * PR3-2: cardDigest の増分更新 API。
+ *
+ * 既存 digest (= prevCardState から computeCardDigest で生成済) を基に、新 cardState への
+ * 遷移で**変化があったフィールドのみ再計算**して新 digest を返す。変化がないフィールドは
+ * prev の値をそのまま流用 (オブジェクトも参照流用、=== 比較成立)。
+ *
+ * 目的 (PR3-3 の前提整備):
+ * - PR3-3 で深さ N の子ノードがカード/ドロー候補を取るとき、毎ノードで
+ *   computeCardDigest (= 2× Math.exp() 呼び出しを含む全再計算) を回すのを避ける。
+ * - 比較は length / 数値 === / null チェックのみで O(1)、変化がないフィールドは
+ *   exp() 呼び出しもスキップ。
+ *
+ * 振る舞いキープ (本 PR スコープ):
+ * - 本関数は新規追加のみで production コードからは未呼び出し。PR3-3 で wiring。
+ * - 等価性: updateCardDigest(computeCardDigest(prev), prev, new) は computeCardDigest(new) と
+ *   完全に同じ値を返す (本ファイル隣接の `card-digest.test.ts` 等価性 fixture で保証)。
+ *
+ * 注意 (W-2 sente 絶対視点維持):
+ * - 全フィールドの符号方針は computeCardDigest と同一 (sente が有利なら正)。
+ * - prev に含まれる manaCap は静的値のため常に流用 (将来動的化したら本関数も拡張要)。
+ */
+export function updateCardDigest(
+  prev: CardDigest,
+  prevCardState: CardGameState,
+  newCardState: CardGameState,
+): CardDigest {
+  const manaChanged =
+    prevCardState.mana.sente !== newCardState.mana.sente ||
+    prevCardState.mana.gote !== newCardState.mana.gote;
+  const handChanged =
+    prevCardState.hand.sente.length !== newCardState.hand.sente.length ||
+    prevCardState.hand.gote.length !== newCardState.hand.gote.length;
+  const drawChanged =
+    prevCardState.drawProgress.sente !== newCardState.drawProgress.sente ||
+    prevCardState.drawProgress.gote !== newCardState.drawProgress.gote;
+  const senteTrapDefId = newCardState.trap.sente?.defId ?? null;
+  const goteTrapDefId = newCardState.trap.gote?.defId ?? null;
+  const trapChanged =
+    senteTrapDefId !== prev.trapPresence.sente ||
+    goteTrapDefId !== prev.trapPresence.gote;
+  const marksChanged =
+    prevCardState.noPromoteMarks.sente.length !==
+      newCardState.noPromoteMarks.sente.length ||
+    prevCardState.noPromoteMarks.gote.length !==
+      newCardState.noPromoteMarks.gote.length;
+
+  return {
+    manaDelta: manaChanged
+      ? newCardState.mana.sente - newCardState.mana.gote
+      : prev.manaDelta,
+    // manaCap は現状 MANA_CAP 固定 (将来動的化想定で枠は維持、本関数も常に prev 流用)。
+    manaCap: prev.manaCap,
+    manaAbsolute: manaChanged
+      ? { sente: newCardState.mana.sente, gote: newCardState.mana.gote }
+      : prev.manaAbsolute,
+    handValueDelta: handChanged
+      ? computeHandValue(newCardState.hand.sente.length) -
+        computeHandValue(newCardState.hand.gote.length)
+      : prev.handValueDelta,
+    drawProgressDelta: drawChanged
+      ? newCardState.drawProgress.sente - newCardState.drawProgress.gote
+      : prev.drawProgressDelta,
+    trapPresence: trapChanged
+      ? { sente: senteTrapDefId, gote: goteTrapDefId }
+      : prev.trapPresence,
+    noPromoteMarkCountDelta: marksChanged
+      ? newCardState.noPromoteMarks.sente.length -
+        newCardState.noPromoteMarks.gote.length
+      : prev.noPromoteMarkCountDelta,
+  };
+}


### PR DESCRIPTION
## Summary
Issue #193 (AI 棋力強化 epic) の PR3-2 = **cardDigest 増分更新 API 追加**。PR3-3 (深読み探索) の前提整備として、`updateCardDigest(prev, prevCardState, newCardState)` を新規導入。本 PR 単独では production コードから未呼び出し、振る舞いキープ (PR3-3 で wiring 予定)。

## 背景・目的
- PR3-3 で深さ N の子ノードがカード/ドロー候補を取るとき、毎ノードで `computeCardDigest` (= 2× `Math.exp()` 呼び出しを含む全再計算) を回すのを避けたい
- 増分更新で変化のないフィールドは prev の値・オブジェクトを参照流用、変化のあるフィールドのみ再計算 (handValueDelta は `handChanged` 時のみ exp() 呼び出し)

## 変更内容

### `src/lib/shogi/ai/cards/digest.ts`
- `updateCardDigest(prev, prevCardState, newCardState): CardDigest` 新規追加
- 比較は length / 数値 === / null チェックのみで O(1)
- `manaCap` は静的のため常に prev 流用 (将来動的化したら本関数も拡張要)

### `src/lib/shogi/ai/__tests__/card-digest.test.ts` (+18 件)
- **挙動テスト 9 件**: 変化なし(reference 流用検証含む) / マナのみ / 手札 / トラップ設置・解除 / マーク / drawProgress / 複数同時変化 / manaCap 流用
- **等価性 fixture 9 シナリオ**: `updateCardDigest(computeCardDigest(prev), prev, new) === computeCardDigest(new)` を no-op / draw / playCard / trap 設置・発動 / マーク / マナ上限 / drawProgress / 複合 の 9 種で **byte-level `toEqual`** 検証

## 振る舞いキープ
- 本関数は production コードから未呼び出し (PR3-3 で wiring 予定)
- 等価性 fixture で `computeCardDigest` との byte-level 同値を保証
- standard variant への影響なし (variant 非依存の pure function)

## Test plan
- [x] `npm run lint`: 0 errors (21 既存 warning、変更ファイルに該当なし)
- [x] `npm run typecheck`: クリーン
- [x] `npm run test:ci`: **491 passed / 9 skipped** (473 + 本 PR 新規 18 件)
- [x] `npm run build`: 成功
- [x] Vercel preview: 本 PR は API 追加のみで production 呼び出しなしのため実機挙動変化ゼロ、既存挙動非破壊をユーザー確認

Refs #193 (epic、本 PR で OPEN 維持。PR3-3/4 が後続)

🤖 Generated with [Claude Code](https://claude.com/claude-code)