### PR TITLE
refactor: #235 S1 L0カーネル統合 (reducer/AI 単一権威化, S1a〜S1d)

### DIFF
--- a/docs/bench-results/issue-235-before-baseline.json
+++ b/docs/bench-results/issue-235-before-baseline.json
@@ -1,0 +1,406 @@
+{
+  "schema": "issue-235-before-baseline/v1",
+  "description": "Issue #235 S0 before-baseline: canonical main (PR3-3 マージ済) の探索性能・カード使用率。以降の全段 DoD はこの中央値を基準に判定する。",
+  "measuredAt": "2026-06-06T13:34:45.253Z",
+  "commitSHA": "414981d66b92908738d4f5a19ebc3fbbacceebb0",
+  "runs": 3,
+  "difficulties": [
+    "beginner",
+    "intermediate",
+    "advanced",
+    "expert"
+  ],
+  "aggregation": "median",
+  "conditions": {
+    "harness": "scripts/measure-baseline-235.ts (standalone tsx、vitest 非依存)",
+    "command": "npx tsx scripts/measure-baseline-235.ts 3",
+    "difficultyParams": {
+      "beginner": {
+        "maxDepth": 3,
+        "timeLimitMs": 800
+      },
+      "intermediate": {
+        "maxDepth": 6,
+        "timeLimitMs": 1800
+      },
+      "advanced": {
+        "maxDepth": 16,
+        "timeLimitMs": 3000
+      },
+      "expert": {
+        "maxDepth": 24,
+        "timeLimitMs": 3500
+      }
+    },
+    "note": "findBestMoveWithStats を直接呼び bench fixture を再現。depthCompleted は time-budget 探索のため計測機 CPU 性能依存 → 各段/PoC の ±10% 比較は同一機・同一条件で取得すること。",
+    "metrics": {
+      "perfBench": "makeBenchPositions() の 9 局面 (initial + 8 ply) を全難易度で探索し、stats.depthCompleted / nodes / elapsedMs の局面平均。",
+      "cardUsage": "makeScenarios() の isolation 局面 7 シナリオで action 種別を集計。cardCount = move/none 以外 (draw / playCard) の件数、ratePct = cardCount/7。",
+      "scope": "S0 before-baseline は depthCompleted / nodes / card-usage の三軸。rootMoveScore 等の 棋力スコア指標は本段では scope 外 (PoC-1 以降で必要に応じ engine 拡張)。"
+    }
+  },
+  "perfBench": {
+    "beginner": {
+      "avgDepth": 3,
+      "avgNodes": 2263,
+      "avgMs": 133,
+      "positions": 9
+    },
+    "intermediate": {
+      "avgDepth": 5.33,
+      "avgNodes": 30877,
+      "avgMs": 1371,
+      "positions": 9
+    },
+    "advanced": {
+      "avgDepth": 5.78,
+      "avgNodes": 48634,
+      "avgMs": 2269,
+      "positions": 9
+    },
+    "expert": {
+      "avgDepth": 6,
+      "avgNodes": 63918,
+      "avgMs": 2834,
+      "positions": 9
+    }
+  },
+  "cardUsage": {
+    "beginner": {
+      "cardCount": 7,
+      "ratePct": 100,
+      "totalScenarios": 7,
+      "breakdownPerRun": [
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+      ]
+    },
+    "intermediate": {
+      "cardCount": 7,
+      "ratePct": 100,
+      "totalScenarios": 7,
+      "breakdownPerRun": [
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+      ]
+    },
+    "advanced": {
+      "cardCount": 4,
+      "ratePct": 57,
+      "totalScenarios": 7,
+      "breakdownPerRun": [
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+      ]
+    },
+    "expert": {
+      "cardCount": 4,
+      "ratePct": 57,
+      "totalScenarios": 7,
+      "breakdownPerRun": [
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move",
+        "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+      ]
+    }
+  },
+  "rawRuns": [
+    {
+      "perf": {
+        "beginner": {
+          "avgDepth": 3,
+          "avgNodes": 2263,
+          "avgMs": 155,
+          "positions": 9,
+          "perPositionDepth": [
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3
+          ]
+        },
+        "intermediate": {
+          "avgDepth": 5.33,
+          "avgNodes": 30877,
+          "avgMs": 1371,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6,
+            3,
+            5
+          ]
+        },
+        "advanced": {
+          "avgDepth": 5.78,
+          "avgNodes": 44715,
+          "avgMs": 2093,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            6,
+            6,
+            6,
+            6,
+            6,
+            8,
+            3,
+            5
+          ]
+        },
+        "expert": {
+          "avgDepth": 6,
+          "avgNodes": 64146,
+          "avgMs": 2834,
+          "positions": 9,
+          "perPositionDepth": [
+            7,
+            6,
+            6,
+            6,
+            6,
+            7,
+            8,
+            3,
+            5
+          ]
+        }
+      },
+      "card": {
+        "beginner": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "intermediate": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "advanced": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        },
+        "expert": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        }
+      }
+    },
+    {
+      "perf": {
+        "beginner": {
+          "avgDepth": 3,
+          "avgNodes": 2263,
+          "avgMs": 129,
+          "positions": 9,
+          "perPositionDepth": [
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3
+          ]
+        },
+        "intermediate": {
+          "avgDepth": 5.33,
+          "avgNodes": 31332,
+          "avgMs": 1355,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6,
+            3,
+            5
+          ]
+        },
+        "advanced": {
+          "avgDepth": 5.78,
+          "avgNodes": 49086,
+          "avgMs": 2269,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            6,
+            6,
+            6,
+            6,
+            6,
+            8,
+            3,
+            5
+          ]
+        },
+        "expert": {
+          "avgDepth": 5.78,
+          "avgNodes": 57606,
+          "avgMs": 2713,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            6,
+            6,
+            6,
+            6,
+            6,
+            8,
+            3,
+            5
+          ]
+        }
+      },
+      "card": {
+        "beginner": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "intermediate": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "advanced": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        },
+        "expert": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        }
+      }
+    },
+    {
+      "perf": {
+        "beginner": {
+          "avgDepth": 3,
+          "avgNodes": 2263,
+          "avgMs": 133,
+          "positions": 9,
+          "perPositionDepth": [
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3,
+            3
+          ]
+        },
+        "intermediate": {
+          "avgDepth": 5.33,
+          "avgNodes": 30877,
+          "avgMs": 1375,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6,
+            3,
+            5
+          ]
+        },
+        "advanced": {
+          "avgDepth": 5.78,
+          "avgNodes": 48634,
+          "avgMs": 2272,
+          "positions": 9,
+          "perPositionDepth": [
+            6,
+            6,
+            6,
+            6,
+            6,
+            6,
+            8,
+            3,
+            5
+          ]
+        },
+        "expert": {
+          "avgDepth": 6,
+          "avgNodes": 63918,
+          "avgMs": 2854,
+          "positions": 9,
+          "perPositionDepth": [
+            7,
+            6,
+            6,
+            6,
+            6,
+            7,
+            8,
+            3,
+            5
+          ]
+        }
+      },
+      "card": {
+        "beginner": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "intermediate": {
+          "cardCount": 7,
+          "totalScenarios": 7,
+          "ratePct": 100,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=draw, calib-trap-only-no-draw=playCard:trap(no_promote), calib-endgame-empty-hand-mana-mid=draw"
+        },
+        "advanced": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        },
+        "expert": {
+          "cardCount": 4,
+          "totalScenarios": 7,
+          "ratePct": 57,
+          "breakdown": "midgame-mana-surplus=playCard:board(pawn_return), midgame-mana-cap=playCard:board(pawn_return), endgame-hand-surplus=playCard:board(pawn_return), midgame-hand-pressure=playCard:board(pawn_return), calib-empty-hand-mana-surplus=move, calib-trap-only-no-draw=move, calib-endgame-empty-hand-mana-mid=move"
+        }
+      }
+    }
+  ]
+}

--- a/docs/bench-results/issue-235-poc1.json
+++ b/docs/bench-results/issue-235-poc1.json
@@ -1,0 +1,306 @@
+{
+  "schema": "issue-235-poc1/v1",
+  "description": "Issue #235 PoC-1 探索枝刈り: 同一プロトタイプ negamax で候補生成 (ALL/TOPM/CARD) を切替え、card 込み (CARD) の depthCompleted が move-only (ALL) 比 ±10% に収まる M/K が存在するか実測。",
+  "measuredAt": "2026-06-06T14:29:40.822Z",
+  "commitSHA": "1185067aab049d5e753778169dfbcba69348b517",
+  "difficulties": [
+    "beginner",
+    "intermediate",
+    "advanced",
+    "expert"
+  ],
+  "configs": [
+    {
+      "label": "ALL",
+      "mode": "ALL",
+      "M": "all",
+      "K": 0
+    },
+    {
+      "label": "TOPM-10",
+      "mode": "TOPM",
+      "M": 10,
+      "K": 0
+    },
+    {
+      "label": "CARD-M10-K2",
+      "mode": "CARD",
+      "M": 10,
+      "K": 2
+    },
+    {
+      "label": "CARD-M14-K3",
+      "mode": "CARD",
+      "M": 14,
+      "K": 3
+    }
+  ],
+  "protoMaxDepth": 12,
+  "note": "プロトタイプは TT/killer/quiescence/LMR/noise なしの bare αβ。production と絶対深さは異なるが、同一エンジン内の ALL→CARD 比でエンジン効率交絡を相殺。before-baseline (advanced 5.78 / expert 6.0) は ALL の fidelity 参照。",
+  "results": {
+    "beginner": [
+      {
+        "config": "ALL",
+        "avgDepth": 3,
+        "avgNodes": 15154,
+        "perPositionDepth": [
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          4,
+          3,
+          2
+        ]
+      },
+      {
+        "config": "TOPM-10",
+        "avgDepth": 3.89,
+        "avgNodes": 10266,
+        "perPositionDepth": [
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M10-K2",
+        "avgDepth": 3.78,
+        "avgNodes": 10494,
+        "perPositionDepth": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M14-K3",
+        "avgDepth": 3.67,
+        "avgNodes": 11892,
+        "perPositionDepth": [
+          3,
+          3,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ]
+      }
+    ],
+    "intermediate": [
+      {
+        "config": "ALL",
+        "avgDepth": 3.56,
+        "avgNodes": 30360,
+        "perPositionDepth": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          3,
+          3
+        ]
+      },
+      {
+        "config": "TOPM-10",
+        "avgDepth": 4.33,
+        "avgNodes": 19653,
+        "perPositionDepth": [
+          5,
+          4,
+          5,
+          4,
+          4,
+          5,
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M10-K2",
+        "avgDepth": 4,
+        "avgNodes": 21348,
+        "perPositionDepth": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M14-K3",
+        "avgDepth": 4,
+        "avgNodes": 22041,
+        "perPositionDepth": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ]
+      }
+    ],
+    "advanced": [
+      {
+        "config": "ALL",
+        "avgDepth": 3.89,
+        "avgNodes": 45879,
+        "perPositionDepth": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          3
+        ]
+      },
+      {
+        "config": "TOPM-10",
+        "avgDepth": 4.67,
+        "avgNodes": 35194,
+        "perPositionDepth": [
+          5,
+          4,
+          5,
+          4,
+          5,
+          5,
+          5,
+          5,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M10-K2",
+        "avgDepth": 4.44,
+        "avgNodes": 32619,
+        "perPositionDepth": [
+          4,
+          4,
+          5,
+          4,
+          4,
+          5,
+          5,
+          5,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M14-K3",
+        "avgDepth": 4.11,
+        "avgNodes": 37020,
+        "perPositionDepth": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          5,
+          4,
+          4,
+          4
+        ]
+      }
+    ],
+    "expert": [
+      {
+        "config": "ALL",
+        "avgDepth": 3.89,
+        "avgNodes": 53274,
+        "perPositionDepth": [
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          3
+        ]
+      },
+      {
+        "config": "TOPM-10",
+        "avgDepth": 4.78,
+        "avgNodes": 40201,
+        "perPositionDepth": [
+          5,
+          4,
+          5,
+          4,
+          5,
+          5,
+          5,
+          5,
+          5
+        ]
+      },
+      {
+        "config": "CARD-M10-K2",
+        "avgDepth": 4.44,
+        "avgNodes": 36260,
+        "perPositionDepth": [
+          4,
+          4,
+          5,
+          4,
+          4,
+          5,
+          5,
+          5,
+          4
+        ]
+      },
+      {
+        "config": "CARD-M14-K3",
+        "avgDepth": 4.22,
+        "avgNodes": 42684,
+        "perPositionDepth": [
+          4,
+          4,
+          5,
+          4,
+          4,
+          5,
+          4,
+          4,
+          4
+        ]
+      }
+    ]
+  }
+}

--- a/docs/bench-results/issue-235-poc2.json
+++ b/docs/bench-results/issue-235-poc2.json
@@ -1,0 +1,82 @@
+{
+  "schema": "issue-235-poc2/v1",
+  "description": "Issue #235 PoC-2 ValueModel: modifyBoard 型 (eval 差分) と setTrap 型 (P_trigger×E_damage) の 2 関数で 5 カードを per-card switch なしにカバーし、トラップ価値を固定定数から局面依存に置換できることの実証。",
+  "measuredAt": "2026-06-06T14:24:01.606Z",
+  "commitSHA": "1185067aab049d5e753778169dfbcba69348b517",
+  "fixedConstantsReplaced": {
+    "TRAP_VALUE_CHECK_BREAK": 80,
+    "TRAP_VALUE_NO_PROMOTE": 50,
+    "note": "現状これらは局面非依存の固定値。valueModelSetTrap は玉露出度で変動する期待値に置換。"
+  },
+  "pocCoefficients": {
+    "SAFETY_REF": 150,
+    "SAFETY_SPAN": 400,
+    "P_MIN": 0.05,
+    "P_MAX": 0.9,
+    "CHECK_BREAK_E_DAMAGE": 300,
+    "NO_PROMOTE_E_DAMAGE": 160,
+    "note": "PoC 仮値。本採用時は S3 で bench 校正する。"
+  },
+  "effectSpecCoverage": {
+    "modifyBoard": [
+      "pawn_return",
+      "piece_return",
+      "double_pawn"
+    ],
+    "setTrap": [
+      "check_break",
+      "no_promote"
+    ],
+    "functionsCount": 2,
+    "measuredStatus": "5 カード全て実測 (modifyBoard 3 + setTrap 2)。exposed-king は王手中のため modifyBoard 系が全 -∞ (有効 target なし) = 正常。",
+    "note": "5 カードを 2 関数でカバー = ファイル横断の per-card switch 増殖なし。各カードの差は valueModelSetTrap 内の E_damage 等の per-card パラメータ (= データ) で、これは CardSpec.valueModel の data-driven 設計の意図通り (S2 registry 化で吸収)。"
+  },
+  "caveats": {
+    "coefficientsArePlaceholder": "setTrap 係数 (E_damage/P_MIN/P_MAX/SAFETY_*) は PoC 仮値で、-25↔+230 の差は係数選択に依存。本採用値は S3 bench 校正まで未確定。",
+    "noPromoteTriggerPerspective": "triggerProbability は自玉露出度を使用。check_break は自玉が王手される確率に連動するため妥当だが、no_promote は相手の成り活動を阻止するカードで、本来は相手の成り脅威指標で trigger 確率を測るべき → S3 で no_promote 専用 trigger に分離検討。",
+    "positionDependentNotEqualStrength": "本 PoC は『局面依存値付けが簡潔関数で可能』の実証であり、棋力向上の証明ではない (棋力は S3 bench で評価)。",
+    "perTargetEvalCost": "valueModelModifyBoard は 81 マス全 simulateCardEffect+eval。selection (top-K) では PoC-1 同様 target 数の上限/安価 proxy で bounded 化する必要 (本 PoC は値付け実現性の実証に限定)。"
+  },
+  "rows": [
+    {
+      "position": "initial(safe)",
+      "kingSafety": 154,
+      "pTrigger": 0.05,
+      "pawn_return_vm": 100,
+      "piece_return_vm": 80,
+      "double_pawn_vm": null,
+      "check_break_vm": -25,
+      "no_promote_vm": -22
+    },
+    {
+      "position": "midgame-12ply",
+      "kingSafety": 154,
+      "pTrigger": 0.05,
+      "pawn_return_vm": 85,
+      "piece_return_vm": 70,
+      "double_pawn_vm": 145,
+      "check_break_vm": -25,
+      "no_promote_vm": -22
+    },
+    {
+      "position": "midgame-24ply",
+      "kingSafety": 144,
+      "pTrigger": 0.06,
+      "pawn_return_vm": 15,
+      "piece_return_vm": 70,
+      "double_pawn_vm": 130,
+      "check_break_vm": -21.2,
+      "no_promote_vm": -20
+    },
+    {
+      "position": "exposed-king",
+      "kingSafety": -751,
+      "pTrigger": 0.9,
+      "pawn_return_vm": null,
+      "piece_return_vm": null,
+      "double_pawn_vm": null,
+      "check_break_vm": 230,
+      "no_promote_vm": 114
+    }
+  ]
+}

--- a/docs/bench-results/issue-235-poc3.json
+++ b/docs/bench-results/issue-235-poc3.json
@@ -1,0 +1,28 @@
+{
+  "schema": "issue-235-poc3/v1",
+  "description": "Issue #235 PoC-3 TT cardState ハッシュ: computeHash(board) に cardState (mana/手札種別カウント/trap/drawProgress) を XOR fold した hash で (A) board+fold次元の誤ヒット解消 (B) 衝突率・TT 断片化を測定。",
+  "measuredAt": "2026-06-06T14:22:42.038Z",
+  "commitSHA": "1185067aab049d5e753778169dfbcba69348b517",
+  "foldedFields": "両プレイヤーの mana / 手札カード種別カウント / trap defId / drawProgress",
+  "notFolded": "deck 順 (auto-draw で引く先頭札)。同一 fold・異 deck の 2 状態は同一 hash → draw 後の分岐が異なる残存誤ヒットが理論上ある。→ 『board+fold次元の誤ヒット解消』であり完全解消ではない。S4 で card-aware ノードの保守的 store (depth 制限/verify 強化) で対応する検討事項。",
+  "ttSizeNote": "TT_SIZE=1<<22 (4M entries) は不変。hash 関数のみ拡張 → メモリ予算に影響なし。",
+  "determinismNote": "deck は決定的に構築 (シャッフルなし) + seeded playout で、distinctGroundTruths/boardOnly/cardAware/fragmentation/衝突数は run 間再現 (確認済)。indexCollisionSlots のみ run 間変動 (24〜37) — これは computeHash (zobrist.ts) の PIECE_KEYS が production の Math.random 生成で、TT index 分布が乱数 key に依存するため (production TT と同性質)。hi 検証で解決される birthday-paradox 診断値で、PoC の決定性欠陥ではない。",
+  "fragmentationCaveat": "fragmentationRatio≈1.0 は random playout が transposition (同一盤面に別手順で到達) を過小サンプリングした下界。実探索では同一盤面が別 cardState で到達する transposition が増え断片化が上がりうる → S4 で TT instrument 搭載探索で実測する。",
+  "partA": {
+    "variants": 64,
+    "distinctGroundTruths": 64,
+    "distinctBoardOnlyHashes": 1,
+    "distinctCardAwareHashes": 64
+  },
+  "partB": {
+    "playouts": 400,
+    "maxPly": 40,
+    "distinctGroundTruths": 15159,
+    "distinctBoardOnlyHashes": 15151,
+    "distinctCardAwareHashes": 15159,
+    "fragmentationRatio": 1.001,
+    "cardAwareCollisionHashes": 0,
+    "cardAwareCollisionPairs": 0,
+    "indexCollisionSlots": 30
+  }
+}

--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -270,18 +270,18 @@ L0 統合 (reducer/AI が単一カーネル `applyTurnAction` に委譲) は最�
 #### 8.5.1 feature-flag 設計 (additive + 影 + 段階切替)
 - **カーネルは既存経路を消さず additive に新設**。最終 cutover まで production の振る舞いは旧経路が支配。
 - **AI 探索側**: config フラグ `useKernelSearch` (既定 OFF) で「既存 engine」⇔「カーネル委譲 engine」を切替。OFF = PR3-3 完了時点の振る舞い完全保持。card-shogi のみ対象、standard は分岐に入れない。
-- **reducer (UI) 側**: カーネルを reducer の**実装裏側**に置き、reducer は薄いラッパに後退。移行中は **shadow-assert モード** (dev/test 限定): reducer が旧経路結果とカーネル結果の両方を計算し §8.3 の must-match 射影で `===` を assert、**採用するのは旧経路結果**。等価が安定したら採用をカーネルへ flip。本番ビルドでは shadow を無効化 (二重計算コストを避ける)。
+- **reducer (UI) 側 (2026-06-07 lean 改訂で shadow-assert 不採用)**: カーネルを reducer の**実装裏側**に置き、reducer は薄いラッパに後退する方針は維持。ただし移行中の **shadow-assert モードは廃止**。理由: S1a の property-based 等価テスト (reducer dispatch ≡ applyTurnAction を数千局面で検証済) が等価担保の主目的を達成済で、throwaway な二重計算コードを production reducer に入れる価値が小さいため。reducer の薄ラッパ化 (各演出フェーズが kernel building-block を呼ぶ委譲) は S1d cutover で一括実施し、等価は property test + reducer.test/undo/effects + 演出オーケストレーション統合テストで担保する。
 - **standard variant**: カーネル分岐に一切入れず byte-level 不変 (§12 不変ゲート)。
 
 #### 8.5.2 段階統合 (S1a〜S1d、各段で不変ゲート green)
 1. **S1a**: `WorldState` 型 + `applyTurnAction` を**新規モジュールとして追加** (production 未配線)。§8.3.4 の property-based 等価テストを同時に author し green 化。reducer.test/undo-policy.test/effects.test は不変。
 2. **S1b**: AI 探索を `useKernelSearch` フラグ裏で配線 (既定 OFF)。bench で旧経路と depthCompleted/カード使用率比較。
-3. **S1c**: reducer を薄いラッパ化し shadow-assert モードで旧経路と並走。reducer.test/undo-policy.test/effects.test green を**全コミットで維持**。
-4. **S1d**: 等価テスト + bench green 確認後に既定をカーネルへ flip (AI: `useKernelSearch` ON、reducer: 採用切替)。shadow を本番無効化。
+3. **S1c (lean 改訂)**: `makeMoveWithEffects` (+ `MakeMoveMode`) を reducer.ts → 新規 lib モジュール `src/lib/shogi/kernel/move-effects.ts` へ**物理移設のみ** (reducer は import して従来どおり直接呼ぶ、ロジック無改変)。world-kernel (lib) → reducer (hooks) の暫定逆依存を解消。**挙動完全不変・純粋リファクタ**。shadow-assert は廃止。reducer.test/undo-policy.test/effects.test/property 等価テスト green を維持。
+4. **S1d (cutover)**: 等価テスト + bench green 確認後に単一コミットで ① reducer を kernel building-block へ委譲 (薄ラッパ化、shadow-assert なし) ② 既定をカーネルへ flip (AI: `useKernelSearch` ON)。S1c で reducer ロジックは未変更のため、reducer 振る舞いを変える cutover は本段に隔離される。等価は property test + reducer.test/undo/effects + 演出オーケストレーション統合テストで担保。
 
 #### 8.5.3 rollback 手順 (多層)
 - **第1層 (無コード)**: 不具合時は **フラグを OFF に戻すだけ**で旧経路へ即時復帰 (S1d 後も flag は残置)。
-- **第2層 (git)**: カーネルは S1a〜S1c で additive (新規ファイル)、production 振る舞いを変える cutover は **S1d の単一コミットに隔離** → `git revert <S1d-cutover>` で旧経路復帰。各コミットは atomic・reversible。
+- **第2層 (git)**: S1a/S1b は additive (新規ファイル + フラグ既定 OFF)、S1c は production 振る舞い不変の純粋リファクタ (関数の物理移設のみ、reducer ロジック無改変)。production 振る舞いを変える cutover は **S1d の単一コミットに隔離** → `git revert <S1d-cutover>` で旧経路復帰。各コミットは atomic・reversible。
 - **第3層 (test gate)**: reducer.test/undo-policy.test/effects.test + property-based 等価テストを cutover の blocking gate に。1 つでも赤なら cutover しない。
 - **test isolation**: 等価テストは旧 reducer 経路 vs カーネル経路を同一ランダム TurnAction 列で並走し must-match 射影 (§8.3.1) を deep-equal 比較。DP-1〜7 を seed 済みエッジケースで固定。
 

--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -1,0 +1,286 @@
+# Issue #235: カード将棋 AI 土台再設計 — 設計ドキュメント (単一情報源)
+
+> 本ドキュメントはカード将棋 AI 土台再設計の **単一情報源 (single source of truth)**。
+> 多エージェント徹底調査 (10 agents) + 設計提案 + 敵対的検証の統合結果。各段階の実装はここを参照する。
+
+## 0. 文書管理
+
+| 項目 | 内容 |
+|---|---|
+| epic Issue | [#235](https://github.com/ryuichiTtb/Shogi/issues/235) カード将棋AI 土台再設計 |
+| 親 (AI強化 epic) | [#193](https://github.com/ryuichiTtb/Shogi/issues/193) — 探索・評価再設計部分を本 epic が引き取る |
+| 共通レビュー観点 | [#109](https://github.com/ryuichiTtb/Shogi/issues/109) |
+| 起点 | `origin/main` = `1185067` |
+| 本 doc ブランチ | `feature/#235-design` (worktree `.claude/worktrees/issue-235-design`) |
+| ステータス | **S0 起草中 (実装着手前、adversarial verify + ユーザーレビュー待ち)** |
+
+> #193/#235 自動クローズ注意: コミット/PR で `fix: #193` 形式を使わない (GitHub クローズキーワード)。`feat:` は安全、PR 本文は `Refs`。
+
+---
+
+## 1. 背景・現状 (なぜ土台から作り直すか)
+
+現状の card-shogi CPU は「**強い通常将棋エンジン (move-only negamax + αβ/TT/killer/history/LMR/quiescence) を不変に保ち、カードを root に薄く後付け**」した二重構造。多エージェント調査で確認した根本問題:
+
+| # | 根本問題 | 実体 (path) |
+|---|---|---|
+| **P1** | 探索の深さ非対称・二重探索 | move は深さN本物探索 (`search.ts:322` negamax)、card/draw は `engine.ts` root の別系統 (`evaluateActionWithLookahead`、`search.ts:1115`) が並走。相手応答は常に move-only 1-ply (`getOpponentResponseScore`)。※ parked ブランチ `feature/#193-pr3-3-2` は本経路を `evaluateActionDeep`(budget再帰)に拡張済だが未マージ・本再設計で L2 に吸収 |
+| **P2** | カード価値が内容非依存のスカラー圧縮 | `CardDigest` 6スカラー (`digest.ts:34`) = mana/手札枚数/draw/trap有無。各カードが盤面を何 cp 改善するか・局面/コスト依存値を持たない。トラップは固定 (`TRAP_VALUE_*`) |
+| **P3** | 相手手札の隠れ情報モデルが皆無 | `cardState.hand[opponent]` が完全透視 (`state.ts` serialize、AI も参照可)。eventLog は AI に渡らず DB 非永続。相手デッキ構成は初期化後破棄 |
+| **P4** | ルール/状態の二重実装と分離 | 権威 `reducer.ts` (makeMoveWithEffects/applyTurnEndEffects/二手指し/トラップ遅延) と AI 側 (`current-rules.ts`/`action-generator.ts`/`search.ts`) が独立再実装。`GameState`(盤) と `CardGameState`(マナ・手札) も分離し都度手動同期 |
+| **P5** | カード追加が9箇所横断の手作業 | 新カード1枚で types/definitions(+CARD_USE_CONDITIONS)/effects/reducer/undo-policy/digest+heuristics/action-generator/test/seed を手動更新。`effectId` 族別 switch が散在 |
+| **P6** | TT が cardState 非対応 | `zobrist.computeHash` は GameState のみ。同一盤面・別 cardState で誤キャッシュ |
+| **P7** | 時間軸価値が反映されない | PR3-3 C-6 で root の 1-ply lookahead は per-action digest 更新済 (`updateCardDigest`) だが、**深部 negamax/quiescence ノードは root scalar digest 固定**。「N手後に自動ドロー発火」「相手が王手なら check_break 価値UP」等の多手 (N>1) 時間軸価値を捕捉不可 |
+
+> **参照スナップショット**: 上表の path/関数は canonical main (`1185067`、PR3-3 マージ済) 時点。`evaluateActionDeep`/`scanOpponentResponse`/`cardSearchBudget` は parked ブランチ `feature/#193-pr3-3-2` のみの拡張で main には無い (混同回避)。
+
+**実測の裏付け** (parked ブランチ `feature/#193-pr3-3-2` C-2/C-3、main 未マージ): 深掘り (`evaluateActionDeep` budget=1) を入れると、上級でカード使用が 57%→0% に**悪化**。深く読むほど「move-now + card-later ≈ card-now + move-later」で同点化し move を優先 = カードを後回し。これは「カードを一律・固定で粗く評価」している (P2) ことの帰結であり、継ぎはぎの深掘りでは解決しない。**S0 で before-baseline を canonical main (PR3-3) 上で改めて計測**し、PR3-3 単体のカード使用率を基準にする (この 57%→0% は parked 深掘りの結果であり main の現状ではない)。
+
+---
+
+## 2. ビジョン (再設計のゴール = ユーザー要件)
+
+1. **カードのカタログ/データモデル化**: どんなカードがあり何ができコストいくらか等のコア情報を CPU 理解可能な単一構造化データ/フレームワークに。新カード追加・調整はそこを更新するだけ (工数削減・品質担保・テンプレ化)。
+2. **自分・相手の手札を踏まえた判断** (相手手札は隠れ情報)。
+3. **メタ認知/推測**: 相手の使用履歴 → 残りに何があり得ないか。ランク別投入上限 → 既使用枚数から残り推定。
+4. **カード込みの多手読み**: カード使用・ドロー・駒移動を同列に多手先まで探索。各カードを内容・コスト・局面依存で正しく値付け。
+5. **ルール改修/新カード/調整のたびに土台から見直せる構造** (継ぎはぎ修正を脱却)。
+6. **重要部分のデータモデル化・フレームワーク化・テンプレート化で将来エンハンスに強く**。
+
+---
+
+## 3. 目標アーキテクチャ (4層)
+
+カード将棋を「駒+マナ+手札カード+トラップ+ドローを含む単一世界状態上の**不完全情報ゲーム**」として再定義し、4層に再編する。
+
+### L0 — ルール/状態カーネル (単一権威)
+- **`WorldState` = `GameState`(盤) + `CardGameState`(マナ/手札/山札/墓地/trap/drawProgress/noPromoteMarks/lastTurnStartedAt) を統合した不変更新可能な純粋状態。**
+- 唯一の遷移関数 `applyTurnAction(world, action, rules): { world, events, turnEnded }`。**reducer (UI) も AI 探索もこの同一カーネルを呼ぶ** (P4 解消)。reducer は薄い UI ラッパに後退。
+- 既存 `TurnRules` 抽象 (`turn/types.ts`) をカーネルの差替点に活用。`isTurnTerminating` で二手指し等のマルチ ply を表現。
+- **ビジョン⑤** を満たす: ルール改修は L0 の遷移定義1箇所。
+
+### L1 — カードフレームワーク (宣言 + ハンドラ登録)
+- 各カードを単一 **`CardSpec`** に集約し registry 登録 (詳細 §4)。
+- 新カードは `CardSpec` を1つ書くだけで効果適用・候補生成・undo判定・AI値付け・seed が registry 経由で自動追従 (P2/P5 解消)。
+- **ビジョン①⑥** を満たす。
+
+### L2 — 不完全情報探索エンジン (TurnAction が一級市民)
+- move/draw/playCard を区別しない**単一の探索木**。negamax を `WorldState × TurnAction` に拡張し、αβ/TT/killer/history/LMR/quiescence をカード込みで効かせる (詳細 §6)。
+- leaf 評価 = 盤面評価 (既存 evaluators 7成分) + **ValueModel 集約** (内容・局面依存)。子ノードで digest 更新 (P1/P6/P7 解消)。
+- **ビジョン④** を満たす。
+
+### L3 — 相手モデル/メタ認知 (不完全情報)
+- **`OpponentModel`**: 相手の公開デッキスペック (レアリティ別枚数 + `RARITY_MAX_PER_DECK`) + 使用履歴 (eventLog) + ルール上限 → **相手残り手札のカード別存在確率**をベイズ推定 (詳細 §5)。
+- 探索の相手ノードで期待値 minimax。**手札の中身は覗かない (フェア)**。
+- **ビジョン②③** を満たす。超上級で有効化 (= 旧 PR3-4)。
+
+### 横断
+`WorldState`/`CardSpec`/`ValueModel`/`OpponentModel` はすべてデータモデル化・テンプレート化。ルール改修・新カード・調整は「スキーマ値編集 + bench 校正」で完結。standard variant の扱いは §11 D-B で決定。
+
+---
+
+## 4. カードデータモデル/フレームワーク (L1 詳細)
+
+### 現状の分散 (1カードが6ファイル以上に散在)
+`definitions.ts` CARD_DEFS (メタ) + `CARD_USE_CONDITIONS` (関数) + `effects.ts` applyXxx 群 + `digest.ts`/`heuristics.ts` (固定係数) + `action-generator.ts` (候補) + `undo-policy.ts` isCardOpEvent + reducer CONFIRM 分岐。CardId は手書きユニオン (`types.ts`)。
+
+### 目標: 単一 `CardSpec` registry
+```
+interface CardSpec {
+  meta: { id, kind: 'normal'|'trap', name, icon, cost, rarity, phase, status, relatedIssues };
+  targeting: 'none'|'ownPiece'|'enemyPiece'|'square'; // 将来 'multiTarget'
+  effect: EffectSpec;          // 判別共用体 (下記)
+  useCondition?: (world, player) => boolean;          // = CARD_USE_CONDITIONS 内包 (サーバ専用)
+  checkUsage: 'forbidden'|'conditional'|'unconditional';
+  valueModel: (world, player, opp?: OpponentModel) => number; // cp、内容・局面・コスト依存 (P2 解消)
+  eventKind: GameEventKind;    // undo-policy.isCardOpEvent を registry から自動導出
+}
+type EffectSpec =
+  | { type: 'modifyBoard'; apply: (world, player, target) => WorldState | null }   // pawn_return/piece_return/double_pawn
+  | { type: 'setTrap'; trigger: 'promotion_declared'|'check_declared'; onTrigger: (world)=>WorldState } // no_promote/check_break
+  | { type: 'multiPly'; plies: number }                                            // double_move
+  | { type: 'modifyResource'; mana?: number; draw?: number };                      // mana_up 等
+```
+- `simulateCardEffect`/applyXxx/reducer CONFIRM 分岐をこの `effect.apply` 一本に統合 (P5 解消)。
+- **CPU 理解可能性**: AI は registry を単一窓口にクエリ (cost/targeting/effect種別/valueModel)。族別 switch を排除。
+- **テンプレ化**: `EffectSpec.type` 別の雛形 (modifyBoard/setTrap/multiPly/modifyResource) を用意。新カードは type 選択 + パラメータ埋めで雛形生成 (ビジョン⑥)。
+- **CardId**: registry から codegen で型生成 or branded string + ランタイム registry (§11 D-D で方式決定)。
+- **serialize 境界**: 関数を持つ registry はサーバ専用、Client へは `meta` のみ送る (現 `CARD_USE_CONDITIONS` 分離の理由を踏襲)。
+- **系統定数**: `RARITY_MAX_PER_DECK` / マナ定数を `CardSystemConfig` として registry 近傍に集約し phase 別バージョニング可能化 (§11 D-F)。
+
+### 移行方針 (critique R3)
+**完全置き換えでなく段階移行**: 新規カード (Phase A 以降) のみ `CardSpec`、既存7カードは当面 legacy wrapper で旧構造を包む → 新 schema の成功を実証してから既存カード移植。一括移植の工数とデグレリスクを分散。
+
+---
+
+## 5. 相手モデル / メタ認知 (L3 詳細)
+
+### 現状: 皆無
+`cardState.hand[opponent]` 完全透視、negamax は盤面のみ、eventLog は AI 非伝播・DB 非永続、相手デッキ構成は破棄。`RARITY_MAX_PER_DECK` (`deck-rules.ts`: common/rare=無制限, super_rare=10, epic=4) はデッキ編成時のみ参照。
+
+### 目標 OpponentModel
+**情報源パイプライン (新設が前提):**
+1. **eventLog の AI 伝播 + 永続化**: cardPlayEvent/drawEvent に turn/timestamp 付与、`ai-move/route.ts` で cardState と共に engine へ。`GameMove.moveData` か独立テーブル (#193 PR1e と統合、§11 D-E)。
+2. **相手デッキ公開スペックの伝播**: 対局開始時に相手デッキの「レアリティ別枚数 + 上限」を AI へ (**手札の中身は渡さない = フェア**)。
+
+**推定エンジン (ベイズ的):**
+- 初期分布 = 相手デッキ公開スペックから各カードの保有確率の事前分布。
+- 逐次更新: eventLog から「使用済/墓地 = 確定除外」「ドロー = 未知1枚追加 (山札残で条件付け)」「ランク上限から残り可能枚数を制約」を反映し `P(opponent holds card c)` を維持。
+- **軽量近似** (critique R7): 全分布保持はメモリ過大。(a) カード別 marginal 確率 + (b) 主要脅威カード (check_break/double_move) の保有確率のみ精密保持。
+
+**探索への組込み (S5、超上級):**
+- L2 探索の相手ノードで相手の playCard/draw を確率重みで分岐し期待値 minimax。例「相手が check_break を p% 持つなら自分の王手プランの期待値を割引」。
+- **αβ が期待値ノードで効かない既知課題** → 上位脅威カードのみ branch + 確率閾値枝刈り。S0 PoC で実効性を実測 (critique F5/R7)。
+- 低〜中難易度は OpponentModel を使わず弱さ維持、超上級のみ有効化。
+
+### フェアネス (critique R10, §11 D-H)
+現状 AI が相手手札を透視している構造的不公正 (`digest.handValueDelta` も相手手札枚数使用) を是正。AI が使うのは「公開スペック + 履歴 + ルール上限」からの確率推定のみ。**遮断の時期**は D-H で決定。
+
+---
+
+## 6. 探索コア (L2 詳細)
+
+### 目標: カード込み多手読み単一探索木
+1. **単一探索木**: negamax を `WorldState × TurnAction` に一般化。各ノードの候補 = `getLegalTurnActions(world, player)` = 全 move + (許可深さで) draw + playCard。move/draw/playCard を同列に最大化 → 「カード使う→相手応答→自分の続き→…今は安全だからドロー」を同じ木で多手評価。
+2. **ターン制御**: `turnEnded` フラグで二手指し等の同色マルチ ply を player 反転抑止 (現 super-action を木に統合、`double_move` 特別扱い廃止)。
+3. **評価**: leaf = 盤面評価 (既存7成分) + ValueModel 集約。子ノードで cardState 遷移ごとに digest 更新 (P7 解消)。
+4. **TT**: zobrist を cardState 込みに拡張 (`hashLo ^ digestHash`、mana/手札カウント/trap/drawProgress を 32-bit ハッシュ化)。同一盤面・異 cardState の誤 hit 解消 (P6)。card-aware ノードは保守的 store。
+5. **爆発抑制** (最重要、critique F4/R5): ノード分岐を **move 上位 M (`scoreMoveForOrdering`) + カード候補 top-K + draw** に selector で絞る。難易度別 maxDepth/budget/M/K で棋力差。深さ予算超過は findBestMove 既定 move へフォールバック (既存 deadline 流用)。**S0 PoC で「±10% を実現する M/K/budget が存在するか」を先に確定** (C-2 実測 budget=3≈130万 evaluate を起点)。
+6. **相手カード**: 既定は相手 move-only (性能安全)。超上級のみ OpponentModel の確率分布で相手 playCard/draw を期待値展開 (S5)。
+
+### 移行戦略 (critique R9, F6)
+一気に置換せず: (a) card-shogi 専用 TurnAction-negamax を既存 move-only negamax と**並走** (standard は触らない) → (b) bench で depthCompleted/棋力を旧経路と比較 → (c) 優位確認後に engine root 統合切替。standard は当面既存 negamax 温存 (二重保守期限は §11 D-B)。
+
+---
+
+## 7. 段階計画 (S0〜S6)
+
+各段で Issue #109 観点レビュー3マイルストーン (計画直後/実装後/マージ前)、standard byte-level 不変、bench ゲートを適用。ブランチは `feature/#235-{slug}` を `origin/main`/親ブランチ起点、worktree 分離。
+
+| 段 | prefix | ゴール | 主要 DoD |
+|---|---|---|---|
+| **S0** | docs/chore | 設計確定 + before-baseline + **PoC de-risk** | 本 doc 確定 / 現状の棋力・性能・全難易度カード使用率を before 計測 / PoC: (a)探索枝刈り±10%可否 (b)ValueModel 1-2カード試作 (c)TT cardState ハッシュ衝突/ヒット率 → **「実現可能か」を判定** |
+| **S1** | refactor | L0 状態/ルールカーネル統合 | `WorldState`+`applyTurnAction` 新設、reducer/AI がカーネル委譲。reducer.test/undo-policy.test/effects.test 不変 (property-based 等価)。standard byte-level 不変 |
+| **S2** | refactor+feature | L1 カードフレームワーク化 | `CardSpec` registry + EffectSpec。既存7カード移植 (legacy wrapper 経由の段階移行可)。CardId codegen。effects/reducer分岐/undo を registry 駆動 |
+| **S3** | feature | L1 内容依存値付け | ValueModel でカードを局面・コスト依存に。固定係数 (TRAP_VALUE_* 等) 脱却。digest は集約キャッシュへ。bench で旧評価比較・校正 |
+| **S4** | feature | L2 TurnAction 単一探索 + TT 拡張 **(最重要)** | card-shogi 専用 TurnAction-negamax (standard 温存)。zobrist cardState 拡張・誤hit対策。selector(M/K/budget)。double_move 木統合。before-baseline 比 depthCompleted ±10% + カード使用率改善 |
+| **S5** | feature | L3 相手モデル/期待値読み (超上級) | OpponentModel (ベイズ残り手札)。eventLog 伝播+永続化。相手ノード確率分岐+閾値枝刈り。超上級のみ。フェアネス (手札非透視) を test 固定。**依存 (blocking): eventLog 永続化は #193 PR1e の DB schema と協調が前提 → S5 着手条件に PR1e completion を明記** |
+| **S6** | chore+feature | 仕上げ・新カード運用確立 | テンプレ化された追加フロー (AGENTS.md 更新)。phase 別レアリティ上限 config 化。exhaustive fixture。Phase A カードを新フローで1枚追加し工数・品質実証 |
+
+> 段の粒度はトレードオフ (critique 弱点)。S4 が大きすぎる場合は **S4a 基礎探索 + S4b 最適化/校正** に分割する (PoC 結果で判断)。
+
+---
+
+## 8. S0 詳細 (今の作業 = PoC-first で de-risk)
+
+critique が「方向性は正当だが理想像、PoC で実現性を先に確定すべき」と強く推奨。S0 を以下に特化。**PoC はすべて `feature/#235-poc-{n}` 独立ブランチで実装し main へマージしない (S0 完了時に破棄)。production コードは S0 では一切変更しない。** 各 PoC は seed 固定 fixture で決定的に自動計測する。
+
+### 8.1 設計 doc 確定
+本ファイル + adversarial verify + ユーザーレビュー (= 現在地)。
+
+### 8.2 before-baseline 計測・固定 (completeness-3)
+- **対象**: canonical main (`1185067`) の (a) `perf-bench.test.ts` depthCompleted/nodes (全4難易度・代表 midgame fixture)、(b) `perf-bench-card-usage.test.ts` カード使用率 (**全4難易度 = 中級含む**)、(c) 代表局面の棋力指標 (rootMoveScore 等)。
+- **方法**: `RUN_PERF_BENCH=true` で 3 回計測し中央値。
+- **保存先**: `docs/bench-results/issue-235-before-baseline.json` (commit)。以降の全段 DoD は本ファイル比で判定。
+
+### 8.3 PoC-0 ルール等価 property 仕様確定 (completeness-2 / S1 前提)
+S1 (L0 カーネル統合) の「振る舞い完全等価」を担保する **property list** を S1 着手前に固定:
+- 等価対象: `applyTurnAction` 後の `WorldState` が既存 reducer 経路と {盤面 zobrist, mana, hand 構成, deck, graveyard, trap, drawProgress, noPromoteMarks, turnEnded, events 列} で一致。
+- 等価が**許容されない**箇所 (演出 flag・タイムスタンプ等) を明示。
+- 検証手段: reducer.test/undo-policy.test/effects.test を不変ゲート + property-based (ランダム局面列で reducer 経路 vs カーネル経路の状態一致)。
+
+### 8.4 PoC (実現性ゲート) — 合否基準を operationalize
+- **PoC-1 探索枝刈り (R-1 最大リスク)**: 独立 PoC で `selectBranchCandidates(actions, depth, M, K)` (move 上位M + card 上位K + draw) を試作し、難易度別 `M/K/budget` を振って depthCompleted を計測。
+  - **合否バンド** (before-baseline 比、複数 run の統計): **±10% 以内=合格・S4 着手** / ±10〜20%=要再試行 (M/K 再調整) / **±20% 超=不合格** → フォールバック: (i) S4 目標を「depthCompleted −X% 許容 + カード使用率 +Y%」へ再定義、(ii) S4 を S4a(基礎探索) / S4b(最適化・校正) に分割、(iii) カード深掘りを playCard のみ・浅 budget に限定。
+  - 起点参考: parked C-2 実測「フル盤面 budget=3 ≈ 130万 evaluate (枝刈りなし)」。枝刈りで K=1〜2 がどこまで圧縮できるかを表で提示。
+- **PoC-2 ValueModel (R-5)**: `pawn_return`(modifyBoard 型) と `check_break`(setTrap 型) の `valueModel(world, player)` を試作。検証=「簡潔な関数で内容・局面依存値付けが可能か / 条件分岐が増殖しないか」。trap は「相手が trigger を踏む確率 × 被害 cp」の期待値関数の実現性を確認。**modifyBoard 型と setTrap 型の両系統**をカバー (単一カード種では不足、PoC-2 拡張)。
+- **PoC-3 TT cardState ハッシュ (R-2)**: cardState 6要素を fold した 32-bit hash を試作し、(a) 衝突率 (b) 既存 move-only TT のヒット率悪化 を小規模盤面で測定。card-aware ノードの保守的 store 方針の妥当性も確認。
+
+### 8.5 S1 リスク準備 (completeness-12)
+S0 完了条件に「S1 実装計画 + rollback 手順 + feature-flag 設計レビュー完了」を含める (L0 統合は最大の technical risk のため、段階統合・test isolation・差し戻し手順を先に用意)。
+
+### 8.6 S0 完了の定義 (DoD)
+- [ ] 本設計 doc 確定 (adversarial verify 反映 + ユーザー合意)
+- [ ] before-baseline 計測完了・`docs/bench-results/issue-235-before-baseline.json` に保存
+- [ ] PoC-0 property list 確定
+- [ ] PoC-1/2/3 完了・各合否判定 (特に PoC-1 の ±10% 実現可否で S4 粒度・目標値を確定)
+- [ ] S1 実装計画 + rollback 手順を doc 化
+- [ ] PoC 結果に基づき S1-S6 の DoD/粒度/目標値を本 doc に確定反映
+
+---
+
+## 9. #193 との関係・引き継ぎ
+
+`#193` (AI 棋力強化 epic) の **探索・評価エンジン再設計部分を本 epic #235 が引き取る**。
+
+| #193 項目 | 状態 | 本 epic での扱い |
+|---|---|---|
+| PR3-1 校正 (getDrawValue/トラップ/死にマナ/handValue) | main マージ済 | **再利用** → L1 ValueModel の出発点 (内容・局面依存へ進化) |
+| PR3-2 `updateCardDigest` | main マージ済 | **再利用** → L2 ノード別 digest キャッシュ |
+| PR3-3 1-ply lookahead + 校正回帰テスト + honesty 修正 | main マージ済 | lookahead 機構は L2 に**置換**。テスト・修正は**継承** |
+| PR2 evaluators 分割 / cardDigest (PR1d) | main マージ済 | **再利用** → L2 leaf 盤面評価 / ValueModel 集約キャッシュ |
+| **PR3-3-2 深掘り** (`feature/#193-pr3-3-2`) | 進行中・逆効果 | **park** (L2 に吸収。マージしない、§11 D-A) |
+| **PR3-4 相手期待値モデル** | 未着手 | **= L3 OpponentModel** に正式統合 (S5) |
+| PR1e 棋譜DB schema | 未着手 | **連携** → L3 の eventLog/相手デッキ永続化と統合 (§11 D-E) |
+| PR4 データ投入 / PR5 Vercel Pro / PR6 NNUE | 未着手 | #193 に**据え置き** (NNUE は将来 L1/L2 拡張点) |
+
+捨てるのは「逆効果の深掘りパッチ (PR3-3-2)」のみ。校正・評価器・digest・相手モデルの意図はすべて新土台に乗る。
+
+---
+
+## 10. リスクと対策 (敵対的検証反映)
+
+| # | リスク | 対策 |
+|---|---|---|
+| R-1 | **S4 候補爆発** (C-2 実測 budget=3≈130万 evaluate) | S0 PoC-1 で M/K/budget の±10%実現可否を**先に確定**。難易度別 selector。深さ予算超過は findBestMove 既定 move フォールバック。根拠なき「枝刈りで解決」を避ける |
+| R-2 | **TT cardState 拡張の誤hit/メモリ/ヒット率低下** | S0 PoC-3 で衝突率・ヒット率測定。card-aware ノードは保守的 (upper) store。4M entries のメモリ予算 (Vercel) 再評価 |
+| R-3 | **S1/S2 の広範囲リファクタでデグレ** (二手指し/トラップ遅延/undo/自動ドロー) | reducer.test/undo-policy.test/effects.test を不変ゲート。property-based で振る舞い完全等価検証 (property リストを S1 着手前に明文化、critique R2) |
+| R-4 | **OpponentModel 誤推定で超上級が弱体化/不自然** | S0/PoC で小規模実証。主要脅威カードのみ精密の近似。bench で旧 expert と棋力比較必須 |
+| R-5 | **ValueModel 校正難航・bench flaky 再来** | 決定的 unit test + sanity-only bench に分離 (PR3-3 C-13 方針踏襲) |
+| R-6 | **standard variant 二重保守の恒久化** | §11 D-B で統合期限を明記。L0 カーネル設計時に standard 互換層/分岐層を明示 |
+| R-7 | **工期の順序依存・長期化** | S0 で段粒度・DoD を確定。S4 を S4a/S4b 分割可能に。PoC で目標値を現実化 |
+| R-8 | **フェアネス (相手手札透視) が S5 まで残る** | §11 D-H で早期遮断するか決定 |
+
+---
+
+## 11. 未決事項 (ユーザー判断、私の推奨つき)
+
+| ID | 論点 | 推奨 |
+|---|---|---|
+| **D-A** | PR3-3-2 の扱い | **park** (マージしない)。深掘りは逆効果・L2 に吸収。確定済 (ユーザー Q1 回答で「新方針に乗せる」方針) |
+| **D-B** | standard variant 最終形 | **当面は既存 negamax 温存 (card-shogi のみ新エンジン)**。対策: (1) L0 設計時に standard 互換層 interface を明示 (variant 駆動の条件分岐を集約)、(2) **S2-S3 完了時点で「standard 統合タスク」を評価 Issue 起票し S5-S6 着手条件に明記** (恒久二重保守の期限化)、(3) 全段 DoD に standard byte-level 不変を固定 (§12) |
+| **D-C** | OpponentModel 精度・有効化難易度 | 主要脅威カードのみ精密 + 超上級のみ有効化 (= 旧 PR3-4)。上級含めるかは S5 bench で判断 |
+| **D-D** | CardId/registry の codegen 方式 | branded string + ランタイム registry を既定 (ビルド複雑度低)。型安全が不足なら codegen を S2 で検討 |
+| **D-E** | eventLog 永続化先 | #193 PR1e と統合し**独立テーブル** (遡及・分析・PvP 見据え)。DB schema 変更を伴うため S5 着手時に PR1e と協調 |
+| **D-F** | レアリティ上限バージョニング | `CardSystemConfig` の config で runtime 切替 (DB schema 不変) を既定。頻繁な試験変更に強い |
+| **D-G** | 移行のリスク許容度 | big-bang 不可。S0-S6 段階 + 各段 DoD (depthCompleted ±10%, カード使用率目標) を PoC 結果で確定 |
+| **D-H** | フェアネス是正の時期 | S1-S2 中間で「相手手札を探索入力から早期遮断」を推奨。移行設計: (1) `anonymizeOpponentHand()` で探索入力から相手手札中身を除去 + 「AI が相手手札中身を入力に使わない」を assert する test fixture を先に作成、(2) 現評価の `handValueDelta` 等が相手手札枚数に依存する箇所を「公開情報 (枚数は可視) のみ」に整理し透視前提を段階的に剥がす |
+
+---
+
+## 12. 検証方針 (de-risk ゲート)
+
+- **S0 PoC ゲート**: PoC-1/2/3 の結果で「実現可能か」を判定。±10% が無理なら目標棋力 or 段粒度を見直し (理論でなく実測で決める)。
+- **不変ゲート**: 全段で standard variant byte-level 不変 + reducer/undo/effects テスト不変。
+- **棋力ゲート**: before-baseline 比 depthCompleted ±10%。多面指標 (棋力 variance / phase別カード使用率 / undo 堅牢性) も併用 (critique 指摘、単一指標を避ける)。
+- **フェアネス test**: AI が相手手札の中身を探索入力に使っていないことを test で固定 (S5、D-H 早期なら S1-S2)。
+- **必須チェック** (AGENTS.md ルール6): 各段 lint→typecheck→test:ci→build。bench は `RUN_PERF_BENCH=true`。
+
+---
+
+## 13. 設計 doc adversarial verify 反映 (4観点 / 47 agents / 43 確定)
+
+初稿に対し doc 検証 workflow (忠実性/決定/PoC充足/完全性) を実施し反映:
+- **忠実性 (F-001 high)**: 初稿が parked ブランチ用語 `evaluateActionDeep`/`scanOpponentResponse`/`cardSearchBudget` を「現状」として参照していた誤りを訂正 → canonical main は `evaluateActionWithLookahead`/`getOpponentResponseScore` (§1 + 参照スナップショット明記)。
+- **P7 明確化 (F-002)**: PR3-3 C-6 は 1-ply root で per-action digest 更新済、深部ノードは固定 = 多手時間軸が未捕捉、と正確化。
+- **実測の出典 (F-015)**: 57%→0% は parked 深掘りの結果であり main の現状でない旨を明記、before-baseline を main で再計測 (§8.2)。
+- **PoC 具体化 (PoC-1/完全性群)**: §8 を S0 として全面具体化 — PoC は独立ブランチ・production 不変、PoC-1 合否バンド (±10/20%) + フォールバック、PoC-0 property list、before-baseline 仕様 (保存先)、PoC-2 を modifyBoard+setTrap 両系統に拡張、S1 rollback 準備、S0 DoD 明文化。
+- **決定補強 (D-B/D-H high)**: standard 統合の期限化 (S2-S3 で評価 Issue 起票)、フェアネス移行の具体手順 (anonymizeOpponentHand + test fixture)。
+- **依存明記 (completeness-8)**: S5 が #193 PR1e (eventLog 永続化) に blocking 依存。
+
+> 残 medium/low (各段 DoD の数値バンド詳細等) は S0 PoC 確定後に各段の plan doc で operationalize する方針 (本 epic doc はアーキ + 決定 + S0 を確定する層)。棄却なし (43/43 確定だが検証は寛容傾向のため、本反映は実装影響のある指摘に重点)。
+
+---
+
+## 付録: 調査の根拠 (10 agents)
+本 doc は「8領域の現状調査マップ + 設計提案 + 敵対的検証」の統合。各領域の patchSeams/visionGaps と提案の coreProblems/phasedPlan、critique の gaps/feasibilityConcerns/recommendations を反映済。詳細ログは session workflow 出力に保持。

--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -273,7 +273,9 @@ L0 統合 (reducer/AI が単一カーネル `applyTurnAction` に委譲) は最�
 - **reducer (UI) 側 (2026-06-07 lean 改訂で shadow-assert 不採用)**: カーネルを reducer の**実装裏側**に置き、reducer は薄いラッパに後退する方針は維持。ただし移行中の **shadow-assert モードは廃止**。理由: S1a の property-based 等価テスト (reducer dispatch ≡ applyTurnAction を数千局面で検証済) が等価担保の主目的を達成済で、throwaway な二重計算コードを production reducer に入れる価値が小さいため。reducer の薄ラッパ化 (各演出フェーズが kernel building-block を呼ぶ委譲) は S1d cutover で一括実施し、等価は property test + reducer.test/undo/effects + 演出オーケストレーション統合テストで担保する。
 - **standard variant**: カーネル分岐に一切入れず byte-level 不変 (§12 不変ゲート)。
 
-#### 8.5.2 段階統合 (S1a〜S1d、各段で不変ゲート green)
+#### 8.5.2 段階統合 (S1a〜S1d、各段で不変ゲート green) — **S1 全段完了 (2026-06-07)**
+> **S1 完了**: S1a/S1b/S1c/S1d すべて完了・push 済。L0 カーネルが reducer/AI の単一権威として採用済 (P4 解消)。
+> 完了の定義・S2 引き継ぎは `docs/plans/issue-235-s1-kernel.md §16` を正本とする。次段 = S2 (L1 CardSpec registry)。
 1. **S1a**: `WorldState` 型 + `applyTurnAction` を**新規モジュールとして追加** (production 未配線)。§8.3.4 の property-based 等価テストを同時に author し green 化。reducer.test/undo-policy.test/effects.test は不変。
 2. **S1b**: AI 探索を `useKernelSearch` フラグ裏で配線 (既定 OFF)。bench で旧経路と depthCompleted/カード使用率比較。
 3. **S1c (lean 改訂)**: `makeMoveWithEffects` (+ `MakeMoveMode`) を reducer.ts → 新規 lib モジュール `src/lib/shogi/kernel/move-effects.ts` へ**物理移設のみ** (reducer は import して従来どおり直接呼ぶ、ロジック無改変)。world-kernel (lib) → reducer (hooks) の暫定逆依存を解消。**挙動完全不変・純粋リファクタ**。shadow-assert は廃止。reducer.test/undo-policy.test/effects.test/property 等価テスト green を維持。

--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -293,7 +293,7 @@ L0 統合 (reducer/AI が単一カーネル `applyTurnAction` に委譲) は最�
 - [x] PoC-1/2/3 完了・各合否判定 (§8.4.5、adversarial verify 反映: PoC-1 CONDITIONAL PASS / PoC-2・3 PASS)
 - [x] S1 実装計画 + rollback 手順を doc 化 (§8.5、feature-flag + 段階統合 S1a〜d + 多層 rollback)
 - [x] PoC 結果に基づき S4 を S4a/S4b 分割確定 (§8.4.5 / §7 S4 行)。S2-S6 の数値目標は各段 plan doc で operationalize (本 epic doc はアーキ + S0 確定層)
-- [ ] **本設計 doc 確定 = ユーザーレビュー + 合意待ち** (AGENTS.md ルール8 マイルストーン2: 実装後レビュー相当を adversarial workflow で実施済、ユーザー最終確認が残)
+- [x] **本設計 doc 確定 = ユーザー承認済 (2026-06-07)**。S0 PoC de-risk をユーザー承認 (「承認とします」)、S1 着手指示を受領。レビュー依頼コメントは不要との指示。AGENTS.md ルール8 マイルストーン2 (実装後レビュー相当) は adversarial workflow で実施済。
 
 ---
 

--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -25,10 +25,10 @@
 | # | 根本問題 | 実体 (path) |
 |---|---|---|
 | **P1** | 探索の深さ非対称・二重探索 | move は深さN本物探索 (`search.ts:322` negamax)、card/draw は `engine.ts` root の別系統 (`evaluateActionWithLookahead`、`search.ts:1115`) が並走。相手応答は常に move-only 1-ply (`getOpponentResponseScore`)。※ parked ブランチ `feature/#193-pr3-3-2` は本経路を `evaluateActionDeep`(budget再帰)に拡張済だが未マージ・本再設計で L2 に吸収 |
-| **P2** | カード価値が内容非依存のスカラー圧縮 | `CardDigest` 6スカラー (`digest.ts:34`) = mana/手札枚数/draw/trap有無。各カードが盤面を何 cp 改善するか・局面/コスト依存値を持たない。トラップは固定 (`TRAP_VALUE_*`) |
+| **P2** | カード価値が内容非依存のスカラー圧縮 | `CardDigest` 7フィールド (`digest.ts:34`、PR3-1 で `manaAbsolute`(死にマナ) 追加) = mana/手札枚数/draw/trap有無。各カードが盤面を何 cp 改善するか・局面/コスト依存値を持たない。トラップは固定 (`TRAP_VALUE_*`) |
 | **P3** | 相手手札の隠れ情報モデルが皆無 | `cardState.hand[opponent]` が完全透視 (`state.ts` serialize、AI も参照可)。eventLog は AI に渡らず DB 非永続。相手デッキ構成は初期化後破棄 |
 | **P4** | ルール/状態の二重実装と分離 | 権威 `reducer.ts` (makeMoveWithEffects/applyTurnEndEffects/二手指し/トラップ遅延) と AI 側 (`current-rules.ts`/`action-generator.ts`/`search.ts`) が独立再実装。`GameState`(盤) と `CardGameState`(マナ・手札) も分離し都度手動同期 |
-| **P5** | カード追加が9箇所横断の手作業 | 新カード1枚で types/definitions(+CARD_USE_CONDITIONS)/effects/reducer/undo-policy/digest+heuristics/action-generator/test/seed を手動更新。`effectId` 族別 switch が散在 |
+| **P5** | カード追加が9〜13箇所横断の手作業 | 新カード1枚で types/definitions(+CARD_USE_CONDITIONS)/effects/reducer/undo-policy/digest+heuristics/action-generator/test/seed を手動更新 (実測 11〜13 touch point)。`effectId` 族別 switch が散在 |
 | **P6** | TT が cardState 非対応 | `zobrist.computeHash` は GameState のみ。同一盤面・別 cardState で誤キャッシュ |
 | **P7** | 時間軸価値が反映されない | PR3-3 C-6 で root の 1-ply lookahead は per-action digest 更新済 (`updateCardDigest`) だが、**深部 negamax/quiescence ノードは root scalar digest 固定**。「N手後に自動ドロー発火」「相手が王手なら check_break 価値UP」等の多手 (N>1) 時間軸価値を捕捉不可 |
 
@@ -163,7 +163,7 @@ type EffectSpec =
 | **S1** | refactor | L0 状態/ルールカーネル統合 | `WorldState`+`applyTurnAction` 新設、reducer/AI がカーネル委譲。reducer.test/undo-policy.test/effects.test 不変 (property-based 等価)。standard byte-level 不変 |
 | **S2** | refactor+feature | L1 カードフレームワーク化 | `CardSpec` registry + EffectSpec。既存7カード移植 (legacy wrapper 経由の段階移行可)。CardId codegen。effects/reducer分岐/undo を registry 駆動 |
 | **S3** | feature | L1 内容依存値付け | ValueModel でカードを局面・コスト依存に。固定係数 (TRAP_VALUE_* 等) 脱却。digest は集約キャッシュへ。bench で旧評価比較・校正 |
-| **S4** | feature | L2 TurnAction 単一探索 + TT 拡張 **(最重要)** | card-shogi 専用 TurnAction-negamax (standard 温存)。zobrist cardState 拡張・誤hit対策。selector(M/K/budget)。double_move 木統合。before-baseline 比 depthCompleted ±10% + カード使用率改善 |
+| **S4** | feature | L2 TurnAction 単一探索 + TT 拡張 **(最重要)** | card-shogi 専用 TurnAction-negamax (standard 温存)。zobrist cardState 拡張・誤hit対策。selector(M/K/budget)。double_move 木統合。**S4a で実エンジンに selector を載せ M/K 再校正 → before-baseline 比 depthCompleted ±10%** (PoC-1 は same-engine 比で枝刈り余地を確認済、production 絶対比は S4a 実測) + カード使用率改善 |
 | **S5** | feature | L3 相手モデル/期待値読み (超上級) | OpponentModel (ベイズ残り手札)。eventLog 伝播+永続化。相手ノード確率分岐+閾値枝刈り。超上級のみ。フェアネス (手札非透視) を test 固定。**依存 (blocking): eventLog 永続化は #193 PR1e の DB schema と協調が前提 → S5 着手条件に PR1e completion を明記** |
 | **S6** | chore+feature | 仕上げ・新カード運用確立 | テンプレ化された追加フロー (AGENTS.md 更新)。phase 別レアリティ上限 config 化。exhaustive fixture。Phase A カードを新フローで1枚追加し工数・品質実証 |
 
@@ -179,33 +179,121 @@ critique が「方向性は正当だが理想像、PoC で実現性を先に確�
 本ファイル + adversarial verify + ユーザーレビュー (= 現在地)。
 
 ### 8.2 before-baseline 計測・固定 (completeness-3)
-- **対象**: canonical main (`1185067`) の (a) `perf-bench.test.ts` depthCompleted/nodes (全4難易度・代表 midgame fixture)、(b) `perf-bench-card-usage.test.ts` カード使用率 (**全4難易度 = 中級含む**)、(c) 代表局面の棋力指標 (rootMoveScore 等)。
-- **方法**: `RUN_PERF_BENCH=true` で 3 回計測し中央値。
-- **保存先**: `docs/bench-results/issue-235-before-baseline.json` (commit)。以降の全段 DoD は本ファイル比で判定。
+- **対象**: canonical main (`1185067`) の (a) `perf-bench.test.ts` depthCompleted(avgDepth)/nodes/elapsedMs (全4難易度・代表 midgame fixture、実装済)、(b) `perf-bench-card-usage.test.ts` カード使用率 (全4難易度 = 中級含む)。
+  - **S0 是正**: `perf-bench-card-usage.test.ts` は現状 `["beginner","advanced","expert"]` のみで **intermediate が欠落**していた (PR3-3-2 レビューの「中級未測定」指摘点)。S0 で intermediate を追加 (test-only・AI 挙動不変)。
+- **scope**: S0 before-baseline は **depthCompleted / nodes / card-usage の三軸**に限定。`(c) rootMoveScore 等の棋力スコア指標`は現 bench に未実装のため **S0 scope 外** (PoC-1 以降で必要に応じ `findBestMoveWithStats` の `SearchStats` を拡張)。
+- **方法 (確定、standalone tsx 方式)**: 計測ハーネス `scripts/measure-baseline-235.ts` を `npx tsx` で実行し全4難易度を 3 回計測・中央値で集約。`findBestMoveWithStats` を**直接呼び**、bench fixture (`makeBenchPositions()` 9 局面 / `makeScenarios()` 7 シナリオ) のロジックを再現する。
+  - **vitest parse 方式を採らない理由 (前セッションの教訓)**: ① `perf-bench.test.ts` は `test()` に timeout 未指定 (vitest 既定 5000ms) のため intermediate/advanced/expert が timeout 失敗し計測値が欠落、② vitest は合格テストの `console.log` を既定で非表示にするため値が回収不能。よって vitest 非依存の standalone tsx ハーネスで全難易度を確実計測する。
+  - design ブランチ `feature/#235-design` は canonical main (`1185067`) からの **doc/script/test-only 差分**で `src/` の探索コードは同一 → design worktree での計測 = canonical main の計測 (commitSHA は計測時の HEAD を記録)。
+- **保存先**: `docs/bench-results/issue-235-before-baseline.json` (commit)。以降の全段 DoD は本ファイル比で判定。**注意**: depthCompleted は time-budget 探索のため計測機 CPU 性能に依存 → 各段/PoC の ±10% 比較は同一機・同一条件で取得する。
+- **計測結果 (2026-06-06、commit `414981d`、3 run median)**:
 
-### 8.3 PoC-0 ルール等価 property 仕様確定 (completeness-2 / S1 前提)
-S1 (L0 カーネル統合) の「振る舞い完全等価」を担保する **property list** を S1 着手前に固定:
-- 等価対象: `applyTurnAction` 後の `WorldState` が既存 reducer 経路と {盤面 zobrist, mana, hand 構成, deck, graveyard, trap, drawProgress, noPromoteMarks, turnEnded, events 列} で一致。
-- 等価が**許容されない**箇所 (演出 flag・タイムスタンプ等) を明示。
-- 検証手段: reducer.test/undo-policy.test/effects.test を不変ゲート + property-based (ランダム局面列で reducer 経路 vs カーネル経路の状態一致)。
+  | 難易度 | avgDepth | avgNodes | avgMs | card 使用率 |
+  |---|---|---|---|---|
+  | beginner | 3.00 | 2,263 | 133 | **100%** (7/7) |
+  | intermediate | 5.33 | 30,877 | 1,371 | **100%** (7/7) |
+  | advanced | 5.78 | 48,634 | 2,269 | **57%** (4/7) |
+  | expert | 6.00 | 63,918 | 2,834 | **57%** (4/7) |
+
+  - **再現性**: per-position depthCompleted は 3 run 間でほぼ同一 (expert で一部局面が 6↔7 の微ジッタのみ) → ±10% バンド判定に十分な安定性。
+  - **示唆 (再設計の動機の実証)**: 深い move-only 探索が支配する **advanced/expert で calibration discriminator 3 シナリオ (空手札+マナ余剰/トラップのみ/終盤空手札) が全て `move` に倒れ、card 使用率 100%→57% に低下**。これは P1 (深さ非対称) + P2 (カード価値スカラー圧縮) の帰結であり、L2 単一探索木 + L1 ValueModel で是正すべき構造的非対称が定量化された。pawn_return 4 シナリオは盤面 delta が大きく全難易度で card 採用。
+
+### 8.3 PoC-0 ルール等価 property 仕様確定 (completeness-2 / S1 前提) — **確定 (2026-06-06)**
+
+S1 (L0 カーネル統合) の「振る舞い完全等価」を担保する **property list** を確定。reducer の全遷移面を網羅精読 (PoC-0 workflow: 7 面並列読み + 統合 + 敵対的 3 観点レビュー、11 agents) し、3 レビュアーが収束した high 論点を以下 **DP-1〜DP-7** の設計判断で解決済 (= S1 着手前の正本)。
+
+**source-of-truth = reducer 経路** (recon 確定): AI 側 `current-rules.ts` の `applyAction` は move/double_move のみ実装 (draw/playCard は `throw`)。S1 カーネル `applyTurnAction` が一致させる正本は **reducer 経路** (`makeMoveWithEffects` reducer.ts:373 / `applyTurnEndEffects` :447 / double_move 遅延 finalize :670 / trap 遅延発火 :277-358)。
+
+#### 8.3.1 等価フィールド分類 (must-match / must-not-match)
+- **must-match (12)**: `CardGameState` の {mana, manaCap, hand, deck, graveyard, trap, noPromoteMarks, drawProgress} + 盤面 (board 駒種/owner/promoted + capturedPieces + currentPlayer + status + zobrist) + turnEnded (= currentPlayer 反転の射影) + events 列 (kind + ドメインフィールド射影、`at` timestamp 除外)。
+  - **hand / deck / graveyard**: instanceId 列として**順序込み一致** (draw=末尾 append reducer.ts:1088、consumeNormalCard/applyTrapSet=filter 除去 effects.ts:455/419、いずれも stable)。
+  - **trap**: `{instanceId,defId,owner}` 値一致 (両プレイヤー独立スロット)。
+  - **noPromoteMarks**: → **DP-5 で {row,col} 集合一致に確定**。
+- **must-not-match (= 射影から除外)**: `pendingCard` (UI 確認/ターゲット選択の中間状態、適用完了後は null)、`lastTurnStartedAt` (Date.now() 起点・DB 往復で null・早指し判定用)、`isDrawing`/`pendingDrawSource`/`isPlayingCard`/`pendingPlayCardOpponent`/`isCheckBreakAnimating` (演出オーケストレーション flag)、`selectedSquare`/`legalMoves` 等 UI 状態、`undoSnapshots`/double_move スナップショット (UNDO 層責務)、全 event の `at` (Date.now())。
+
+#### 8.3.2 アクション別 property (事前→事後) 要点
+- **move (通常)**: board=applyMove / mana[player] += 1 (+1 早指し、DP-4 で fastMove=false 固定) clamp / noPromoteMarks=取得駒マーク削除+自駒 from→to 追従 (drop 型は不変) / drawProgress は applyTurnEndEffects 経由 (DP-1) / 相手 trap 発火時のみ trap[opp]=null + trapTriggerEvent / turnEnded=true。
+- **draw (手動)**: 事前=deck 非空 ∧ mana≥DRAW_COST(2) ∧ 自手番 ∧ 非王手。deck 先頭 pop→hand 末尾 append (instanceId 保持) / mana -=2 / drawProgress は DP-1 / events=[drawEvent{source:manual}] / turnEnded=true。
+- **playCard:modifyBoard (pawn_return/piece_return/double_pawn)**: board=effect 適用 / hand=使用カード除去 (+返却駒を持ち駒加算) / mana -=cost / **graveyard=使用カード末尾 append** / noPromoteMarks=対象マスのマーク削除 (pawn/piece_return) / events=[cardPlayEvent{returnedPiece}] / turnEnded=true。
+- **playCard:setTrap (no_promote/check_break)**: trap[player]=設定 / hand=除去 / mana -=cost / **graveyard=不変 (DP-3)** / events=[trapSetEvent] (cardPlayEvent ではない) / turnEnded=true。王手中は checkUsage='forbidden' で BEGIN 拒否。
+- **double_move (DP-2、マルチ ply)**: CONFIRM=doubleMove フラグ set のみ (mana/hand/graveyard **不変**=消費遅延) / 1手目=board 変化・mana チャージなし・drawProgress 加算なし・currentPlayer 反転戻し (turnEnded=false)・check_break は defer / 2手目=board 変化・defer check_break 発火・finalize で consumeNormalCard (mana-=cost, hand→graveyard, cardPlayEvent) (turnEnded=true)。
+- **turnEnd (applyTurnEndEffects 共通基盤)**: drawProgress[player]=current+1、`next≥AUTO_DRAW_INTERVAL(5) ∧ deck 非空` で 0 reset + 自動ドロー (deck pop→hand append, drawEvent{source:auto}) **1 回のみ (非再帰、DP-1)** / mana/manaCap/trap/noPromoteMarks/graveyard 不変 / 終局後 (status≠active) は全スキップ。
+
+#### 8.3.3 解決済み設計判断 (openQuestions → 確定。S1 実装の入力)
+- **DP-1 (drawProgress、最重要)**: カーネルは **reducer セマンティクス (遅延+条件付き)** を正本とする。`applyTurnAction` は手番終了時に `applyTurnEndEffects` 相当で drawProgress を +1 し、5 到達 ∧ deck 非空でのみ 0 reset + 自動ドロー 1 回。AI 既存経路 `applyActionForLookahead` の「全 action 即時 +1・reset なし」(PR3-3 C-12 近似) は**カーネルが S1 で解消する既知の差異** (継ぎはぎの近似を正す = 再設計の効用)。等価テストは reducer semantics で assertion 固定。
+- **DP-2 (double_move スコープ)**: カーネルは double_move を **マルチ ply アクション** (`isTurnTerminating` で 1手目 turnEnded=false) として **applyTurnAction 内に統合**。消費は 2手目 finalize に遅延 (reducer 準拠)。現 AI の別系統 `searchDoubleMoveSuperAction` は S4 で単一探索木に吸収 (= double_move 特別扱い廃止、§6)。PoC-0 等価テストでは CONFIRM→move→move→finalize の複合列として検証。
+- **DP-3 (保存則)**: カード総数保存則は **hand+deck+graveyard+trap スロット = 一定**。通常カード=hand→graveyard、トラップ=hand→trap[player] (graveyard に入らない)。素朴な hand+deck+graveyard 保存則は trap を取りこぼすため、経路別に assertion を分ける。
+- **DP-4 (決定論化)**: 等価テストは **spectatorMode=true 固定 + Date.now() を固定 clock に stub**。これで早指しボーナス無効 (fastMove=false 確定) かつ event `at` 再現。**manaChargeEvent は events 射影から除外し、mana 値一致で代替検証** (演出寄りイベント + fastMove 依存を避ける)。
+- **DP-5 (noPromoteMarks)**: 等価は **{row,col} 集合一致** (reducer の配列順は push/filter/map の実装由来の人工物で意味的不変量でない)。
+- **DP-6 (manaCap)**: 現状 **不変** (reducer 内代入なし、`mana_up` は deprecated)。must-match に定数として含める。**将来カードで manaCap 動的化する場合は本 property list を更新する** (§11 D-F と連動、要 guard)。
+- **DP-7 (check_break 発火範囲)**: `applyCheckBreak` は `getCheckingPieces` で**発動時点で直接王手している駒のみ**除去し、開き王手 (遮蔽が破れて露出) は次手番に委ねる。カーネルもこの「直接王手駒のみ」を再現 (board.ts `getCheckingPieces` 実装を S1 で再確認)。
+
+#### 8.3.4 property-based テスト設計 (S1 で実装、本 doc が雛形仕様)
+- **generator**: seed 済み WorldState から、各ステップで現手番の合法 TurnAction (`getFullLegalMoves` + `canDraw`?draw + `getCardActions`) を列挙 → seeded PRNG で 1 つ選択 → reducer 経路 (BEGIN→[SELECT]→CONFIRM→COMMIT / DRAW→COMMIT / MAKE_MOVE) と カーネル `applyTurnAction` の両方に同一 action を適用。double_move は複合列に展開。10〜40 手 × 数百〜数千 seed。**決定論化=DP-4**。
+- **射影 (equivalenceProjection)**: §8.3.1 の must-match 12 を抽出 (hand/deck/graveyard=順序込み、noPromoteMarks=集合、events=kind+ドメイン射影 `at` 除外、manaChargeEvent 除外)、must-not-match を捨象。比較は「アクション適用完了後の安定状態」のみ (中間 phase は比較しない)。
+- **assertion**: 各適用後に両経路の射影が deep-equal / mana∈[0,manaCap] / 保存則 (DP-3) / trap 発火後 trap[opp]=null ∧ trapTriggerEvent / drawProgress 5 到達で 0 reset + deck-1/hand+1 / turnEnded=false 手 (double_move 1手目) で currentPlayer 不変 / events 射影列順序一致 (特に double_move の [move,move,(trapTrigger),cardPlay])。
+- **seed すべきエッジケース**: 自動ドロー発火境界 (drawProgress=4→5)、山札空ドロー禁止、manaCap 飽和、両者異種トラップ同時保有、double_move 中の check_break defer→2手目発火、double_move 1手目で詰み成立、捕獲駒の no_promote マーク削除、pawn_return/piece_return での removeNoPromoteMark、終局手直後の turnEnd スキップ、double_pawn で持ち駒歩 1 枚→配置後 0。
+- **不変ゲート併用**: reducer.test/undo-policy.test/effects.test green を S1 全コミットで維持。
+- **provenance**: 機械可読 property map 全文 (フィールド別 reducer 引用 + 3 レビュアーの gap 指摘) は PoC-0 workflow 出力に保存。本 §8.3 はその確定要約 = S1 実装の直接仕様。実テストは applyTurnAction カーネル新設と同時に S1 で author (現時点ではカーネル不在のため runnable test は作らない = dead code 回避)。
 
 ### 8.4 PoC (実現性ゲート) — 合否基準を operationalize
 - **PoC-1 探索枝刈り (R-1 最大リスク)**: 独立 PoC で `selectBranchCandidates(actions, depth, M, K)` (move 上位M + card 上位K + draw) を試作し、難易度別 `M/K/budget` を振って depthCompleted を計測。
-  - **合否バンド** (before-baseline 比、複数 run の統計): **±10% 以内=合格・S4 着手** / ±10〜20%=要再試行 (M/K 再調整) / **±20% 超=不合格** → フォールバック: (i) S4 目標を「depthCompleted −X% 許容 + カード使用率 +Y%」へ再定義、(ii) S4 を S4a(基礎探索) / S4b(最適化・校正) に分割、(iii) カード深掘りを playCard のみ・浅 budget に限定。
+  - **合否バンド**: **同一プロトタイプ内 move-only control 比** (bare-αβ の engine 効率交絡を相殺) で **±10% 以内=合格** / ±10〜20%=要再試行 / ±20% 超=不合格 → フォールバック: (i) S4 目標を「depthCompleted −X% 許容 + カード使用率 +Y%」へ再定義、(ii) **S4 を S4a(基礎探索)/S4b(最適化・校正) に分割**、(iii) カード深掘りを playCard のみ・浅 budget に限定。**before-baseline (production) 絶対比は bare-αβ プロトタイプでは到達不可 (ALL=production の 64-67%) のため fidelity 参照に留め、production ±10% は S4a で実エンジンに selector を載せて再検証する** (PoC-1 adversarial verify 反映)。
   - 起点参考: parked C-2 実測「フル盤面 budget=3 ≈ 130万 evaluate (枝刈りなし)」。枝刈りで K=1〜2 がどこまで圧縮できるかを表で提示。
 - **PoC-2 ValueModel (R-5)**: `pawn_return`(modifyBoard 型) と `check_break`(setTrap 型) の `valueModel(world, player)` を試作。検証=「簡潔な関数で内容・局面依存値付けが可能か / 条件分岐が増殖しないか」。trap は「相手が trigger を踏む確率 × 被害 cp」の期待値関数の実現性を確認。**modifyBoard 型と setTrap 型の両系統**をカバー (単一カード種では不足、PoC-2 拡張)。
 - **PoC-3 TT cardState ハッシュ (R-2)**: cardState 6要素を fold した 32-bit hash を試作し、(a) 衝突率 (b) 既存 move-only TT のヒット率悪化 を小規模盤面で測定。card-aware ノードの保守的 store 方針の妥当性も確認。
 
-### 8.5 S1 リスク準備 (completeness-12)
-S0 完了条件に「S1 実装計画 + rollback 手順 + feature-flag 設計レビュー完了」を含める (L0 統合は最大の technical risk のため、段階統合・test isolation・差し戻し手順を先に用意)。
+### 8.4.5 PoC 実測結果 + adversarial verify (2026-06-06、結論)
+3 PoC を独立ブランチ (`feature/#235-poc-{1,2,3}`) で実装・実測し、結果と私 (実装者) の解釈を **4 観点 adversarial workflow** で検証。下記は**指摘 (mustFix 4) を是正・honest caveat を反映した確定結論**。生データは `docs/bench-results/issue-235-poc{1,2,3}.json`、コードは各 poc ブランチ。
+
+| PoC | 結論 | 実測の核心 |
+|---|---|---|
+| **PoC-1 探索枝刈り (R-1)** | **CONDITIONAL PASS** | 同一プロトタイプで move-only(ALL)/ top-M(TOPM)/ +card(CARD) を切替計測。**同一 M=10 での card on/off (CARD-M10-K2 vs TOPM-10) = 91-97%** → カード追加 (K=2+draw) の純コストは **3-9% (±10%内)**。move-cap M が深さの主レバーで、TOPM が ALL 比 120-125% と深く読める余裕も確認。**→ 分岐爆発 (R-1) は制御可能**。ただし下記 caveat により production 絶対 ±10% は S4a で再検証。 |
+| **PoC-2 ValueModel (R-5)** | **PASS (構造的実現性)** | modifyBoard 型 (eval差分) と setTrap 型 (P_trigger×E_damage) の **2 関数で 5 カード全実測被覆**。check_break が安全玉 **-25cp** / 露出玉 **+230cp** と局面依存に変動 (固定 `TRAP_VALUE_CHECK_BREAK=80` を脱却)。pawn_return/piece_return/double_pawn も局面で変動。**→ 固定スカラーの内容・局面依存化は簡潔関数で実現可能**。 |
+| **PoC-3 TT hash (R-2)** | **PASS (board+fold次元)** | cardState (mana/手札種別カウント/trap/drawProgress) を XOR fold した hash で、Part A: 同一盤面×64 cardState を board-only=1個 (誤ヒット) → card-aware=64個 (分離)。Part B: 15,159 distinct states で **衝突 0 / 断片化 1.001 (再現確認済)**。TT_SIZE 不変 = メモリ影響なし。**→ board+fold 次元の誤ヒットは解消可能**。 |
+
+**adversarial verify 反映 (mustFix 是正済)**:
+- PoC-1 合否基準を「same-engine control 比 ±10%」に明文訂正 (§8.4 / §7 S4 行 / §12)。doc 旧記述「before-baseline 比 ±10%」は bare-αβ では測れないため fidelity 参照に降格、production ±10% は S4a へ。
+- PoC-3 を seeded deck (シャッフル排除) + DP-1 auto-draw reset 化し再現性確保。「誤ヒット完全解消」→「board+fold次元の解消」に限定 (deck 順未 fold)。
+- PoC-2 に piece_return 実測を追加 (claim を実測に整合)。
+
+**honest caveats (S4 以降の前提)**:
+1. **PoC-1 fidelity**: プロトタイプは bare-αβ (TT/LMR/quiescence/LMR 非搭載) で ALL 絶対深さ (advanced/expert ≈ 3.9) は production before-baseline (5.78/6.0) の **64-67%**。same-engine 比は交絡相殺として妥当だが、**production の LMR/TT が既に soft 枝刈りするため M/K 最適値が同値転移する保証はない** → **S4a で実エンジンに selector を載せ M/K を再校正してから S4 粒度・目標を確定** (PoC-1 結論は「枝刈り余地が存在する」まで)。
+2. depthCompleted は time-budget 探索で計測機 CPU 依存 → ±10% 比較は同一機・同一条件で取得 (§8.2)。
+3. **PoC-2 係数は仮値**: setTrap 係数 (E_damage/P_min/max/SAFETY_*) は PoC 仮値で、-25↔+230 の差は係数選択に依存。本採用値は **S3 bench 校正**まで未確定。no_promote の trigger は自玉露出度を流用しており (check_break は妥当)、相手成り脅威指標への分離を S3 検討。「局面依存になった」ことは棋力向上の証明ではない (S3 bench で別途評価)。valueModel の per-target eval コストは selection で bounded 化要 (PoC-1 と同じ selector コスト論点)。
+4. **PoC-3 deck 順未 fold**: 同一 fold・異 deck の 2 状態は同一 TT エントリ → draw 後に分岐が異なる残存誤ヒット。S4 で card-aware ノードの保守的 store (depth 制限/verify 強化) で対応。fragmentation 1.001 は random playout が transposition を過小サンプリングした下界で、実探索では上がりうる → S4 で TT instrument 搭載探索で実測。
+5. **baseline calibration e/f/g** は AI が move に倒れる「再設計の動機の実証 (regression indicator)」であり control 値ではない。S1 改善後の before/after 比較では canonical main が e/f/g で本来取るべき手を別途固定し、改善と baseline 不具合解消の交絡を避ける。
+
+### 8.5 S1 リスク準備 — rollback + feature-flag 設計 (completeness-12)
+L0 統合 (reducer/AI が単一カーネル `applyTurnAction` に委譲) は最大の technical risk のため、段階統合・test isolation・差し戻し手順を S0 で確定する。
+
+#### 8.5.1 feature-flag 設計 (additive + 影 + 段階切替)
+- **カーネルは既存経路を消さず additive に新設**。最終 cutover まで production の振る舞いは旧経路が支配。
+- **AI 探索側**: config フラグ `useKernelSearch` (既定 OFF) で「既存 engine」⇔「カーネル委譲 engine」を切替。OFF = PR3-3 完了時点の振る舞い完全保持。card-shogi のみ対象、standard は分岐に入れない。
+- **reducer (UI) 側**: カーネルを reducer の**実装裏側**に置き、reducer は薄いラッパに後退。移行中は **shadow-assert モード** (dev/test 限定): reducer が旧経路結果とカーネル結果の両方を計算し §8.3 の must-match 射影で `===` を assert、**採用するのは旧経路結果**。等価が安定したら採用をカーネルへ flip。本番ビルドでは shadow を無効化 (二重計算コストを避ける)。
+- **standard variant**: カーネル分岐に一切入れず byte-level 不変 (§12 不変ゲート)。
+
+#### 8.5.2 段階統合 (S1a〜S1d、各段で不変ゲート green)
+1. **S1a**: `WorldState` 型 + `applyTurnAction` を**新規モジュールとして追加** (production 未配線)。§8.3.4 の property-based 等価テストを同時に author し green 化。reducer.test/undo-policy.test/effects.test は不変。
+2. **S1b**: AI 探索を `useKernelSearch` フラグ裏で配線 (既定 OFF)。bench で旧経路と depthCompleted/カード使用率比較。
+3. **S1c**: reducer を薄いラッパ化し shadow-assert モードで旧経路と並走。reducer.test/undo-policy.test/effects.test green を**全コミットで維持**。
+4. **S1d**: 等価テスト + bench green 確認後に既定をカーネルへ flip (AI: `useKernelSearch` ON、reducer: 採用切替)。shadow を本番無効化。
+
+#### 8.5.3 rollback 手順 (多層)
+- **第1層 (無コード)**: 不具合時は **フラグを OFF に戻すだけ**で旧経路へ即時復帰 (S1d 後も flag は残置)。
+- **第2層 (git)**: カーネルは S1a〜S1c で additive (新規ファイル)、production 振る舞いを変える cutover は **S1d の単一コミットに隔離** → `git revert <S1d-cutover>` で旧経路復帰。各コミットは atomic・reversible。
+- **第3層 (test gate)**: reducer.test/undo-policy.test/effects.test + property-based 等価テストを cutover の blocking gate に。1 つでも赤なら cutover しない。
+- **test isolation**: 等価テストは旧 reducer 経路 vs カーネル経路を同一ランダム TurnAction 列で並走し must-match 射影 (§8.3.1) を deep-equal 比較。DP-1〜7 を seed 済みエッジケースで固定。
+
+> **AI 評価系との整合 (DP-2 由来の留意)**: double_move をカーネルのマルチ ply に統合する際、現 AI の `searchDoubleMoveSuperAction` / cardDigest 近似 (cost を digest 側で扱う) との整合は S1b/S4 で個別調整する。S1 の等価ゲートは **reducer 経路との一致**を担保し、AI 評価系の数値変化は bench (棋力ゲート) で別途監視する。
 
 ### 8.6 S0 完了の定義 (DoD)
-- [ ] 本設計 doc 確定 (adversarial verify 反映 + ユーザー合意)
-- [ ] before-baseline 計測完了・`docs/bench-results/issue-235-before-baseline.json` に保存
-- [ ] PoC-0 property list 確定
-- [ ] PoC-1/2/3 完了・各合否判定 (特に PoC-1 の ±10% 実現可否で S4 粒度・目標値を確定)
-- [ ] S1 実装計画 + rollback 手順を doc 化
-- [ ] PoC 結果に基づき S1-S6 の DoD/粒度/目標値を本 doc に確定反映
+- [x] before-baseline 計測完了・`docs/bench-results/issue-235-before-baseline.json` に保存 (§8.2、2026-06-06)
+- [x] PoC-0 property list 確定 (§8.3、DP-1〜7 + property-based テスト設計、workflow 11 agents)
+- [x] PoC-1/2/3 完了・各合否判定 (§8.4.5、adversarial verify 反映: PoC-1 CONDITIONAL PASS / PoC-2・3 PASS)
+- [x] S1 実装計画 + rollback 手順を doc 化 (§8.5、feature-flag + 段階統合 S1a〜d + 多層 rollback)
+- [x] PoC 結果に基づき S4 を S4a/S4b 分割確定 (§8.4.5 / §7 S4 行)。S2-S6 の数値目標は各段 plan doc で operationalize (本 epic doc はアーキ + S0 確定層)
+- [ ] **本設計 doc 確定 = ユーザーレビュー + 合意待ち** (AGENTS.md ルール8 マイルストーン2: 実装後レビュー相当を adversarial workflow で実施済、ユーザー最終確認が残)
 
 ---
 
@@ -262,7 +350,7 @@ S0 完了条件に「S1 実装計画 + rollback 手順 + feature-flag 設計レ�
 
 - **S0 PoC ゲート**: PoC-1/2/3 の結果で「実現可能か」を判定。±10% が無理なら目標棋力 or 段粒度を見直し (理論でなく実測で決める)。
 - **不変ゲート**: 全段で standard variant byte-level 不変 + reducer/undo/effects テスト不変。
-- **棋力ゲート**: before-baseline 比 depthCompleted ±10%。多面指標 (棋力 variance / phase別カード使用率 / undo 堅牢性) も併用 (critique 指摘、単一指標を避ける)。
+- **棋力ゲート**: depthCompleted ±10% (PoC は same-engine control 比で確認、S4a で実エンジン→before-baseline 絶対比を再校正)。多面指標 (棋力 variance / phase別カード使用率 / undo 堅牢性) も併用 (critique 指摘、単一指標を避ける)。
 - **フェアネス test**: AI が相手手札の中身を探索入力に使っていないことを test で固定 (S5、D-H 早期なら S1-S2)。
 - **必須チェック** (AGENTS.md ルール6): 各段 lint→typecheck→test:ci→build。bench は `RUN_PERF_BENCH=true`。
 
@@ -277,6 +365,9 @@ S0 完了条件に「S1 実装計画 + rollback 手順 + feature-flag 設計レ�
 - **PoC 具体化 (PoC-1/完全性群)**: §8 を S0 として全面具体化 — PoC は独立ブランチ・production 不変、PoC-1 合否バンド (±10/20%) + フォールバック、PoC-0 property list、before-baseline 仕様 (保存先)、PoC-2 を modifyBoard+setTrap 両系統に拡張、S1 rollback 準備、S0 DoD 明文化。
 - **決定補強 (D-B/D-H high)**: standard 統合の期限化 (S2-S3 で評価 Issue 起票)、フェアネス移行の具体手順 (anonymizeOpponentHand + test fixture)。
 - **依存明記 (completeness-8)**: S5 が #193 PR1e (eventLog 永続化) に blocking 依存。
+- **S0 recon 反映 (2026-06-06)**: 設計 doc のコード参照を canonical main (`1185067`) で網羅再検証 (6 エージェント)。P1〜P7・#193 引き継ぎ資産は全て verified、parked 用語 (`evaluateActionDeep`/`scanOpponentResponse`/`cardSearchBudget`) は main に不在を確認。軽微訂正: ① `CardDigest` は 6→**7 フィールド** (`manaAbsolute`、§1 P2)、② カード横断は 9→**実 11〜13 箇所** (§1 P5)、③ `perf-bench-card-usage` に **intermediate を追加** (欠落是正、§8.2)、④ rootMoveScore は **S0 scope 外** = 三軸に確定 (§8.2)、⑤ PoC-0 等価の source-of-truth は **reducer 経路** (AI 側 `current-rules` は draw/playCard 未実装=throw、§8.3)。
+
+- **S0 PoC 実装 + adversarial verify 反映 (2026-06-06)**: before-baseline 計測 (§8.2) + PoC-0 property list workflow (§8.3、11 agents、DP-1〜7) + PoC-1/2/3 独立ブランチ実装・実測 (§8.4.5) を完了し、PoC 結果と実装者解釈を 4 観点 adversarial workflow で検証。high 指摘 4 件を是正: ① **PoC-1 合否基準を「same-engine control 比 ±10%」に訂正** (旧「before-baseline 比」は bare-αβ で測定不可、production 絶対比は S4a へ。§8.4/§7/§12)、② PoC-3 を seeded deck + DP-1 auto-draw reset 化し再現性確保 + 「board+fold次元の解消」に限定 (deck 順未 fold)、③ PoC-2 に piece_return 実測追加、④ honest caveat (bare-αβ fidelity 64-67% / PoC-2 係数仮値 / PoC-3 deck順・transposition 過小サンプリング / baseline calibration は regression indicator) を §8.4.5 に明記。検証 synthesis 判定: **S1 着手は条件付きで正当化可** (3 大リスク R-1/R-5/R-2 が方向として実現可能、S1 は探索コア S4 と独立に着手可)。S4 は PoC-1 の production 転移を S4a で再検証してから粒度確定。
 
 > 残 medium/low (各段 DoD の数値バンド詳細等) は S0 PoC 確定後に各段の plan doc で operationalize する方針 (本 epic doc はアーキ + 決定 + S0 を確定する層)。棄却なし (43/43 確定だが検証は寛容傾向のため、本反映は実装影響のある指摘に重点)。
 

--- a/docs/plans/issue-235-s1-kernel.md
+++ b/docs/plans/issue-235-s1-kernel.md
@@ -1,0 +1,120 @@
+# Issue #235 S1: L0 ルール/状態カーネル統合 — 実装計画 (実装着手前)
+
+> 親 doc (epic 単一情報源): `docs/plans/issue-235-card-shogi-ai-redesign.md` (§3 L0 / §8.5 rollback / §8.3 DP-1〜7)。
+> 本 doc は S1 (= L0 カーネル統合 refactor) の**実装計画**。AGENTS.md ルール8 マイルストーン1 (実装着手前レビュー) の対象。
+> ブランチ `refactor/#235-s1` (origin/main `1185067` 起点、worktree `.claude/worktrees/issue-235-s1`)。
+
+## 0. ゴールと非ゴール
+**ゴール**: カード将棋のルール/状態遷移を単一権威 `applyTurnAction(world, action)` に集約し、reducer (UI) と AI 探索が**同一ロジック**を呼ぶ構造にする (epic P4 解消の第一歩)。
+**非ゴール (S1 では触らない)**: 探索コア (S4)、カードフレームワーク registry (S2)、ValueModel (S3)、相手モデル (S5)。standard variant は byte-level 不変。
+
+## 1. 中核戦略 — 「再実装せず抽出して委譲」(reuse, not rewrite)
+reducer の純粋ゲームロジック (`makeMoveWithEffects` reducer.ts:239 / `applyTurnEndEffects` の cardState 部 :447 / `finalizeDoubleMoveCardConsumption` :666 / CONFIRM_PLAY_CARD の効果適用 :1207) は**既に大半が純粋**。これらを**新規 `world-kernel.ts` モジュールに抽出 (lift) し、reducer・AI 双方が import して委譲**する。ロジックを**書き換えず再利用**することで振る舞いを構造的に保存し、デグレリスクを最小化する (S1 最大の technical risk への対策)。
+
+## 2. 設計テンション (要レビュー) — kernel atomicity vs reducer 演出フェーズ
+reducer はカード/ドローを **CONFIRM (効果適用、演出前) → COMMIT (flip + turn-end、演出後)** に分割し、間でフライト/王手崩し演出を駆動する。一方 AI / property test は **atomic な 1 遷移**を要する。両立のための設計:
+- **二層構造**: kernel は (a) 純粋 building-block 関数群 (`applyMoveLogic` = lift した makeMoveWithEffects / `advanceDrawProgress` = applyTurnEndEffects の cardState 部 / `applyCardEffectLogic` / `finalizeDoubleMoveLogic`) と、(b) それらを合成する atomic `applyTurnAction` の 2 層で提供。
+- **reducer**: 演出フェーズ構造は維持しつつ、各フェーズが (a) の同一 building-block を呼ぶ → **関数レベルで single-authority** (演出は reducer 側、ロジックは kernel 側)。
+- **AI / headless / property test**: (b) `applyTurnAction` を atomic に呼ぶ。
+- → 「単一権威」は building-block レベルで達成。applyTurnAction は building-block を演出抜きで合成したもの = reducer の演出フェーズ合成と**同じロジック経路**になり、property test で等価検証できる。
+
+## 3. WorldState 型 (L0)
+```ts
+interface WorldState {
+  gameState: GameState;          // 盤 + 持ち駒 + currentPlayer + status (手番は gameState.currentPlayer)
+  cardState: CardGameState;      // mana/manaCap/hand/deck/graveyard/trap/drawProgress/noPromoteMarks
+  doubleMove: DoubleMoveState | null;  // 二手指し継続状態 {active, movesLeft, cardInstance, cardCost} (DP-2 マルチ ply)
+}
+```
+- `cardState` 型は既存 `CardGameState` をそのまま使う (pendingCard/lastTurnStartedAt フィールドを含むが、**kernel は読み書きしない** = DP の must-not-match。pendingCard は UI 確認用で kernel には confirmed action が渡る、lastTurnStartedAt は spectator/決定論化で扱う)。
+- `doubleMove` は reducer の `state.doubleMove` と同型 (active/movesLeft/cardInstance/cardCost)。AI 既存 `AiTurnState.doubleMove` (active/movesLeft のみ) は kernel 型へ統合。
+- WorldState は不変更新 (純粋)。
+
+## 4. applyTurnAction 仕様
+```ts
+function applyTurnAction(
+  world: WorldState,
+  action: TurnAction,                 // move / draw / playCard (move/draw/playCard)
+  opts?: { spectatorMode?: boolean },  // DP-4 決定論化 (早指し無効化)
+): { world: WorldState; events: GameEvent[]; turnEnded: boolean }
+```
+アクション別 (DP-1〜7 準拠、§8.3.2 の per-action property が仕様):
+> **注**: `action` の playCard は TurnAction union の単一メンバ + `defId` dispatch (types.ts:19-22)。下記 modifyBoard/setTrap/double_move は新 union メンバではなく defId 分岐。新メンバを増やさない (疎結合・余分コード回避)。
+> **currentPlayer flip 規約 (DP-2、SSOT §8.3.2 転記)**: 「ターン終了 = currentPlayer 反転」は applyTurnAction が一元決定。ただし **double_move 2手目は `applyMoveLogic` (applyMove) が既に opponent へ flip 済**のため、kernel の turnEnded=true は**再 flip を伴わない** (reducer.ts:692 の pendingPlayCardOpponent=null による flip 抑止と等価)。double_move 1手目は applyMove の flip を**戻して** turnEnded=false (ターン継続、reducer.ts:821 相当)。
+- **move**: `world.doubleMove` から mode 決定 (null→normal / movesLeft 2→double_move_first / 1→double_move_second)。`applyMoveLogic` (reuse makeMoveWithEffects) で盤・trap発火・noPromoteMarks・manaCharge を適用。
+  - normal: turnEnded=true (currentPlayer は applyMove で flip 済) + `advanceDrawProgress`。
+  - double_move_first: turnEnded=false・flip 戻し (currentPlayer を元の手番に戻す)・**advanceDrawProgress 呼ばない** (ターン継続) ・check_break defer (DP-7)。movesLeft 2→1。1手目で詰み成立 (status≠active) 時は即 finalize (下記)。
+  - double_move_second: defer check_break 発火 → `finalizeDoubleMoveLogic` で遅延消費 (consumeNormalCard + cardPlayEvent) + doubleMove=null + turnEnded=true (再 flip なし) + `advanceDrawProgress` 1回。
+- **draw**: deck先頭→hand末尾 / mana -= DRAW_COST / flip + `advanceDrawProgress` (DP-1: drawProgress は turn-end で +1、5到達で reset+auto-draw)。turnEnded=true。
+- **playCard:modifyBoard** (pawn_return/piece_return/double_pawn): **reducer.ts:1249-1293 と同一の direct-apply 経路を reuse** (`applyPawnReturn`/`applyPieceReturn`/`applyDoublePawn` を直接呼ぶ。`simulateCardEffect` は使わない — returnedPieceInfo と removeNoPromoteMark を落とすため誤り)。盤変更 + `consumeNormalCard` (mana-=cost, hand→graveyard) + **returnedPieceInfo を cardPlayEvent.returnedPiece に載せる** + pawn/piece_return 後に **removeNoPromoteMark** (reducer.ts:1266/1284) → flip + advanceDrawProgress。turnEnded=true。
+- **playCard:setTrap** (no_promote/check_break): `applyTrapSet` (hand→trap, **graveyard 不変** DP-3) + mana-=cost → flip + advanceDrawProgress。turnEnded=true。
+- **playCard:double_move**: doubleMove フラグ set のみ (mana/hand/graveyard **不変** = 遅延消費 DP-2)。turnEnded=false。
+
+## 5. 抽出マッピング (どの reducer ロジックを kernel へ)
+| reducer 現在地 | kernel 抽出先 | 備考 |
+|---|---|---|
+| `makeMoveWithEffects` (:239) | `applyMoveLogic(world, move, mode, opts)` | ほぼそのまま lift。CardShogiGameStateInternal 依存なし (gameState+cardState のみ) → WorldState 化容易 |
+| `applyTurnEndEffects` (:447) の cardState 部 (drawProgress/deck/hand) | `advanceDrawProgress(cardState, gameState, player) → { cardState, events }` | **新規実装** (reducer 版は UI 結合のため再利用不可)。drawProgress +1、5到達∧deck非空で 0 reset + auto-draw (deck先頭→hand, drawEvent{source:auto} を events に)。**非再帰・1回のみ** (DP-1)。UI flag (isDrawing/pendingDrawPlayer/selectedSquare clear) は **reducer が S1c で返り値 events を読んで event-driven にセット** (kernel は cardState+events のみ返す) |
+| `finalizeDoubleMoveCardConsumption` (:666) の consumeNormalCard+event 部 | `finalizeDoubleMoveLogic(world, dm)` | isPlayingCard/pendingPlayCardOpponent flag は reducer に残す |
+| CONFIRM_PLAY_CARD (:1207) の効果適用部 | `applyCardEffectLogic(world, action)` | pendingCard/演出 flag は reducer に残す |
+| currentPlayer flip (MAKE_MOVE/COMMIT_* に散在) | applyTurnAction 内に集約 | 「ターン終了で flip」を kernel が一元管理 |
+
+reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (eventLog append / animation flag / selectedSquare / pendingCard / undoSnapshot) のみ自前管理**。
+
+## 6. 移行段階 (S1a〜d、各段で不変ゲート green を維持) — **epic SSOT §8.5.2 準拠 (マイルストーン1レビュー反映)**
+> **重要訂正**: 初版は S1a に「reducer を委譲へ refactor」を含めていたが、これは epic SSOT §8.5.2 の定める staging (S1a=additive 新規モジュールのみ / reducer 薄ラッパ化=S1c / cutover=S1d 単一コミット隔離) と矛盾し、最大リスクの production rewire を property 等価 green より前に前倒しして rollback 第2層 (cutover 隔離) の前提を壊す。SSOT 通り **S1a は production (reducer/AI) 完全不変**に訂正。
+- **S1a (本計画の主対象)**: `world-kernel.ts` を**新規モジュールとして追加** = WorldState + building-block (applyMoveLogic/advanceDrawProgress/applyCardEffectLogic/finalizeDoubleMoveLogic) + atomic applyTurnAction。**production (reducer/AI) は完全不変** (例外: 純粋関数 `makeMoveWithEffects` 等を kernel から再利用するため reducer.ts に `export` を**付与するのみ**の振る舞い不変変更は許容。reducer の呼出経路・ロジックは一切変えない)。**property-based 等価テスト新設** (現 reducer 経路 vs 新 applyTurnAction の独立2実装比較、§8.3.4)。既存 reducer.test/undo-policy.test/effects.test 全 green 維持。
+  - **reuse 方針**: `makeMoveWithEffects` は純粋 (gameState+cardState のみ依存、レビューで確認) のため reducer.ts から `export` して kernel が import 再利用 (rewrite 回避)。`applyTurnEndEffects` は UI state 結合のため**そのコア (drawProgress/deck/hand 変換) を kernel に新規実装** (`advanceDrawProgress`)、reducer 側は S1a では不変 (S1c で advanceDrawProgress へ委譲)。両者の等価は property test で担保。
+- **S1b**: AI 探索が `useKernelSearch` フラグ (既定 OFF) 裏で applyTurnAction 経由に切替可能化 + `AiTurnState.doubleMove` の kernel 型統合 + double_move cardState 近似 (current-rules.ts:114) 解消。OFF で既存挙動完全保持。bench で旧経路と depthCompleted/カード使用率比較。
+- **S1c**: reducer を完全な薄ラッパ化 (各演出フェーズが kernel building-block を呼ぶ) + shadow-assert モード (旧経路 vs kernel を dev/test で `===` assert、採用は旧経路)。`advanceDrawProgress` の {cardState, events} 返り値を reducer が読んで isDrawing/isCheckBreakAnimating 等の演出 flag を event-driven にセット。
+- **S1d**: 等価 + bench green 確認後に**単一コミット**で既定をカーネルへ flip (rollback 第2層: `git revert` 対象)。shadow 本番無効化。
+
+## 7. property-based 等価テスト (S1a、§8.3.4 + DP-1〜7)
+- **framework (依存追加なし)**: fast-check は package.json 未導入 + AGENTS.md §7 (パッケージ追加は要確認) のため**使わない**。PoC-3 と同じ **hand-rolled seeded PRNG (mulberry32) + 手書き generator** で実装 (vitest のみで完結、決定的・再現可能)。
+- **generator**: seeded WorldState から各ステップで合法 TurnAction (`getFullLegalMoves` + canDraw?draw + `getCardActions`) を seeded PRNG 選択。reducer 経路 (BEGIN→[SELECT]→CONFIRM→COMMIT / DRAW→COMMIT / MAKE_MOVE を**プログラム的に dispatch**) と applyTurnAction の両方に同一 action 適用。double_move は複合列展開。reducer は現状不変 (S1a) のため、これは**独立2実装 (既存 reducer vs 新 kernel) の等価検証**になる (= 「委譲で自明」ではなく真の regression guard)。
+- **決定論化 (DP-4)**: spectatorMode=true 固定 + Date.now() stub (fake clock)。
+- **射影 (DP-1〜7)**: must-match 12 (mana/manaCap/hand[順序]/deck[順序]/graveyard[順序]/trap/noPromoteMarks[集合 DP-5]/drawProgress + board zobrist + turnEnded + events[kind+ドメイン射影, at除外, manaChargeEvent除外 DP-4])。must-not-match (pendingCard/lastTurnStartedAt/演出flag/UI) は捨象。
+- **assertion**: 各適用後 deep-equal / 保存則 hand+deck+graveyard+trap (DP-3) / drawProgress 5到達で reset+auto-draw / double_move 1手目 turnEnded=false で currentPlayer 不変 / events 順序一致。
+- **seed エッジケース**: 自動ドロー境界(4→5) / 山札空 / manaCap飽和 / 両者異種trap / double_move中 check_break defer→2手目発火 / double_move 1手目詰み / 捕獲駒の no_promote マーク削除 / 終局手後 turn-end スキップ。
+- **位置づけ**: reducer が building-block 委譲なら reducer 経路 == applyTurnAction はほぼ自明だが、**flip / turn-end 合成の orchestration 差**を検出する regression guard (atomic 合成 vs 演出フェーズ合成の一致確認)。
+
+## 8. DP-1〜7 遵守マップ
+- DP-1 drawProgress: `advanceDrawProgress` が reducer semantics (遅延+条件 reset+auto-draw)。AI 旧 immediate+1 (applyActionForLookahead) は S1b でカーネル委譲時に解消。
+- DP-2 double_move: applyTurnAction がマルチ ply (1手目 turnEnded=false / 2手目 finalize 遅延消費)。
+- DP-3 保存則: setTrap は hand→trap (graveyard 不変)、通常カードは hand→graveyard。
+- DP-4 決定論化: opts.spectatorMode + Date.now stub、manaChargeEvent は events 射影除外。
+- DP-5 noPromoteMarks: 集合一致。
+- DP-6 manaCap: 不変 (kernel 内代入なし)。
+- DP-7 check_break: applyCheckBreak が getCheckingPieces (直接王手駒のみ)。double_move_first は defer。
+
+## 9. feature-flag + rollback (epic §8.5 準拠)
+- flag `useKernelSearch` (AI、既定 OFF) / reducer shadow-assert。
+- rollback 3層: フラグ OFF / S1d cutover commit を `git revert` / reducer.test+undo+effects+property を blocking gate。
+- standard byte-level 不変ゲート。
+
+## 10. リスク
+- **R-S1-1 抽出時の暗黙依存見落とし**: makeMoveWithEffects/applyTurnEndEffects が CardShogiGameStateInternal の他フィールドに暗黙依存していないか精査 (applyTurnEndEffects は selectedSquare 等を触るが cardState 変換と分離可能なことを確認済)。→ property test + 既存 test で担保。
+- **R-S1-2 演出フェーズ分割との不整合**: §2 の二層設計で両立。CONFIRM/COMMIT の中間状態 (pendingCard/animation) は kernel 対象外を明示。
+- **R-S1-3 AI 評価系の数値変化**: DP-1 で AI の drawProgress semantics が変わる (immediate→lazy) → cardDigest 経由の評価が微変。S1b で bench 監視、棋力ゲートで検出。
+- **R-S1-4 二手指し orchestration の複雑性**: finalize の pendingPlayCardOpponent re-flip ロジック (reducer.ts:692) を kernel の turnEnded 決定に正しく移植。property test の double_move エッジケースで担保。
+
+## 11. S1a DoD (additive のみ・production 不変)
+- [ ] `world-kernel.ts`: WorldState + building-block + applyTurnAction 実装 (新規ファイル)
+- [ ] reducer.ts: `makeMoveWithEffects` 等の `export` 付与のみ (振る舞い不変、呼出経路・ロジック不変)
+- [ ] property-based 等価テスト新設・green (現 reducer 経路 vs 新 applyTurnAction の独立2実装比較、DP-1〜7 + エッジケース、**hand-rolled seeded generator = fast-check 等の依存追加なし**)
+- [ ] reducer.test / undo-policy.test / effects.test 全 green (不変ゲート = production 不変の証跡)
+- [ ] lint / typecheck / test:ci / build green
+- [ ] standard variant byte-level 不変 (kernel は card-shogi 専用、standard は kernel 非経由)
+- [ ] **reducer の薄ラッパ化・AI 配線は含めない (S1c/S1b へ隔離)**
+
+## 12. マイルストーン1レビュー反映 (2026-06-07、AGENTS.md ルール8)
+本計画初版を 3観点 adversarial workflow (#109 観点 + reducer 実コード照合) でレビューし、以下を反映:
+- **[最重要] S1a スコープを epic SSOT §8.5.2 へ整合** (§6/§11): 初版は reducer rewire を S1a に前倒ししていたが、SSOT は S1a=additive 新規モジュールのみ・reducer 薄ラッパ化=S1c・cutover=S1d 単一コミット隔離。rollback 第2層の前提を守るため production 不変に訂正。
+- **modifyBoard を direct-apply に訂正** (§4): `simulateCardEffect` は returnedPieceInfo / removeNoPromoteMark を落とすため誤り。reducer.ts:1249-1293 と同一の `applyPawnReturn`/`applyPieceReturn`/`applyDoublePawn` 直接呼出を reuse。
+- **DP-2 double_move の flip 抑止を明文化** (§4): 2手目は applyMove で flip 済 → kernel turnEnded=true は再 flip しない (reducer.ts:692 等価)。doubleMove=null タイミング・1手目詰み finalize を明記。
+- **advanceDrawProgress を {cardState, events} 返却に確定** (§5): UI flag は reducer が S1c で event-driven セット。非再帰1回 (DP-1)。
+- **property test は hand-rolled seeded generator** (§7): fast-check 依存追加を回避 (AGENTS.md §7)。reducer 不変ゆえ独立2実装の真の等価検証。
+- **AI doubleMove 型統合・近似解消は S1b へ隔離** (§6): S1a の WorldState.doubleMove は reducer 由来 {active,movesLeft,cardInstance,cardCost} に限定。
+- **playCard は単一 union メンバ + defId dispatch** (§4 注): 新 union メンバを増やさない。
+- 妥当と確認: 中核戦略 (抽出して委譲)・二層構造・DP-1〜7 射影・check_break reuse・feature-flag+多層 rollback・evaluateGameEnd 共有。
+- 着手前提: S0 design doc はユーザー承認済 (2026-06-07、epic §8.6)。本 worktree に epic SSOT を co-locate 済 (design ブランチ merge)。

--- a/docs/plans/issue-235-s1-kernel.md
+++ b/docs/plans/issue-235-s1-kernel.md
@@ -72,7 +72,7 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 ## 7. property-based 等価テスト (S1a、§8.3.4 + DP-1〜7)
 - **framework (依存追加なし)**: fast-check は package.json 未導入 + AGENTS.md §7 (パッケージ追加は要確認) のため**使わない**。PoC-3 と同じ **hand-rolled seeded PRNG (mulberry32) + 手書き generator** で実装 (vitest のみで完結、決定的・再現可能)。
 - **generator**: seeded WorldState から各ステップで合法 TurnAction (`getFullLegalMoves` + canDraw?draw + `getCardActions`) を seeded PRNG 選択。reducer 経路 (BEGIN→[SELECT]→CONFIRM→COMMIT / DRAW→COMMIT / MAKE_MOVE を**プログラム的に dispatch**) と applyTurnAction の両方に同一 action 適用。double_move は複合列展開。reducer は現状不変 (S1a) のため、これは**独立2実装 (既存 reducer vs 新 kernel) の等価検証**になる (= 「委譲で自明」ではなく真の regression guard)。
-- **決定論化 (DP-4)**: spectatorMode=true 固定 + Date.now() stub (fake clock)。
+- **決定論化 (DP-4)**: spectatorMode=true 固定 (早指しボーナス無効 = fastMove=false 確定)。event の `at` (Date.now()) は射影 (projectEvents/stripAt) で除外するため **Date.now() stub は不要** (S1a part2 実装で確定。当初案の fake clock は採用せず)。
 - **射影 (DP-1〜7)**: must-match 12 (mana/manaCap/hand[順序]/deck[順序]/graveyard[順序]/trap/noPromoteMarks[集合 DP-5]/drawProgress + board zobrist + turnEnded + events[kind+ドメイン射影, at除外, manaChargeEvent除外 DP-4])。must-not-match (pendingCard/lastTurnStartedAt/演出flag/UI) は捨象。
 - **assertion**: 各適用後 deep-equal / 保存則 hand+deck+graveyard+trap (DP-3) / drawProgress 5到達で reset+auto-draw / double_move 1手目 turnEnded=false で currentPlayer 不変 / events 順序一致。
 - **seed エッジケース**: 自動ドロー境界(4→5) / 山札空 / manaCap飽和 / 両者異種trap / double_move中 check_break defer→2手目発火 / double_move 1手目詰み / 捕獲駒の no_promote マーク削除 / 終局手後 turn-end スキップ。
@@ -82,7 +82,7 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 - DP-1 drawProgress: `advanceDrawProgress` が reducer semantics (遅延+条件 reset+auto-draw)。AI 旧 immediate+1 (applyActionForLookahead) は S1b でカーネル委譲時に解消。
 - DP-2 double_move: applyTurnAction がマルチ ply (1手目 turnEnded=false / 2手目 finalize 遅延消費)。
 - DP-3 保存則: setTrap は hand→trap (graveyard 不変)、通常カードは hand→graveyard。
-- DP-4 決定論化: opts.spectatorMode + Date.now stub、manaChargeEvent は events 射影除外。
+- DP-4 決定論化: opts.spectatorMode (fastMove=false) + event `at` を射影除外 (Date.now stub 不要) + manaChargeEvent を events 射影除外。
 - DP-5 noPromoteMarks: 集合一致。
 - DP-6 manaCap: 不変 (kernel 内代入なし)。
 - DP-7 check_break: applyCheckBreak が getCheckingPieces (直接王手駒のみ)。double_move_first は defer。
@@ -99,13 +99,13 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 - **R-S1-4 二手指し orchestration の複雑性**: finalize の pendingPlayCardOpponent re-flip ロジック (reducer.ts:692) を kernel の turnEnded 決定に正しく移植。property test の double_move エッジケースで担保。
 
 ## 11. S1a DoD (additive のみ・production 不変)
-- [ ] `world-kernel.ts`: WorldState + building-block + applyTurnAction 実装 (新規ファイル)
-- [ ] reducer.ts: `makeMoveWithEffects` 等の `export` 付与のみ (振る舞い不変、呼出経路・ロジック不変)
-- [ ] property-based 等価テスト新設・green (現 reducer 経路 vs 新 applyTurnAction の独立2実装比較、DP-1〜7 + エッジケース、**hand-rolled seeded generator = fast-check 等の依存追加なし**)
-- [ ] reducer.test / undo-policy.test / effects.test 全 green (不変ゲート = production 不変の証跡)
-- [ ] lint / typecheck / test:ci / build green
-- [ ] standard variant byte-level 不変 (kernel は card-shogi 専用、standard は kernel 非経由)
-- [ ] **reducer の薄ラッパ化・AI 配線は含めない (S1c/S1b へ隔離)**
+- [x] `world-kernel.ts`: WorldState + building-block + applyTurnAction 実装 (新規ファイル) — part1 commit `29d1e1e`
+- [x] reducer.ts: `makeMoveWithEffects` 等の `export` 付与のみ (振る舞い不変、呼出経路・ロジック不変) — part1
+- [x] property-based 等価テスト新設・green (現 reducer 経路 vs 新 applyTurnAction の独立2実装比較、DP-1〜7 + エッジケース、**hand-rolled seeded generator = fast-check 等の依存追加なし**) — part2: `src/lib/shogi/kernel/__tests__/world-kernel-equivalence.test.ts` (16 件: ランダム harness 180 seed×40 ply + targeted 15)
+- [x] reducer.test / undo-policy.test / effects.test 全 green (不変ゲート = production 不変の証跡) — test:ci 528 passed
+- [x] lint / typecheck / test:ci / build green — part2 完了時点で全 green
+- [x] standard variant byte-level 不変 (kernel は card-shogi 専用、standard は kernel 非経由)
+- [x] **reducer の薄ラッパ化・AI 配線は含めない (S1c/S1b へ隔離)** — additive のみ維持
 
 ## 12. マイルストーン1レビュー反映 (2026-06-07、AGENTS.md ルール8)
 本計画初版を 3観点 adversarial workflow (#109 観点 + reducer 実コード照合) でレビューし、以下を反映:
@@ -118,3 +118,15 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 - **playCard は単一 union メンバ + defId dispatch** (§4 注): 新 union メンバを増やさない。
 - 妥当と確認: 中核戦略 (抽出して委譲)・二層構造・DP-1〜7 射影・check_break reuse・feature-flag+多層 rollback・evaluateGameEnd 共有。
 - 着手前提: S0 design doc はユーザー承認済 (2026-06-07、epic §8.6)。本 worktree に epic SSOT を co-locate 済 (design ブランチ merge)。
+
+## 13. マイルストーン2レビュー反映 (実装後、2026-06-07、AGENTS.md ルール8)
+S1a part2 (property-based 等価テスト) 実装完了時点で、5観点 adversarial workflow (#109 観点 + 実コード照合 + 計装 coverage probe、16 agents) を実施。**16 findings → high/medium 11 件を独立検証 = 全件 confirmed (refuted/uncertain 0)**。指摘は「計画 §8.3.4 必須エッジのうち**終局 (status≠active) 系がランダム harness でも targeted でも未踏**」に収束。下記をすべて反映:
+- **[high] 通常 move 終局の turn-end スキップ**: 固定盤面 (head-gold 詰み) で詰ます手を適用し、`advanceDrawProgress` の status≠active no-op (drawProgress 境界 4 でも reset/auto-draw しない) と status/winner/flip 等価を pin。
+- **[high] double_move 1手目詰みの即 finalize** (world-kernel.ts:258-274): 1手目で詰む固定盤面で、flip 戻し抑止・カード遅延消費 (hand→graveyard, mana-=5, cardPlayEvent)・drawProgress スキップを reducer 経路と等価 pin。
+- **[medium] DP-5×カード**: pawn_return で戻した駒の no_promote マーク削除 (removeNoPromoteMark) を pin。
+- **[medium] DP-7**: double_move 中の check_break が 1手目で defer (トラップ残置)・2手目で発火 (王手駒捕獲・トラップ消費・trapTriggerEvent) する複合列を pin。捕獲駒の no_promote マーク削除も pin。
+- **[medium] 王手中 double_move (checkUsage=unconditional)**: 王手中の double_move 開始 + RELAXED 1手目 (自玉王手のまま) → 2手目で解消、を等価 pin (王手中カード orchestration / RELAXED 1手目の双方をカバー)。
+- **[low] OBS4-5**: ランダム harness の doubleMove 同期チェックに cardInstance.instanceId / cardCost 比較を追加 (遅延消費パラメータの一致を直接 pin)。
+- **[low] OBS5-3**: deprecated `mana_up` 分岐 (kernel/reducer 両在) の等価を targeted で pin しデッドカバレッジ解消。
+- **[low] F-3 (doc)**: 本計画 §4/§8 の「Date.now() stub」記述を実態 (stripAt による at 射影除外 = stub 不要) に訂正。
+- 結果テスト: ランダム harness 180 seed×40 ply + targeted 15 = 計 16 件 green。test:ci 528 passed / build green。

--- a/docs/plans/issue-235-s1-kernel.md
+++ b/docs/plans/issue-235-s1-kernel.md
@@ -150,3 +150,21 @@ S1c (lean) 計画を 4観点 adversarial workflow (deps/behavior/tests/doc-ssot�
 - **[スコープ訂正] doc/コメント精度**: 旧 doc の「S1c=薄ラッパ化+shadow-assert」記述を lean (S1c=物理移設のみ、委譲=S1d、shadow-assert 廃止) に上書き (§5/§6/§9)。world-kernel.ts:8-11/41 ヘッダコメントも S1c 完了版に更新する。
 - **[S1d へ反映] テスト十分性の論理飛躍**: 「world-kernel-equivalence green = S1c 移設の絶対証拠」は S1c (純粋移設) では成立する (reducer ロジック無改変ゆえ全テスト green で十分) が、レビューが懸念した「演出 flag の event-driven 化の検証不足」は **S1d の懸念**。S1d DoD に演出オーケストレーション統合テストを含める旨を §6 S1d 項に明記済。なお shadow-assert 再導入は lean 決定により行わない。
 - 妥当と確認: 物理移設可・循環依存なし・import 整理範囲確定・import パス更新は world-kernel.ts のみ・tsconfig 変更不要・tree-shaking 影響なし・baseline (test:ci 539 passed/build green) 再現で純粋移設担保。
+
+## 16. S1 完了宣言 + S2 引き継ぎ (S1d cutover 完了時、2026-06-07)
+S1d cutover (詳細計画: `docs/plans/issue-235-s1d-cutover.md`) 完了をもって **S1 (L0 カーネル統合) 全段 (S1a/S1b/S1c/S1d) 完了**。
+- **S1 完了の定義 (達成済)**:
+  - L0 カーネル (`world-kernel.ts` applyTurnAction + building-block / `move-effects.ts` makeMoveWithEffects) が
+    reducer (UI) と AI 探索の **単一権威** として採用済 (P4 二重実装解消)。
+  - production 振る舞いは UI=等価 (reducer.test + 演出統合テスト)、AI=DP-1 lazy drawProgress / base mana charge の
+    意図的既知差分のみ (move 間順位不変、move vs card/draw 選好のみ作用、S3 再校正前提・ユーザー承認済)。
+  - 等価担保: world-kernel-equivalence (180 seed×40 ply + targeted 15) / kernel-search-equivalence / reducer.test /
+    undo-policy.test / effects.test 全 green。bench で棋力退化なし実測 (cardRate 4/4、action OFF==ON、d4==d4)。
+  - rollback: 単一 cutover コミット `git revert` + AI は route.ts の `useKernelSearch: true` 削除で OFF 復帰。
+- **S2 (L1 CardSpec registry) への引き継ぎ**:
+  - L0 が export する building-block (`applyTurnAction` / `advanceDrawProgress` / `finalizeDoubleMoveLogic` /
+    `applyCardEffectLogic` / `makeMoveWithEffects`) が S2 の土台。
+  - `applyCardEffectLogic` は現状 effectId switch (trap/mana_up/pawn_return/piece_return/double_pawn) のハードコード。
+    S2 で単一 `CardSpec.effect.apply` registry に supersede 予定 (= 本 switch は S2 で CardSpec 駆動へ置換される暫定 bridge)。
+  - 新カード追加は S2 完了までは AGENTS.md「カード将棋: 新規カード追加時のチェックリスト」+ applyCardEffectLogic の
+    switch 追記が必要 (S2 で registry 化されると 1 スキーマで自動追従)。

--- a/docs/plans/issue-235-s1-kernel.md
+++ b/docs/plans/issue-235-s1-kernel.md
@@ -54,7 +54,7 @@ function applyTurnAction(
 | reducer 現在地 | kernel 抽出先 | 備考 |
 |---|---|---|
 | `makeMoveWithEffects` (:239) | `applyMoveLogic(world, move, mode, opts)` | ほぼそのまま lift。CardShogiGameStateInternal 依存なし (gameState+cardState のみ) → WorldState 化容易 |
-| `applyTurnEndEffects` (:447) の cardState 部 (drawProgress/deck/hand) | `advanceDrawProgress(cardState, gameState, player) → { cardState, events }` | **新規実装** (reducer 版は UI 結合のため再利用不可)。drawProgress +1、5到達∧deck非空で 0 reset + auto-draw (deck先頭→hand, drawEvent{source:auto} を events に)。**非再帰・1回のみ** (DP-1)。UI flag (isDrawing/pendingDrawPlayer/selectedSquare clear) は **reducer が S1c で返り値 events を読んで event-driven にセット** (kernel は cardState+events のみ返す) |
+| `applyTurnEndEffects` (:447) の cardState 部 (drawProgress/deck/hand) | `advanceDrawProgress(cardState, gameState, player) → { cardState, events }` | **新規実装** (reducer 版は UI 結合のため再利用不可)。drawProgress +1、5到達∧deck非空で 0 reset + auto-draw (deck先頭→hand, drawEvent{source:auto} を events に)。**非再帰・1回のみ** (DP-1)。UI flag (isDrawing/pendingDrawPlayer。selectedSquare clear は reducer 演出側責務で advanceDrawProgress の対象外) は **reducer が S1d で返り値 events (auto drawEvent) を読んで event-driven にセット** (kernel は cardState+events のみ返す) |
 | `finalizeDoubleMoveCardConsumption` (:666) の consumeNormalCard+event 部 | `finalizeDoubleMoveLogic(world, dm)` | isPlayingCard/pendingPlayCardOpponent flag は reducer に残す |
 | CONFIRM_PLAY_CARD (:1207) の効果適用部 | `applyCardEffectLogic(world, action)` | pendingCard/演出 flag は reducer に残す |
 | currentPlayer flip (MAKE_MOVE/COMMIT_* に散在) | applyTurnAction 内に集約 | 「ターン終了で flip」を kernel が一元管理 |
@@ -64,10 +64,14 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 ## 6. 移行段階 (S1a〜d、各段で不変ゲート green を維持) — **epic SSOT §8.5.2 準拠 (マイルストーン1レビュー反映)**
 > **重要訂正**: 初版は S1a に「reducer を委譲へ refactor」を含めていたが、これは epic SSOT §8.5.2 の定める staging (S1a=additive 新規モジュールのみ / reducer 薄ラッパ化=S1c / cutover=S1d 単一コミット隔離) と矛盾し、最大リスクの production rewire を property 等価 green より前に前倒しして rollback 第2層 (cutover 隔離) の前提を壊す。SSOT 通り **S1a は production (reducer/AI) 完全不変**に訂正。
 - **S1a (本計画の主対象)**: `world-kernel.ts` を**新規モジュールとして追加** = WorldState + building-block (applyMoveLogic/advanceDrawProgress/applyCardEffectLogic/finalizeDoubleMoveLogic) + atomic applyTurnAction。**production (reducer/AI) は完全不変** (例外: 純粋関数 `makeMoveWithEffects` 等を kernel から再利用するため reducer.ts に `export` を**付与するのみ**の振る舞い不変変更は許容。reducer の呼出経路・ロジックは一切変えない)。**property-based 等価テスト新設** (現 reducer 経路 vs 新 applyTurnAction の独立2実装比較、§8.3.4)。既存 reducer.test/undo-policy.test/effects.test 全 green 維持。
-  - **reuse 方針**: `makeMoveWithEffects` は純粋 (gameState+cardState のみ依存、レビューで確認) のため reducer.ts から `export` して kernel が import 再利用 (rewrite 回避)。`applyTurnEndEffects` は UI state 結合のため**そのコア (drawProgress/deck/hand 変換) を kernel に新規実装** (`advanceDrawProgress`)、reducer 側は S1a では不変 (S1c で advanceDrawProgress へ委譲)。両者の等価は property test で担保。
+  - **reuse 方針**: `makeMoveWithEffects` は gameState+cardState+move+options のみ依存し reducer の他 state フィールドに隠れた依存を持たない (レビューで確認) ため reducer.ts から `export` して kernel が import 再利用 (rewrite 回避)。※ 厳密には純粋関数ではなく `Date.now()` に依存する (早指しボーナス isFastMove 判定 + イベント at) が、この非決定性は spectatorMode=true (fastMove 無効化) と at 射影除外で制御済 (§7 DP-4)。`applyTurnEndEffects` は UI state 結合のため**そのコア (drawProgress/deck/hand 変換) を kernel に新規実装** (`advanceDrawProgress`)、reducer 側は S1a/S1c では不変 (S1d で advanceDrawProgress へ委譲)。両者の等価は property test で担保。
 - **S1b**: AI 探索が `useKernelSearch` フラグ (既定 OFF) 裏で applyTurnAction 経由に切替可能化 + `AiTurnState.doubleMove` の kernel 型統合 + double_move cardState 近似 (current-rules.ts:114) 解消。OFF で既存挙動完全保持。bench で旧経路と depthCompleted/カード使用率比較。
-- **S1c**: reducer を完全な薄ラッパ化 (各演出フェーズが kernel building-block を呼ぶ) + shadow-assert モード (旧経路 vs kernel を dev/test で `===` assert、採用は旧経路)。`advanceDrawProgress` の {cardState, events} 返り値を reducer が読んで isDrawing/isCheckBreakAnimating 等の演出 flag を event-driven にセット。
-- **S1d**: 等価 + bench green 確認後に**単一コミット**で既定をカーネルへ flip (rollback 第2層: `git revert` 対象)。shadow 本番無効化。
+- **S1c (lean 方式、2026-06-07 ユーザー確定で shadow-assert 不採用)**: `makeMoveWithEffects` (+ `MakeMoveMode` 型) を reducer.ts から新規 lib モジュール `src/lib/shogi/kernel/move-effects.ts` へ**物理移設のみ**。reducer は移設先から import して**従来どおり直接呼ぶ** (呼出経路・ロジック・関数本体は 1 行も変えない)。これにより world-kernel (lib) → reducer (hooks) の暫定逆依存 (層違反) を解消する。**挙動完全不変・純粋リファクタ**。
+  - **shadow-assert は廃止**: S1a の property-based 等価テスト (reducer dispatch ≡ applyTurnAction を 180 seed×40 ply + targeted で検証済) が等価担保の主目的を達成済のため、throwaway な二重計算コードを production reducer に入れない。
+  - **reducer の薄ラッパ化 (各演出フェーズが kernel building-block を呼ぶ委譲) は S1c から S1d へ移動**。S1c では reducer ロジックは無改変。
+  - **等価ゲート**: 物理移設のみのため lint/typecheck/test:ci 全 green (特に reducer.test/undo-policy.test/effects.test/world-kernel-equivalence.test/kernel-search-equivalence.test) + build green の再現が純粋移設の証跡。
+- **S1d (cutover、単一 git-revert 可コミット)**: ① reducer の `applyTurnEndEffects` (cardState 部) / `finalizeDoubleMoveCardConsumption` / `CONFIRM_PLAY_CARD` 効果適用部を kernel building-block (`advanceDrawProgress` / `finalizeDoubleMoveLogic` / `applyCardEffectLogic`) へ**委譲 (薄ラッパ化)**、inline 重複除去 + UI flag (isDrawing/pendingDrawPlayer 等) を返り値 events から event-driven セット。`applyCardEffectLogic` は現状 private のため export 要。② AI: `useKernelSearch` 既定 ON。
+  - **S1d 等価ゲート (M1 レビュー反映)**: S1c と異なり S1d は reducer のオーケストレーションを変える (inline → 委譲 + flag の event-driven 化)。S1a property test + reducer.test/undo/effects/S1b 特性化に加え、**演出オーケストレーション (drawProgress→isDrawing/pendingDrawPlayer 変換、check_break defer 順序、二手指し finalize タイミング) を直接突く統合テストを S1d DoD に含める** (ゲーム状態スナップショット比較だけでは演出 flag の順序・defer/trigger タイミングを捕捉できないため)。挙動は意図的に等価 (UI=reducer.test、AI 評価は DP-1 lazy drawProgress 等で微変=bench 監視)。rollback 第2層: `git revert` 対象。
 
 ## 7. property-based 等価テスト (S1a、§8.3.4 + DP-1〜7)
 - **framework (依存追加なし)**: fast-check は package.json 未導入 + AGENTS.md §7 (パッケージ追加は要確認) のため**使わない**。PoC-3 と同じ **hand-rolled seeded PRNG (mulberry32) + 手書き generator** で実装 (vitest のみで完結、決定的・再現可能)。
@@ -87,8 +91,8 @@ reducer 側は抽出後、各フェーズで kernel 関数を呼び **UI state (
 - DP-6 manaCap: 不変 (kernel 内代入なし)。
 - DP-7 check_break: applyCheckBreak が getCheckingPieces (直接王手駒のみ)。double_move_first は defer。
 
-## 9. feature-flag + rollback (epic §8.5 準拠)
-- flag `useKernelSearch` (AI、既定 OFF) / reducer shadow-assert。
+## 9. feature-flag + rollback (epic §8.5 準拠、lean 反映)
+- flag `useKernelSearch` (AI、既定 OFF)。**reducer 側 shadow-assert は不採用** (lean、S1a property test が等価担保の主目的を達成済のため)。reducer の等価は移設の純粋性 (S1c) + 全テスト green + S1d 委譲時の reducer.test/undo/effects/演出統合テストで担保。
 - rollback 3層: フラグ OFF / S1d cutover commit を `git revert` / reducer.test+undo+effects+property を blocking gate。
 - standard byte-level 不変ゲート。
 
@@ -130,3 +134,19 @@ S1a part2 (property-based 等価テスト) 実装完了時点で、5観点 adver
 - **[low] OBS5-3**: deprecated `mana_up` 分岐 (kernel/reducer 両在) の等価を targeted で pin しデッドカバレッジ解消。
 - **[low] F-3 (doc)**: 本計画 §4/§8 の「Date.now() stub」記述を実態 (stripAt による at 射影除外 = stub 不要) に訂正。
 - 結果テスト: ランダム harness 180 seed×40 ply + targeted 15 = 計 16 件 green。test:ci 528 passed / build green。
+
+## 14. S1c (lean = makeMoveWithEffects 物理移設) DoD
+挙動完全不変・純粋リファクタ。reducer ロジックは無改変 (委譲は S1d)。
+- [ ] `src/lib/shogi/kernel/move-effects.ts` 新設: `MakeMoveMode` 型 + `makeMoveWithEffects` 関数を reducer.ts から**本体 1 行も変えず**移設・export。import は全て lib 層 (types/board/moves/rules/variants/cards/effects/定数)。hooks 依存ゼロ。
+- [ ] reducer.ts: `MakeMoveMode`/`makeMoveWithEffects` 定義を削除し `@/lib/shogi/kernel/move-effects` から import。makeMoveWithEffects 専用だった import (`evaluateGameEnd` / `MANA_PER_TURN` / `MANA_FAST_BONUS` / `FAST_THRESHOLD_MS` / `applyCheckBreak` / `applyTrapClear` / `addNoPromoteMark` / `moveNoPromoteMark`) を削除。**`removeNoPromoteMark` (reducer.ts:1268/1286 で使用) / `AUTO_DRAW_INTERVAL` (applyTurnEndEffects で使用) は削除しない**。6 呼び出し箇所 (reducer.ts MAKE_MOVE/CONFIRM_PROMOTION) はシグネチャ同一でコード本体無変更。
+- [ ] world-kernel.ts: makeMoveWithEffects の import 元を `@/hooks/card-shogi/reducer` → `@/lib/shogi/kernel/move-effects` に変更 + ヘッダコメントを「S1c で物理移設・逆依存解消済」に更新。
+- [ ] lint 0err / typecheck exit0 / test:ci 全 green (S1b 完了時点と同値) / build green = 純粋移設の証跡。
+- [ ] 直接ユニットテストの追加は不要 (property-based 等価 + reducer.test で十分。将来 move-effects.ts に意味的変更が入った時点で追加検討)。
+- [ ] shadow-assert は不採用 (S1a property test が等価担保の主目的を達成済のため、§6 S1c / §9 参照)。reducer ロジックは無改変ゆえ二重計算コードを入れる価値が小さい。
+
+## 15. S1c マイルストーン1レビュー反映 (計画直後、2026-06-07、AGENTS.md ルール8)
+S1c (lean) 計画を 4観点 adversarial workflow (deps/behavior/tests/doc-ssot、#109 観点 + 実コード照合、44 agents、22 件 confirmed) でレビュー。**総合判定: 着手可 (計画を覆す欠陥ゼロ)**。過半は「計画の正しさを実証する肯定的指摘」。下記を反映:
+- **[事実訂正] makeMoveWithEffects は純粋関数ではない**: behavior 観点の high「純粋ゆえ安全」は事実誤認 (reducer.ts:384/407 で `Date.now()` 依存)。ただし非決定性は spectatorMode + at 射影で制御済のため移設は安全。本計画 §6 reuse 方針の「純粋」表現を訂正済。実装時は spectatorMode/at 射影の契約を 1bit も変えない (メモ化禁止)。
+- **[スコープ訂正] doc/コメント精度**: 旧 doc の「S1c=薄ラッパ化+shadow-assert」記述を lean (S1c=物理移設のみ、委譲=S1d、shadow-assert 廃止) に上書き (§5/§6/§9)。world-kernel.ts:8-11/41 ヘッダコメントも S1c 完了版に更新する。
+- **[S1d へ反映] テスト十分性の論理飛躍**: 「world-kernel-equivalence green = S1c 移設の絶対証拠」は S1c (純粋移設) では成立する (reducer ロジック無改変ゆえ全テスト green で十分) が、レビューが懸念した「演出 flag の event-driven 化の検証不足」は **S1d の懸念**。S1d DoD に演出オーケストレーション統合テストを含める旨を §6 S1d 項に明記済。なお shadow-assert 再導入は lean 決定により行わない。
+- 妥当と確認: 物理移設可・循環依存なし・import 整理範囲確定・import パス更新は world-kernel.ts のみ・tsconfig 変更不要・tree-shaking 影響なし・baseline (test:ci 539 passed/build green) 再現で純粋移設担保。

--- a/docs/plans/issue-235-s1b-ai-wiring.md
+++ b/docs/plans/issue-235-s1b-ai-wiring.md
@@ -1,0 +1,122 @@
+# Issue #235 S1b: AI 探索を useKernelSearch フラグ裏で applyTurnAction 経由に切替可能化 — 実装計画
+
+> 親 doc: `docs/plans/issue-235-card-shogi-ai-redesign.md` (§3 L0 / §8.5)。S1 計画: `docs/plans/issue-235-s1-kernel.md` (§6 S1b)。
+> ブランチ `refactor/#235-s1` (S1a part1/2 完了済 commit `668cb78`)。本 doc は AGENTS.md ルール8 マイルストーン1 (実装着手前レビュー) の対象。
+
+## 0. ゴールと非ゴール
+**ゴール**: カード将棋 AI 探索の **root カード/ドロー評価経路**を `useKernelSearch` フラグ (既定 OFF) 裏で L0 カーネル `applyTurnAction` 経由に切替可能化する。OFF は既存挙動を**バイト等価で完全保持**、ON は単一権威カーネルを通すことで DP-1〜7 を自動適用する。`AiTurnState.doubleMove` を kernel の `KernelDoubleMove` 型へ統合し、double_move cardState 近似を解消する。
+**非ゴール (S1b では触らない)**: 深い negamax/quiescence の move-only ホットパス (cardState 非搬送のため kernel 化の意味なし)、TT の cardState ハッシュ拡張 (S4)、評価係数の再校正 (S3 ValueModel)、reducer 側 (S1c)、cutover で既定 ON 化 (S1d)、route.ts (S1d まで OFF 固定)。
+
+## 1. スコープの精緻化 (recon 6観点 + 中核ファイル精読で確定)
+kernel 経由化が効くのは **root のカード/ドロー評価 2 関数のみ**:
+- `evaluateActionWithLookahead` (search.ts:1115) — move/draw/playCard(通常) の lookahead 評価。内部で `applyActionForLookahead` (search.ts:1000) を呼ぶ。
+- `searchDoubleMoveSuperAction` (search.ts:834) — double_move の 2 手指し組合せ探索。`CurrentRules.applyAction` + 手動 cardState wiring (search.ts:857-883) を使う。
+
+深い negamax (search.ts:540-721) は move-only で cardState を搬送しないため **OFF/ON とも `applyMoveForSearch` のまま不変**。engine.ts:295-344 の root カード採用ループは `evaluateActionWithLookahead` を ctx 経由で呼ぶだけなので**ループ本体は無改変**(フラグは ctx に相乗り)。
+
+## 2. 中核原則 — 旧コード無改変で OFF 等価を構造保証
+`applyActionForLookahead` / `searchDoubleMoveSuperAction` の手動 wiring / `CurrentRules.applyAction` の double_move 近似は **一切削除・改変しない** (= OFF 経路として丸ごと保持)。ON 経路は別実装を `ctx.useKernelSearch` で二分岐して**追加**する。旧コードに触れないため OFF のバイト等価が構造的に保証される (S1a と同じ additive 戦略)。
+
+## 3. OFF と ON の差分 (= 「ON は production 等価への是正」の全列挙)
+ON は `applyTurnAction` (= 本番 reducer と同一ロジック) を通すため、軽量近似の OFF とは下表の通り差が出る。**すべて「ON がより正確」方向**で、棋力影響は bench で測定・記録する (係数再校正は S3、ユーザー確認済 2026-06-07)。
+
+| action | gameState 差 | cardState 差 |
+|---|---|---|
+| move | OFF=`applyMoveForSearch` (盤+flip のみ、status=active 据置)。ON=`makeMoveWithEffects` (盤+flip + **trap発火 + noPromote追従 + game-end status**) | OFF=drawProgress+1 のみ。ON=**manaCharge+1** + lazy drawProgress (DP-1: +1 or reset+auto-draw) + trap発火時 trap clear + lastTurnStartedAt クリア |
+| draw | OFF=不変 (flip なし)。ON=**currentPlayer flip** (大半は評価不変*) | OFF=mana-2/hand+1/deck-1/drawProgress+1。ON=同左 + **lazy drawProgress** (境界で reset + auto-draw 2枚目) |
+| playCard trap | OFF=不変。ON=**flip** (大半は評価不変*) | OFF=mana-cost/hand-1/trap set/drawProgress+1。ON=同左 + lazy drawProgress (境界 auto-draw) |
+| playCard 通常 | OFF=`simulateCardEffect` (盤, flip なし、status 据置)。ON=`applyCardEffectLogic` (盤 via applyPawnReturn 等 [**盤面は OFF と同一**] + flip) | OFF=mana-cost/hand-1 (graveyard 追加なし)/drawProgress+1。ON=mana-cost/**hand→graveyard** (consumeNormalCard)/**noPromoteMarks: removeNoPromoteMark で対象マス削除** (OFF 不変)/lazy drawProgress |
+| double_move | OFF=`CurrentRules.applyAction` 連鎖 (近似、status 据置)。ON=`applyTurnAction` 連鎖 (playCard→move→move)。**2手目/1手目が終局 (mate 等) なら ON は status セット** | OFF=手動 wiring (mana-5/hand-1/drawProgress+1、**graveyard なし**)。ON=**遅延 finalize で hand→graveyard** + lazy drawProgress + flip 戻し/抑止を kernel が一元処理 |
+
+**評価スコアへの影響**:
+- **board (駒配置)**: trap 未発火・非 modifyBoard の move、および全 modifyBoard カードでは OFF/ON 一致 (`simulateCardEffect` は kernel と同じ `applyPawnReturn` 等を呼ぶ)。trap (check_break/no_promote) が move で発火する局面のみ ON は盤が変わる (ON 是正)。
+- **status / 終局スコア (OBS3-1)**: 着手後/2手目が終局 (checkmate/stalemate/repetition/impasse) になる局面で、ON は `evaluateGameEnd` が status をセット → `evaluate` が mate score (±100000) / draw (0) を返す。OFF は status=active のまま material 評価。→ **score 次元の差** (ON 是正)。
+- **currentPlayer / tempo (OBS2-F1、訂正)**: 旧記述「evaluate は currentPlayer 非依存」は**誤り**。`evaluate` には currentPlayer 依存の tempo 項 (±15cp、evaluate.ts:73 付近) がある。通常経路では `getOpponentResponseScore` が opp 手を `applyMoveForSearch` で再 flip するため tempo は OFF/ON 一致するが、**terminal sub-case (oppMoves=0 = 相手が既に詰み/stalemate) で draw/playCard を打つ稀少局面**では `applied.gameState` の currentPlayer を直接 evaluate するため OFF(自分)/ON(相手) で tempo 符号反転 = 正味 ±30cp 乖離 (ON 是正 = 手番が相手に渡った正しい局面)。move/double_move は OFF/ON とも flip するため tempo 一致。
+- **must-not-match (評価非影響、特性化 test で除外/分離)**: lastTurnStartedAt (ON move/draw でクリア)、moveCount (ON move で +1)、moveHistory/positionHistory (ON move で append)。digest にも oppScore にも効かない。
+
+## 4. 実装方針 (additive・フラグ二分岐)
+### 型統合 (S1b-0、M1 レビュー OFF-1/OFF-3/F-3 反映 = optional 化)
+**[訂正]** 当初案は `AiTurnState.doubleMove` を `KernelDoubleMove` 同型 (cardInstance/cardCost **必須**) に拡張だったが、これは (a) current-rules.ts:93 (move 遷移 `{active,movesLeft:1}`) / :121 (double_move set) を typecheck で破壊、(b) double-move-search.test.ts / action-generator.test.ts の `{active,movesLeft}` リテラル代入を破壊、(c) OFF 経路に cardInstance/cardCost を補完すると `toEqual({active,movesLeft})` を runtime 破壊する。よって **optional 化**に変更:
+- `AiTurnState.doubleMove` を `{ active: Player; movesLeft: 1|2; cardInstance?: CardInstance; cardCost?: number } | null` に拡張 (turn/types.ts:37-40)。**OFF 経路 (current-rules.ts:93/121) は無改変** (optional フィールドを省略するだけ = typecheck/toEqual/既存テスト完全保持、OFF バイト等価)。
+- 変換 `aiTurnStateToWorldState` は narrowing で fallback 補完: `doubleMove === null ? null : { active, movesLeft, cardInstance: dm.cardInstance ?? {instanceId:"",defId:"double_move"}, cardCost: dm.cardCost ?? CARD_DEFS["double_move"].cost }`。
+- **実害なし**: S1b の ON 経路 (searchDoubleMoveSuperAction) は root の AiTurnState (doubleMove=**null**) から開始し、kernel `applyPlayCardAction` (world-kernel.ts:351-364) が `cardInstanceId` + `CARD_DEFS[defId].cost` から `KernelDoubleMove` を**自動構築**するため、AI 側は cardInstanceId を実値で渡すだけでよい。converter の非 null fallback 分岐は型整合のための保険 (S1b 経路では到達しない)。
+- これにより S1 計画 §6 の「AiTurnState.doubleMove 型統合」は optional 拡張 + converter bridge の形で達成 (literal 同型化は不要・破壊的なので不採用)。
+
+### フラグ配線 (S1b-1)
+- `CreateSearchContextOptions` + `SearchContext` (search-context.ts:39-62) に `useKernelSearch?: boolean` / `spectatorMode?: boolean` 追加 (既定 false)。`createSearchContext` で wiring。
+- `FindBestMoveOptions` (engine.ts:111-143) に `useKernelSearch?: boolean` 追加。engine.ts:193-197 の `createSearchContext` 呼出に `useKernelSearch: options.useKernelSearch ?? false` / `spectatorMode: options.spectator ?? false` を渡す。
+- ctx は既に findBestMove→evaluateActionWithLookahead→searchDoubleMoveSuperAction へ伝播済 = 新規スレッド経路不要。
+
+### 変換ヘルパ + 通常 action の ON 経路 (S1b-2)
+- `aiTurnStateToWorldState(state: AiTurnState): WorldState` 純粋関数 (gameState/cardState/doubleMove 直渡し、型統合済なら自明)。
+- `applyTurnActionForLookahead(state, action, player, opts): { gameState; cardState } | null` 薄 wrapper: WorldState 構築 → `applyTurnAction(world, action, {spectatorMode})` → `{gameState: world.gameState, cardState: world.cardState}` を返す (戻り値型は `applyActionForLookahead` と同一 = 後段 updateCardDigest/getOpponentResponseScore に無改変で流れる)。冒頭に variant ガード (防御的)。double_move (defId) が来たら null (delegate、呼出側で分岐済のため通常到達しない)。
+- `evaluateActionWithLookahead` (search.ts:1132): `const applied = ctx?.useKernelSearch ? applyTurnActionForLookahead(...) : applyActionForLookahead(...)` に二分岐。それ以外 (excludeTadasute / updateCardDigest / getDrawValue / oppScore) は無改変。
+
+### double_move の ON 経路 (S1b-3)
+`searchDoubleMoveSuperAction` に `ctx?.useKernelSearch` 分岐を追加:
+- ON: `world0 = aiTurnStateToWorldState(state)` → `applyTurnAction(world0, {kind:"playCard", cardInstanceId, defId:"double_move"})` で `worldDM` (doubleMove set, turnEnded=false)。各 1手目 `applyTurnAction(worldDM, {kind:"move", move:first})` → `worldF`。各 2手目 `applyTurnAction(worldF, {kind:"move", move:second})` → `worldS` (turnEnded=true を assert) → `evaluate(worldS.gameState, variant, innerDigest)`。innerDigest は `updateCardDigest(prevDigest, state.cardState, worldS.cardState)` (kernel が cost 正確消費 + lazy drawProgress 済)。
+- **1手目 mate 分岐 (R3、OBS3-1)**: ON では kernel が 1手目で詰みを検出すると gameOver 分岐 (world-kernel.ts:258-274) で **turnEnded=true** を返す (OFF の CurrentRules.applyAction は game-end 評価せず turnEnded=false で続行)。よって ON 経路は `if (worldF.turnEnded) { worldF.world.gameState を直接 evaluate して候補化し、2手目ループを skip }` を実装する (OFF と非対称だが ON 是正 = 1手目で詰めば 2手目不要)。1手目 turnEnded=false のみ 2手目ループへ。
+- **cardInstanceId 取得 (OBS3-2)**: `state.cardState.hand[player].find(c=>c.defId==="double_move")?.instanceId` を取得し、**未発見 (undefined) なら ON 経路を early-return** (`NEG_INF` を返す = 候補生成 getCardActions で本来除外済の異常系)。`?? ""` の空文字 fallback は kernel consumeNormalCard が instanceId 不一致で null 化し OFF と非対称な mana/digest を生むため**使わない**。
+- OFF: 既存の `CurrentRules.applyAction` + 手動 wiring を**完全保持** (cardInstanceId は OFF では不問 = L846 の空文字のまま)。
+- 1手目候補の上位 K 絞り (DOUBLE_MOVE_TOP_K)・excludeTadasute・bestScoreIgnoringTadasute フォールバックは ON/OFF 共通ロジックとして維持。
+- **caller (F-2)**: `searchDoubleMoveSuperAction` は `evaluateActionWithLookahead` (ply=1、production root 経由) と `evaluateAction` (ply=0、**production 未到達** = engine は ply=1 固定 engine.ts:316/329) の両方から呼ばれるが、関数本体を二分岐するため両 caller を自動カバー。ply=0 経路は production 未到達のため OFF 専用据置で問題なし。
+
+### engine.ts (S1b-2 と同時)
+`FindBestMoveOptions.useKernelSearch` を受領し ctx へ渡すのみ。root ループ本体 (engine.ts:316-343) は無改変。
+
+## 5. 段階 (各段で不変ゲート green、OFF バイト等価維持)
+- **S1b-0** 型統合 (optional 化): `AiTurnState.doubleMove` に `cardInstance?`/`cardCost?` 追加。current-rules.ts は無改変。ゲート: lint/typecheck/test:ci green。**実破壊検出対象 = `double-move-search.test.ts` / `action-generator.test.ts`** (= AiTurnState.doubleMove を行使、optional 化で無改変通過するはず)。strategy-equivalence/card-digest は doubleMove 非依存のため「型変更が無影響」確認用 (実破壊検出には不十分、OFF-2)。
+- **S1b-1** フラグ配線: SearchContext / FindBestMoveOptions / createSearchContext。誰も ON にしない = production 完全不変。ゲート: typecheck/test:ci green。
+- **S1b-2** 通常 action ON 経路: `aiTurnStateToWorldState` + `applyTurnActionForLookahead` + evaluateActionWithLookahead 二分岐。ゲート: 新規 unit/特性化 test で OFF vs ON の applied 差分が §3 の通りであることを pin。**board 一致は条件分岐 (F-5)**: trap 未発火 move / 全 modifyBoard カードは board(駒配置) 一致、trap 発火 move は board も ON 是正。currentPlayer は ON 是正(flip) として期待 (gameState 完全一致を期待しない)。cardState は mana(move:+1)/drawProgress(lazy)/graveyard(card:+1)/noPromoteMarks(通常カード:削除) を ON 是正方向として分離 assert。
+- **S1b-3** double_move ON 経路: searchDoubleMoveSuperAction 二分岐。ゲート: turnEnded 不変条件 (2手目 true / 1手目は非終局で false・終局で true=OBS3-1) を ON で assert、固定盤面で double_move 後の gameState 一致 + cardState (cost 正確消費 = hand→graveyard) を pin。
+- **S1b-4** 特性化 property test: OFF vs ON の applied state を seeded harness で比較し、§3 の差分**のみ**に収まることを pin。board(駒配置)一致を must-match、currentPlayer/status/mana/drawProgress/graveyard/noPromoteMarks/lastTurnStartedAt/moveCount/history は**既知 divergence として分離 assert** (zobrist 一致のみで合格としない、OBS3-1/OBS2-F1)。fixture に **trap 保持下の move / no_promote マーク済自駒の pawn_return / auto-draw 境界(drawProgress=4) / 終局手** を必ず含める (F-5/OBS3-1)。ユーザー方針: property test + bench 両方。
+- **S1b-5** bench 比較: perf-bench-card-usage / perf-bench を OFF/ON 両値で回す。**主指標 = root カード評価フェーズの elapsedMs (OFF/ON 並記)** — depthCompleted は findBestMove 非改変ゆえ構造的に不変なので「kernel 切替が深い探索に無影響」の sanity 確認に留める (F-4)。カード使用率 (usedCardAction) も OFF/ON で記録。**公平性 (F-6)**: bench は spectatorMode=true (manaCharge 非決定性回避) + beginner 以外 (BEGINNER_TADASUTE_ALLOW_RATE の Math.random 回避) で測定。逸脱は**記録に留める** (係数再校正は S3、ユーザー確認済)。drawProgress=4 近傍 fixture で auto-draw 境界差を可視化。ゲート: lint/typecheck/test:ci/build green。
+
+## 6. DP-1〜7 整合 (ON 経路)
+ON は `applyTurnAction` を通すため DP-1 (lazy drawProgress + auto-draw)・DP-2 (double_move 遅延消費 + flip 抑止)・DP-3 (trap は graveyard 不変/通常は hand→graveyard)・DP-5 (noPromoteMarks 集合)・DP-7 (check_break) が自動適用。OFF は旧近似のまま (DP-1 immediate+1、double_move graveyard なし等) で **S1d cutover まで production 既定**。
+
+## 7. リスクと対策
+- **R1 OFF 破壊**: 旧コード無改変 + フラグ既定 OFF + variant ガード + doubleMove optional 化で構造保証。double-move-search/action-generator/strategy-equivalence/card-digest test を不変ゲート。
+- **R2 ON 棋力変化** (DP-1 lazy / manaCharge / cost 正確消費 / 終局 mate score): bench で elapsedMs / カード使用率を測定・記録 (再校正は S3)。
+- **R3 double_move turnEnded + 終局整合 (OBS3-1)**: ON 経路で 2手目 true を assert。1手目/2手目が終局 (mate 等) の場合 kernel gameOver 分岐 (world-kernel.ts:258) で turnEnded=true・status セットになる (OFF の CurrentRules.applyAction は game-end 評価せず status=active 据置)。ON 専用に「1手目 turnEnded=true なら その局面を評価して 2手目 skip」分岐を実装。終局 score 差 (mate ±100000) は特性化 test で既知 divergence として分離。
+- **R4 性能 (F-4)**: ON の super-action は makeMoveWithEffects (重) を TOP_K×second 回呼ぶため OFF より遅い可能性。bench の **elapsedMs** で測定 (depthCompleted は findBestMove 非改変ゆえ不変=指標にならない)。逸脱は記録 (S1b は配線が目的)。
+- **R5 戻り値型差**: `applyTurnActionForLookahead` wrapper で `{gameState,cardState}` に正規化。events は AI 評価不要 (盤面結果のみ使用) のため捨象。
+- **R6 double_move cardInstanceId 異常系 (OBS3-2)**: ON で hand に double_move 不在なら consumeNormalCard が null 化し非対称。getCardActions で除外済だが防御的に early-return (NEG_INF)。`?? ""` 空文字 fallback は使わない。
+- **R7 currentPlayer tempo terminal 乖離 (OBS2-F1)**: draw/playCard を「相手が既に終局」局面で打つ稀少 sub-case で tempo ±30cp 乖離 (ON 是正)。特性化 test で currentPlayer を ON 是正として分離 assert (gameState 完全一致を期待しない)。
+
+## 8. 確定済の設計判断 (ユーザー確認 2026-06-07)
+- **検証**: property test + bench **両方** (厚い検証)。
+- **bench 逸脱時**: 測定・記録に留める (係数再校正は S3 へ)。
+- route.ts は S1b で無改変 (test/bench からのみ ON、production は S1d まで OFF 固定)。
+- スコープは root カード/ドロー評価 2 関数に限定 (深い探索の kernel 化・TT 拡張は S4)。
+
+## 9. S1b DoD
+- [x] `AiTurnState.doubleMove` に `cardInstance?`/`cardCost?` 追加 (optional 化、OFF 経路 = current-rules.ts 無改変、評価値不変)
+- [x] `useKernelSearch` フラグ配線 (FindBestMoveOptions → SearchContext、既定 OFF)
+- [x] `aiTurnStateToWorldState` (converter + fallback) + `applyTurnActionForLookahead` 追加、evaluateActionWithLookahead 二分岐
+- [x] searchDoubleMoveSuperAction 二分岐 (ON = `searchDoubleMoveSuperActionKernel` = applyTurnAction 連鎖、1手目 mate 分岐・cardInstanceId 防御)
+- [x] OFF vs ON 特性化 property test 新設・green (`kernel-search-equivalence.test.ts` 11 件: board 駒配置 must-match、currentPlayer/status/mana/drawProgress/graveyard/noPromoteMarks は既知 divergence 分離 assert、trap 発火 move/no_promote pawn_return/auto-draw境界/終局 move/double_move 1手目 mate fixture 含む)
+- [x] bench で OFF/ON の **elapsedMs** (主) ・カード使用率を測定・記録 (`perf-bench-kernel-search.test.ts`、spectatorMode + advanced/expert で公平化、depthCompleted は sanity)
+- [x] lint / typecheck / test:ci / build green、既存 double-move-search/action-generator/strategy-equivalence/card-digest/world-kernel-equivalence/reducer/undo/effects 全 green (OFF 不変ゲート)
+- [x] standard variant 非経由 (二重ガード = useKernelSearch && variant.id==="card-shogi" + applyTurnActionForLookahead 冒頭ガード)
+
+## 10. マイルストーン1レビュー反映 (実装着手前、2026-06-07、AGENTS.md ルール8)
+S1b 計画初版を 4観点 adversarial workflow (15 agents) でレビューし、**14 findings → high/medium 11 件全 confirmed (refuted/uncertain 0)** を反映:
+- **[high OFF-1/OFF-3/F-3] doubleMove 型統合を optional 化に訂正** (§4): 必須 cardInstance/cardCost は current-rules.ts:93 + 既存テスト + toEqual を破壊。optional + converter fallback で OFF 無改変・テスト無改変・OFF バイト等価を両立。
+- **[high OBS3-1] 終局 score 差を明記** (§3/§5 S1b-4/§7 R3): 着手後/2手目が終局なら ON は status セット → mate score (±100000)/draw(0)。特性化 test で既知 divergence 分離、zobrist 一致のみで合格としない。
+- **[high→med OBS2-F1/F-1] §3 脚注「evaluate は currentPlayer 非依存」を訂正**: tempo 項 ±15cp が currentPlayer 依存。terminal sub-case (draw/playCard) で ±30cp 乖離 (ON 是正)。currentPlayer は ON 是正として分離 assert。
+- **[med OFF-2] S1b-0 ゲートのテスト列挙を是正** (§5): 実破壊検出は double-move-search/action-generator test。strategy/card-digest は doubleMove 非依存。
+- **[med OBS3-2/R6] double_move cardInstanceId 防御** (§4 S1b-3): `?? ""` を廃し未発見なら early-return。
+- **[med F-2] caller 明記** (§4 S1b-3): evaluateAction(ply=0) は production 未到達で OFF 据置、関数本体二分岐で両 caller カバー。
+- **[med F-4] bench 主指標を elapsedMs に変更** (§5 S1b-5/§7 R4): depthCompleted は構造的不変。
+- **[med F-5] board 一致を条件分岐 + noPromoteMarks 差を §3 に追加** (§3/§5 S1b-2): trap 発火 move は board も ON 是正、modifyBoard 通常カードは removeNoPromoteMark で noPromoteMarks 差。fixture に trap 保持 move / no_promote pawn_return を必須化。
+- **[low] must-not-match に lastTurnStartedAt/moveCount/status 明記、bench 公平性 (spectator+非 beginner)** (§3/§5 S1b-5)。
+- 妥当と確認 (欠陥なし): 旧コード無改変の additive 戦略、フラグ ctx 相乗り配線、通常 action の board 一致 (simulateCardEffect == applyPawnReturn)、turnEnded 不変条件 assert、変換 wrapper の戻り値正規化。
+
+## 11. マイルストーン2レビュー反映 (実装完了時、2026-06-07、AGENTS.md ルール8)
+S1b 実装を 4観点 adversarial workflow (9 agents) でレビューし、**10 findings → high/medium 5 件全 confirmed (refuted/uncertain 0)** を反映。OFF は無改変で健全・ON は S1a 検証済で正しいことを確認した上で、**指摘は全て「特性化 test が計画 DoD 必須の fixture を欠き、誤コメントで『カバー済』と主張」というカバレッジ + 記述の問題に収束** (medium、OFF/ON 自体は健全)。下記を反映:
+- **[med S1b-M2-001/OBS3-T1/S1b-O4-1] trap 発火 move の divergence fixture を追加**: 相手 check_break 保持下で先手が王手する move を OFF/ON 比較し、ON は王手駒除去 + trap clear + 相手持ち駒化 (DP-7)・OFF は無視、を既知 divergence として pin。誤コメント (「targeted T1 でカバー」= 実際は T1 は非発火) を訂正。
+- **[med OBS3-T2] 終局手 fixture を追加**: ① 通常 move で詰む局面で ON=status checkmate + evaluate 100000・OFF=status active + material 評価を pin。② double_move 1手目で詰む局面 (捕獲 mate で TOP_K=10 上位保証) で ON super-action が turnEnded=true 分岐を行使し mate score を採用することを pin。
+- **[med OBS3-T3/S1b-O4-2] double_move test の役割を明示**: cardState 消費 (hand→graveyard/mana-5/lazy drawProgress) の正しさは S1a (applyTurnAction ≡ reducer DP-2) が担保済とコメント参照。S1b test は配線 smoke (turnEnded 不変条件で throw せず有限スコア) + 1手目 mate 分岐 pin に役割限定。
+- **[low] header コメントを実 assert と整合** (status mate score / trap 発火 move の board を divergence 次元として明記)、terminal tempo ±30cp (S1B-ON-2) は §3/R7 文書化済で稀少 sub-case のため test 化見送り。
+- 結果テスト: 特性化 11 件 (8 + trap発火 move/終局 move/double_move mate 3) green。test:ci green。

--- a/docs/plans/issue-235-s1b-ai-wiring.md
+++ b/docs/plans/issue-235-s1b-ai-wiring.md
@@ -5,7 +5,9 @@
 
 ## 0. ゴールと非ゴール
 **ゴール**: カード将棋 AI 探索の **root カード/ドロー評価経路**を `useKernelSearch` フラグ (既定 OFF) 裏で L0 カーネル `applyTurnAction` 経由に切替可能化する。OFF は既存挙動を**バイト等価で完全保持**、ON は単一権威カーネルを通すことで DP-1〜7 を自動適用する。`AiTurnState.doubleMove` を kernel の `KernelDoubleMove` 型へ統合し、double_move cardState 近似を解消する。
-**非ゴール (S1b では触らない)**: 深い negamax/quiescence の move-only ホットパス (cardState 非搬送のため kernel 化の意味なし)、TT の cardState ハッシュ拡張 (S4)、評価係数の再校正 (S3 ValueModel)、reducer 側 (S1c)、cutover で既定 ON 化 (S1d)、route.ts (S1d まで OFF 固定)。
+**非ゴール (S1b では触らない)**: 深い negamax/quiescence の move-only ホットパス (cardState 非搬送のため kernel 化の意味なし)、TT の cardState ハッシュ拡張 (S4)、評価係数の再校正 (S3 ValueModel)、reducer 側 (S1c 物理移設 / S1d 委譲)、cutover で既定 ON 化 (S1d)、route.ts (S1d まで OFF 固定)。
+
+> **S1d cutover の相互参照 (lean 改訂)**: 本 S1b の `useKernelSearch` 既定 ON 化は、reducer 側の kernel building-block 委譲 (薄ラッパ化、S1c の物理移設後に S1d で実施) と**同じ S1d 単一コミット**で同期 flip する。shadow-assert は不採用 (S1 計画 doc §9 / epic §8.5.1)。
 
 ## 1. スコープの精緻化 (recon 6観点 + 中核ファイル精読で確定)
 kernel 経由化が効くのは **root のカード/ドロー評価 2 関数のみ**:

--- a/docs/plans/issue-235-s1d-cutover.md
+++ b/docs/plans/issue-235-s1d-cutover.md
@@ -1,0 +1,199 @@
+# Issue #235 S1d: cutover (reducer 委譲化 + AI useKernelSearch 既定 ON) — 実装計画
+
+> 親 doc: `docs/plans/issue-235-card-shogi-ai-redesign.md` (§3 L0 / §8.5 rollback / §8.3 DP-1〜7)。
+> S1 計画: `docs/plans/issue-235-s1-kernel.md` (§6 S1d / §14 S1c DoD)。S1b: `issue-235-s1b-ai-wiring.md`。
+> ブランチ `refactor/#235-s1` (S1a/S1b/S1c 完了済、最新 commit `f5464c0`)。
+> 本 doc は AGENTS.md ルール8 マイルストーン1 (実装着手前レビュー) の対象。
+
+## 0. 位置づけ・ゴール / 非ゴール
+S1 (L0 カーネル統合) の最終段 = **cutover**。S1a で新設し S1c で逆依存解消した L0 カーネル building-block
+を、reducer (UI) と AI の **既定経路** に採用する。S1 の rollback 設計上、production 振る舞いを変える
+変更は本段の **単一コミット**に隔離する (`git revert` で旧経路復帰、epic §8.5.3 第2層)。
+
+**ゴール**:
+1. reducer の inline ロジック 3 箇所を S1a kernel building-block へ**委譲** (二重実装解消、P4):
+   - `applyTurnEndEffects` の cardState 変換部 → `advanceDrawProgress`
+   - `finalizeDoubleMoveCardConsumption` の consume+event 部 → `finalizeDoubleMoveLogic`
+   - `CONFIRM_PLAY_CARD` の効果適用 switch → `applyCardEffectLogic`
+2. UI flag (isDrawing/pendingDrawPlayer/pendingDrawSource/selection clear, isPlayingCard/pendingPlayCardOpponent)
+   は building-block の**返り値 events を読んで reducer が event-driven にセット** (kernel は cardState/events のみ返す)。
+3. AI: `useKernelSearch` を**既定 ON** 化 (DP-1〜7 を production 探索に適用)。
+
+**非ゴール (S1d では触らない)**:
+- L1 CardSpec registry (S2) / ValueModel 値付け (S3) / L2 TurnAction 単一探索・TT 拡張 (S4) / L3 相手モデル (S5)。
+- 評価係数の再校正 (S3)。S1d の AI 評価の微変 (DP-1 lazy drawProgress 等) は bench で監視のみ、再校正しない。
+- 新カード追加・カード仕様変更。
+
+## 1. 設計の核 = 二層構造 (building-block / atomic) の使い分け
+kernel は二層:
+- **building-block** (`advanceDrawProgress` / `finalizeDoubleMoveLogic` / `applyCardEffectLogic`): 効果適用のみ。
+  flip も turn-end も**しない**。reducer の各演出フェーズ (CONFIRM/COMMIT を分割保持) から呼ぶのに適合する。
+- **atomic** (`applyTurnAction`): 効果 + flip + turn-end を 1 遷移で合成。AI / headless から呼ぶ。
+
+reducer は演出フェーズ (CONFIRM_PLAY_CARD で効果適用 + isPlayingCard=true、COMMIT_PLAY_CARD で flip + turn-end)
+を**維持したまま**、各フェーズ内で building-block を呼ぶ。→ atomic ではなく building-block を採用するのが正しい。
+flip / turn-end タイミング (演出完了後) は reducer が引き続き制御する (UX 不変)。
+
+## 2. 等価性の根拠 (なぜ委譲で挙動が変わらないか)
+- **event shape**: `CardInstance = {instanceId, defId}` (owner なし) を確認済。reducer の cardPlayEvent
+  `instance: pending.instance` と kernel `{instanceId, defId}` は deep-equal。trapSetEvent も TrapInstance
+  `{instanceId, defId, owner}` で一致。target/returnedPiece/capturedPieces も両経路で構造一致。
+- **S1a property test が実証済**: `world-kernel-equivalence.test.ts` (180 seed×40 ply + targeted 15) が
+  reducer dispatch 経路 vs applyTurnAction の cardState/gameState/events (projectEvents=at 除外) 完全一致を
+  検証済。applyTurnAction は building-block を合成しているため、**building-block 単位の出力も reducer inline と等価**。
+  → 委譲は「実証済の等価ロジックへの置換」であり挙動不変 (UI)。
+- **drawProgress (DP-1)**: advanceDrawProgress は reducer applyTurnEndEffects と同一 semantics
+  (status≠active で no-op / +1 / 閾値到達∧deck非空で 0 reset + auto-draw 1回)。
+
+## 3. 詳細委譲マッピング (reducer 編集)
+### 3-1. applyTurnEndEffects (reducer.ts:246-293) → advanceDrawProgress 採用
+```
+const { cardState, events } = advanceDrawProgress(state.cardState, state.gameState, player);
+// status≠active なら events=[]・cardState 不変 → state そのまま (現 no-op と等価)
+const autoDraw = events.find(e => e.kind === "drawEvent" && e.source === "auto");
+// cardState 反映 + eventLog append
+// autoDraw あり → isDrawing=true / pendingDrawPlayer=player / pendingDrawSource="auto" + selection clear
+// autoDraw なし → cardState (drawProgress) 反映のみ (flag 不変)
+```
+- 注意: status≠active 時に reducer は現状 `return state` (eventLog も触らない)。advanceDrawProgress も events=[]
+  なので append なし・flag セットなし。完全一致を保つこと。
+- 注意: auto-draw 時の selection clear (selectedSquare/selectedHandPiece/legalMoves/forbiddenMateMoves=空) は
+  reducer 責務として維持 (現 274-278 と同一)。
+
+### 3-2. finalizeDoubleMoveCardConsumption (reducer.ts:465-493) → finalizeDoubleMoveLogic 採用
+```
+const kernelDm = { active: dm.active, movesLeft: dm.movesLeft, cardInstance: dm.cardInstance, cardCost: dm.cardCost };
+const { cardState, events } = finalizeDoubleMoveLogic(state.cardState, kernelDm);
+// events 空 (consume 失敗) → return state (現 475-479 防御と等価)
+// events あり → cardState 反映 + eventLog append + isPlayingCard=true + pendingPlayCardOpponent=null
+```
+- cardPlayEvent の instance は kernelDm.cardInstance = dm.cardInstance (同一) → 一致。
+
+### 3-3. CONFIRM_PLAY_CARD 効果適用 switch (reducer.ts:1033-1182) → applyCardEffectLogic 採用
+- `applyCardEffectLogic` は現状 **private** → **export 化**が必要 (world-kernel.ts)。
+- selectTarget 遷移 (1015-1023) と double_move 分岐 (1093-1130) は reducer に残す:
+  - double_move は building-block 対象外 (UI snapshot preFirstMoveState/preCardState/mateInOneAvailable を持つため)。
+    applyCardEffectLogic も double_move を扱わない (applyTurnAction 側で別扱い)。整合。
+- trap/mana_up/pawn_return/piece_return/double_pawn は applyCardEffectLogic に委譲:
+```
+const action = { kind: "playCard", defId: pending.instance.defId, cardInstanceId: pending.instance.instanceId, target: pending.target };
+const world = { gameState: state.gameState, cardState: state.cardState, doubleMove: null };
+const applied = applyCardEffectLogic(world, action, player);
+if (!applied) return state;  // 不正 (王手未解除等) = 現 return state と等価。check guard は kernel 内蔵
+// applied.gameState/cardState/event を採用、pendingCard=null、selection clear、isPlayingCard=true、pendingPlayCardOpponent=opponent
+```
+- 注意: applyCardEffectLogic は内部で `pendingCard` を持たない (world.cardState は state.cardState から)。
+  reducer は適用後 `nextCardState = { ...applied.cardState, pendingCard: null }` で pendingCard クリアを維持。
+  (kernel の cardState は pendingCard を変更しないので明示クリア要。現 1145-1148 と等価)
+- 注意: check guard (現 1137-1141) は applyCardEffectLogic 内 (world-kernel.ts:204-209) に内蔵済 → 二重不要、kernel に委譲。
+- event は applied.event を採用 (cardPlayEvent/trapSetEvent、returnedPiece 込み)。現 reducer 生成と deep-equal。
+
+## 4. AI: useKernelSearch 既定 ON 化
+### 4-1. 既定値の変更方法 = **案B 採用 (M1 決定)**
+- ~~案A (engine 既定 `?? true`)~~ は不採用。理由 (M1 A-3): `perf-bench.test.ts` / `perf-bench-spectator.test.ts` /
+  `perf-bench-card-usage.test.ts` は useKernelSearch 未指定で engine 既定に依存しており、`?? true` 化で
+  **暗黙 ON へ反転**し計測 baseline がサイレントドリフトする (テストは存在チェックのみで fail しない)。
+- **採用 = 案B**: `engine.ts:203` は `options.useKernelSearch ?? false` のまま維持。**production 入口
+  (`route.ts` ai-move) で `useKernelSearch: true` を明示渡し**。
+  - 利点: production のみ ON 化、default 依存の test/bench は OFF baseline 不変、rollback は route の 1 行削除。
+  - **要確認**: production の AI 入口が route.ts ai-move 以外にあれば (spectate 等) そこにも付与。grep で findBestMoveWithStats の全 production 呼出を確認すること。
+
+### 4-2. spectatorMode × useKernelSearch = **選択肢 (i) 採用 (M1 決定)**
+- **決定: AI 探索 kernel 経路は常に spectatorMode=true 相当で呼ぶ** (探索は仮想局面評価 = 決定論化が正しい)。
+- 根拠 (M1、4 観点収束 + コード照合):
+  - AI 探索は**仮想局面の評価**であり、wall-clock 早指しボーナス (時刻依存) は探索の意味論上無意味かつ非決定的。
+    spectatorMode=true はこの **早指しボーナス (MANA_FAST_BONUS) のみを無効化**する。
+  - ctx.spectatorMode (案ii) のままだと production (spectator=false) で探索ノード間の mana ボーナスが wall-clock
+    依存になり非対称・非決定。spectatorMode=true 固定でこれを構造的に解消する (game-level spectator から独立)。
+- **MANA_PER_TURN の OFF/ON 非対称 = 意図的既知差分 (棋力退化ではない、M2 A-2 で精査)**:
+  - OFF 近似 `applyActionForLookahead` は move に mana を一切付けない (drawProgress+1 のみ)。
+  - ON (`move-effects.ts` makeMoveWithEffects) は move に base `MANA_PER_TURN` を付与 (spectatorMode=true で
+    fast bonus は 0)。よって spectatorMode=true でも **ON は move に base mana を charge する点で OFF と異なる**。
+  - **棋力退化に当たらない理由**: root の同一プレイヤーの兄弟 move 同士は全て同じ +MANA_PER_TURN オフセットを
+    受けるため move 間の argmax 順位は不変。差が出るのは **move vs draw/playCard** の選好のみで、これは
+    DP-1 lazy drawProgress と同じ「ON が production 等価方向の既知差分」(kernel-search-equivalence.test.ts:130-132、
+    係数再校正は S3、ユーザー承認済 2026-06-07)。bench でも全シナリオで action 選択 OFF==ON 一致を実測。
+- **実装**: search.ts の ON 経路 (applyTurnActionForLookahead / searchDoubleMoveSuperActionKernel 内の
+  applyTurnAction 呼出、現 ctx.spectatorMode を渡す箇所 ≈ 972/985/1007/1029/1284) を **spectatorMode: true 固定**に変更。
+  ctx.spectatorMode はゲームレベルの観戦判定であり、探索 lookahead の決定論化とは別概念として分離する。
+  kernel-search-equivalence.test.ts は ON を spectator=true で回しているため本変更で破綻しない。
+
+## 5. UI flag event-driven 化の網羅 (M1 レビュー反映: 演出統合テスト)
+event-driven にセットする flag と発火 event の対応:
+| flag | 発火条件 (event/結果) | セット箇所 |
+|---|---|---|
+| isDrawing / pendingDrawPlayer / pendingDrawSource="auto" | advanceDrawProgress が auto drawEvent を返す | applyTurnEndEffects |
+| selection clear (auto-draw 時) | 同上 | applyTurnEndEffects |
+| isPlayingCard / pendingPlayCardOpponent | applyCardEffectLogic 成功 / finalizeDoubleMoveLogic 成功 | CONFIRM_PLAY_CARD / finalize |
+- selectedSquare clear 等は advanceDrawProgress の責務ではなく reducer 演出側の責務 (kernel は触らない)。
+
+## 6. 演出オーケストレーション統合テスト (S1d DoD、M1 反映)
+ゲーム状態スナップショット比較 (property test) では捕捉できない**演出 flag の順序・タイミング**を直接突く:
+1. **drawProgress→isDrawing 変換**: 閾値到達 move で applyTurnEndEffects 後に isDrawing=true/pendingDrawSource="auto"、
+   閾値未到達で flag 不変、を reducer dispatch で pin。
+2. **check_break defer 順序**: double_move 中の check_break が 1手目 defer / 2手目発火し、isCheckBreakAnimating が
+   正しいタイミングで立つ (委譲後も順序不変)。
+3. **double_move finalize flag 遷移**: 2手目完了で finalize→isPlayingCard=true→COMMIT_PLAY_CARD で flip しない
+   (pendingPlayCardOpponent=null 経路)、drawProgress+1。
+4. **CONFIRM_PLAY_CARD→COMMIT_PLAY_CARD**: 通常カードで isPlayingCard=true/pendingPlayCardOpponent=opponent →
+   COMMIT で flip + drawProgress+1。
+- 既存 reducer.test に該当ケースがあれば再利用、不足分を追加。
+
+## 7. 検証ゲート
+1. lint 0err / typecheck / test:ci 全 green (reducer.test/undo/effects/world-kernel-equivalence/kernel-search-equivalence)。
+2. **bench** (`perf-bench-kernel-search.test.ts`、RUN_PERF_BENCH=true): cutover 前後で depthCompleted /
+   カード使用率 / アクション選択を比較。棋力退化 (depthCompleted -10% 超 or カード使用率の有意低下) がないこと。
+   - bench は **spectator=true 固定**で OFF vs ON を測定。**decision (i) により production の ON 探索は内部
+     spectatorMode=true 固定**のため、spectator=true 測定が production-equivalent (game-level spectator から独立)。
+     M1 A-4 の「production (spectator=false) で wall-clock variance」懸念は decision (i) が**構造的に解消**済
+     (探索 lookahead が game-level spectatorMode を参照しない) なので、spectator=false の別 run は不要。
+   - **実測結果 (2026-06-07)**: advanced/expert ともに cardRate OFF=4/4→ON=4/4、全 8 シナリオで action 選択
+     OFF==ON 一致、depthCompleted d4==d4 (move-only 探索は本変更非影響)。ON は modest overhead (時間制限内)。
+     → 棋力退化なし。
+   - 既存 `perf-bench.test.ts` は engine 既定 OFF (案B) のため無改変で OFF baseline を維持 (サイレントドリフトなし)。
+3. build green。
+4. **rollback 確認**: 本コミットを `git revert` すれば旧経路に戻ることを diff で確認 (単一コミット隔離)。
+
+## 8. リスク
+- **R-1 演出 flag の順序差**: 委譲で flip/turn-end タイミングがズレると UI 演出 (ドロー/カード/王手崩し) が暴れる。
+  → §6 統合テスト + reducer.test で担保。building-block は flip/turn-end しないため演出制御は reducer 維持。
+- **R-2 AI 評価の暴れ (spectatorMode)**: §4-2。production で ON にした際の wall-clock 依存。→ M1 で決定 + bench 監視。
+- **R-3 applyCardEffectLogic export の波及**: private→export で他からの誤用リスクは低 (純粋関数)。world-kernel の
+  既存 import 経路に影響なし。
+- **R-4 eventLog の DB 永続化差**: event shape が deep-equal なので DB save 内容不変 (CardInstance 確認済)。
+- **R-5 stale コメント**: 委譲で不要化する reducer コメント (旧 inline 説明) を残骸として残さない。
+
+## 9. rollback (epic §8.5.3)
+- 第1層: AI は `useKernelSearch` を OFF に戻す (engine 既定 `?? false`)。
+- 第2層: S1d コミットを `git revert` (単一コミット隔離、reducer 委譲も AI 既定も一括復帰)。
+- 第3層: reducer.test/undo/effects/property/演出統合テスト を blocking gate。
+
+## 10. S1d DoD
+- [ ] applyCardEffectLogic を export 化 (world-kernel.ts:146) — **実装初手の blocking 前提** (M1 A-1)。
+- [ ] applyTurnEndEffects は reducer wrapper のまま内部を advanceDrawProgress 委譲 (全 call site 不変)。finalizeDoubleMoveCardConsumption → finalizeDoubleMoveLogic、CONFIRM_PLAY_CARD 効果 switch → applyCardEffectLogic 委譲、inline 重複除去。
+- [ ] UI flag を返り値 events から event-driven にセット (§5)。auto-draw 時の selection clear は reducer 責務として維持 (コメントで §3-1 参照、M1 B-5)。
+- [ ] AI: route.ts で useKernelSearch: true 明示 (案B、M1 A-3)。production 入口が他にあれば全付与。
+- [ ] AI: search.ts ON 経路を spectatorMode=true 固定 (選択肢 i、M1 A-2)。
+- [ ] 演出オーケストレーション統合テスト追加 (§6、M1) + auto-draw selection-clear assertion (M1 B-5)。
+- [ ] finalizeDoubleMoveCardConsumption に currentPlayer flip 済前提の assert/コメント (M1 B-4)。
+- [ ] lint/typecheck/test:ci/build green + bench で棋力退化なし。bench は spectator=true/false 両方で ON/OFF 比較 (§7、M1 A-4)。
+- [ ] 単一 git-revert 可コミットに隔離。
+- [ ] stale コメント除去 (除去対象: applyTurnEndEffects/finalizeDoubleMoveCardConsumption/CONFIRM_PLAY_CARD の旧 inline 説明、M1 A-5)。
+- [ ] (別軽微コミット) UNDO_DOUBLE_MOVE_FIRST / CANCEL_DOUBLE_MOVE の演出 flag を UNDO と対称化 (M1 B-1、live bug ではないが防御強化)。
+
+## 11. M1 マイルストーン1レビュー反映 (計画直後、2026-06-07、AGENTS.md ルール8)
+5観点 adversarial workflow (delegation-fidelity/animation-orchestration/ai-cutover/test-bench-adequacy/scope-rollback-doc、48 agents、28 confirmed) でレビュー。**総合判定: 着手可 (計画を覆す欠陥なし、決定保留 2 点を確定)**。反映:
+- **[決定] spectatorMode = 選択肢 (i)** (§4-2): 探索 kernel 経路は常に spectatorMode=true。OFF 近似が mana ボーナス無のため (i) が整合 (4 観点収束 + コード照合確認)。
+- **[決定] 既定 ON = 案B** (§4-1): 案A は default 依存 bench の baseline サイレントドリフトを招くため不採用。route.ts 明示渡しに変更。
+- **[反映] export applyCardEffectLogic** を実装初手の blocking 前提として DoD 先頭に。
+- **[反映] bench spectator=false 追加** (§7): (i) 採用で wall-clock variance が消えることを確認。
+- **[反映] 演出統合テスト具体化** (§6) + selection-clear assertion + finalize 前提 assert (B-4/B-5)。
+- **[派生] UNDO_DOUBLE_MOVE_FIRST/CANCEL の flag 対称化** (B-1): live bug ではない (該当窓で isDrawing/isPlayingCard は構造上 false) が、cutover で flag を event-driven 化する機に UNDO と対称化。別軽微コミットで対応。
+- 妥当と確認: 二層構造の building-block 採用 (atomic 誤用回避)・event shape deep-equal・委譲マッピング・単一 revert コミット隔離・rollback 3層。
+
+## 12. M2 マイルストーン2レビュー反映 (実装後、2026-06-07、AGENTS.md ルール8)
+5観点 adversarial workflow (delegation-correctness/ai-cutover-correctness/animation-ui/deadcode-imports/scope-rollback-doc、71 agents、32 confirmed) でレビュー。**総合判定: 安全に commit 可 (コード欠陥ゼロ)**。委譲3点・event-driven flag・import 削除9件 (デッドコードなし)・B-1 対称リセットすべて正しいと確認。反映:
+- **[記録訂正 = commit 前必須] MANA_PER_TURN 非対称の正確化** (A-1/A-2): §4-2/§7 を訂正。spectatorMode=true は早指しボーナスのみ無効化。ON は move に base MANA_PER_TURN を charge し OFF 近似は付けない = 意図的既知差分だが move 間順位は不変 (move vs card/draw 選好のみ作用、S3 再校正前提・承認済)。bench は spectator=true 固定 (decision i で production-equivalent)、spectator=false 別 run は decision i が variance を構造解消するため不要。
+- **[反映] S1 complete 宣言 + S2 引き継ぎ** を s1-kernel.md §16 に追記 (S1d push 後)。memory / epic SSOT にも S1d 完了記録。
+- **[後追い可] 任意改善**: COMMIT_PLAY_CARD eventLog 逆走査の不変条件コメント (既存 #82/#130 ロジック)、CONFIRM_PLAY_CARD invalid-target 失敗テスト、bench spectator=false の回帰 pin。いずれも commit を阻害せず後追い。
+- 妥当と確認: 単一 revert 可能 (5ファイル、route.ts:1行 + reducer 委譲)、case B で baseline 不変、棋力退化なし実測。

--- a/scripts/measure-baseline-235.ts
+++ b/scripts/measure-baseline-235.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+// Issue #235 S0: before-baseline 計測ハーネス (standalone tsx 版)。
+//
+// canonical main (PR3-3 マージ済) の depthCompleted / nodes / カード使用率を
+// 全4難易度 (beginner / intermediate / advanced / expert) で RUNS 回計測し、
+// 中央値を docs/bench-results/issue-235-before-baseline.json に保存する。
+// 設計 doc docs/plans/issue-235-card-shogi-ai-redesign.md §8.2 準拠。
+//
+// なぜ standalone tsx か (前セッションの教訓):
+//   旧 .mjs 案 (= bench テストの console.log テレメトリを parse) は不可だった:
+//     ① perf-bench.test.ts は test() に timeout 未指定 (vitest 既定 5000ms) のため、
+//        intermediate(~13s)/advanced(~18s)/expert(~25s) が timeout 失敗し計測値が欠落する。
+//     ② vitest は「合格した」テストの console.log を既定で非表示にするため、beginner の
+//        perf 値や card-usage 値 (assert を通過する) が回収できない。
+//   本ハーネスは findBestMoveWithStats を直接呼び、bench fixture (makeBenchPositions /
+//   makeScenarios) のロジックを再現する。vitest 非依存なので全4難易度を確実に計測できる。
+//
+// fixture の正本 (sync 注意):
+//   - perf 局面: src/lib/shogi/ai/__tests__/perf-bench.test.ts makeBenchPositions()
+//   - card シナリオ: src/lib/shogi/ai/__tests__/perf-bench-card-usage.test.ts makeScenarios()
+//   これらを変更したら本ハーネスの fixture も追従させること。
+//   本ハーネスは scripts 配下の S0 計測専用ツールで production コードは一切変更しない。
+//
+// 計測条件の留意 (設計 doc §8.2):
+//   - depthCompleted は time-budget 探索のため計測機の CPU 性能に依存する。
+//     各段/PoC の ±10% 比較は同一機・同一条件で取得すること (本ファイルの commitSHA・
+//     conditions に固定保存する)。
+//   - beginner/intermediate は addNoise / 初級タダ捨て確率許容により非決定性がある
+//     (特に card-usage の breakdown)。よって RUNS 回計測し中央値で集約する。
+//
+// 使い方 (design worktree の repo ルートで):
+//   npx tsx scripts/measure-baseline-235.ts [runs]      (既定 runs=3、全4難易度)
+//   BASELINE_ONLY=beginner BASELINE_OUT=/tmp/smoke.json npx tsx scripts/measure-baseline-235.ts 1
+//     → smoke 用: 難易度・出力先を絞って高速にハーネスの健全性を検証する。
+
+import { execSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  findBestMoveWithStats,
+  DIFFICULTY_PARAMS,
+} from "@/lib/shogi/ai/engine";
+import {
+  createInitialGameState,
+  applyMoveForSearch,
+} from "@/lib/shogi/board";
+import { createInitialCardState } from "@/lib/shogi/cards/state";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { getFullLegalMoves } from "@/lib/shogi/moves";
+import type { Difficulty, GameState, Player } from "@/lib/shogi/types";
+import type {
+  CardGameState,
+  CardInstance,
+  CardId,
+} from "@/lib/shogi/cards/types";
+import type { TurnAction } from "@/lib/shogi/ai/turn/types";
+
+const RUNS = Math.max(1, Number(process.argv[2] ?? "3") || 3);
+const OUT = process.env.BASELINE_OUT ?? "docs/bench-results/issue-235-before-baseline.json";
+const ALL_DIFFICULTIES: Difficulty[] = [
+  "beginner",
+  "intermediate",
+  "advanced",
+  "expert",
+];
+// smoke 用に難易度を絞れる (BASELINE_ONLY=beginner,intermediate)。
+const DIFFICULTIES: Difficulty[] = process.env.BASELINE_ONLY
+  ? (process.env.BASELINE_ONLY.split(",").map((s) => s.trim()) as Difficulty[])
+  : ALL_DIFFICULTIES;
+
+// ===== perf-bench fixture 再現 (perf-bench.test.ts makeBenchPositions) =====
+
+const PERF_DECK = [
+  { defId: "pawn_return" as const, count: 4 },
+  { defId: "double_move" as const, count: 4 },
+  { defId: "no_promote" as const, count: 4 },
+];
+
+function makeBenchPositions(): {
+  label: string;
+  state: GameState;
+  player: Player;
+}[] {
+  const positions: { label: string; state: GameState; player: Player }[] = [];
+  let gs = createInitialGameState(CARD_SHOGI_VARIANT);
+  positions.push({ label: "initial", state: gs, player: "sente" });
+  for (let i = 0; i < 8; i++) {
+    const mover: Player = i % 2 === 0 ? "sente" : "gote";
+    const moves = getFullLegalMoves(gs, mover, CARD_SHOGI_VARIANT);
+    if (moves.length === 0) break;
+    gs = applyMoveForSearch(gs, moves[0]);
+    const next: Player = mover === "sente" ? "gote" : "sente";
+    positions.push({ label: `ply-${i + 1}`, state: gs, player: next });
+  }
+  return positions;
+}
+
+// ===== card-usage fixture 再現 (perf-bench-card-usage.test.ts makeScenarios) =====
+
+const CARD_DECK = [
+  { defId: "pawn_return" as const, count: 4 },
+  { defId: "double_pawn" as const, count: 4 },
+  { defId: "no_promote" as const, count: 4 },
+];
+
+type ActionKind =
+  | "move"
+  | "draw"
+  | "playCard:trap"
+  | "playCard:board"
+  | "playCard:double_move";
+
+// perf-bench-card-usage.test.ts classifyAction と同一ロジック。
+function classifyAction(action: TurnAction | null): ActionKind | "none" {
+  if (action === null) return "none";
+  if (action.kind === "move") return "move";
+  if (action.kind === "draw") return "draw";
+  if (action.defId === "double_move") return "playCard:double_move";
+  if (action.defId === "no_promote" || action.defId === "check_break") {
+    return "playCard:trap";
+  }
+  return "playCard:board";
+}
+
+function mkHand(n: number, defId: CardId): CardInstance[] {
+  return Array.from({ length: n }, (_, i) => ({
+    instanceId: `bench-${defId}-${i}`,
+    defId,
+  }));
+}
+
+interface BenchScenario {
+  label: string;
+  state: GameState;
+  player: Player;
+  cardState: CardGameState;
+}
+
+function makeScenarios(): BenchScenario[] {
+  const initial = createInitialGameState(CARD_SHOGI_VARIANT);
+  const midState: GameState = { ...initial, moveCount: 50 }; // phase=1
+  const endState: GameState = { ...initial, moveCount: 120 }; // phase=2
+
+  const buildPawnReturnHand = (
+    handSize: number,
+    manaSente: number,
+    manaGote: number,
+  ): CardGameState => {
+    const cs = createInitialCardState(CARD_DECK);
+    cs.hand.sente = mkHand(handSize, "pawn_return");
+    cs.mana.sente = manaSente;
+    cs.mana.gote = manaGote;
+    return cs;
+  };
+
+  const buildLimitedHand = (
+    handCards: CardInstance[],
+    manaSente: number,
+    manaGote: number,
+    emptyDeck = false,
+  ): CardGameState => {
+    const cs = createInitialCardState(CARD_DECK);
+    cs.hand.sente = handCards;
+    if (emptyDeck) cs.deck.sente = [];
+    cs.mana.sente = manaSente;
+    cs.mana.gote = manaGote;
+    return cs;
+  };
+
+  return [
+    {
+      label: "midgame-mana-surplus",
+      state: midState,
+      player: "sente",
+      cardState: buildPawnReturnHand(3, 15, 13),
+    },
+    {
+      label: "midgame-mana-cap",
+      state: midState,
+      player: "sente",
+      cardState: buildPawnReturnHand(3, 19, 16),
+    },
+    {
+      label: "endgame-hand-surplus",
+      state: endState,
+      player: "sente",
+      cardState: buildPawnReturnHand(5, 12, 10),
+    },
+    {
+      label: "midgame-hand-pressure",
+      state: midState,
+      player: "sente",
+      cardState: buildPawnReturnHand(4, 10, 8),
+    },
+    {
+      label: "calib-empty-hand-mana-surplus",
+      state: midState,
+      player: "sente",
+      cardState: buildLimitedHand([], 15, 8),
+    },
+    {
+      label: "calib-trap-only-no-draw",
+      state: midState,
+      player: "sente",
+      cardState: buildLimitedHand(mkHand(2, "no_promote"), 19, 12, true),
+    },
+    {
+      label: "calib-endgame-empty-hand-mana-mid",
+      state: endState,
+      player: "sente",
+      cardState: buildLimitedHand([], 14, 10),
+    },
+  ];
+}
+
+// ===== 計測 =====
+
+interface PerfMetric {
+  avgDepth: number;
+  avgNodes: number;
+  avgMs: number;
+  positions: number;
+  perPositionDepth: number[];
+}
+
+interface CardMetric {
+  cardCount: number;
+  totalScenarios: number;
+  ratePct: number;
+  breakdown: string;
+}
+
+interface RunResult {
+  perf: Partial<Record<Difficulty, PerfMetric>>;
+  card: Partial<Record<Difficulty, CardMetric>>;
+}
+
+function measurePerf(difficulty: Difficulty): PerfMetric {
+  // bench と同様 cardState は 1 回生成して全局面で共有する。
+  const cardState = createInitialCardState(PERF_DECK);
+  const positions = makeBenchPositions();
+  let sumDepth = 0;
+  let sumNodes = 0;
+  let sumMs = 0;
+  const perPositionDepth: number[] = [];
+  for (const pos of positions) {
+    const r = findBestMoveWithStats(
+      pos.state,
+      pos.player,
+      difficulty,
+      CARD_SHOGI_VARIANT,
+      { cardState },
+    );
+    sumDepth += r.stats.depthCompleted;
+    sumNodes += r.stats.nodes;
+    sumMs += r.stats.elapsedMs;
+    perPositionDepth.push(r.stats.depthCompleted);
+  }
+  const n = positions.length;
+  return {
+    avgDepth: round2(sumDepth / n),
+    avgNodes: Math.round(sumNodes / n),
+    avgMs: Math.round(sumMs / n),
+    positions: n,
+    perPositionDepth,
+  };
+}
+
+function measureCard(difficulty: Difficulty): CardMetric {
+  const scenarios = makeScenarios();
+  let cardCount = 0;
+  const breakdown: string[] = [];
+  for (const sc of scenarios) {
+    const r = findBestMoveWithStats(
+      sc.state,
+      sc.player,
+      difficulty,
+      CARD_SHOGI_VARIANT,
+      { cardState: sc.cardState },
+    );
+    const kind = classifyAction(r.action);
+    const summary =
+      kind === "none"
+        ? "none"
+        : kind === "move"
+          ? "move"
+          : kind === "draw"
+            ? "draw"
+            : `${kind}(${
+                r.action?.kind === "playCard" ? r.action.defId : "?"
+              })`;
+    breakdown.push(`${sc.label}=${summary}`);
+    if (kind !== "move" && kind !== "none") cardCount++;
+  }
+  return {
+    cardCount,
+    totalScenarios: scenarios.length,
+    ratePct: Math.round((cardCount / scenarios.length) * 100),
+    breakdown: breakdown.join(", "),
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function median(nums: number[]): number {
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  const m = s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  return round2(m);
+}
+
+// ===== main =====
+
+const runs: RunResult[] = [];
+for (let i = 0; i < RUNS; i++) {
+  process.stderr.write(`\n[measure] run ${i + 1}/${RUNS} ...\n`);
+  const run: RunResult = { perf: {}, card: {} };
+  for (const d of DIFFICULTIES) {
+    const t0 = performance.now();
+    run.perf[d] = measurePerf(d);
+    run.card[d] = measureCard(d);
+    const dt = ((performance.now() - t0) / 1000).toFixed(1);
+    const p = run.perf[d]!;
+    const c = run.card[d]!;
+    process.stderr.write(
+      `[measure]   ${d}: perf avgDepth=${p.avgDepth} avgNodes=${p.avgNodes} ` +
+        `avgMs=${p.avgMs} | card rate=${c.ratePct}% (${c.cardCount}/${c.totalScenarios}) ` +
+        `[${dt}s]\n`,
+    );
+  }
+  runs.push(run);
+}
+
+// 中央値集約 (RUNS 回の avgDepth / avgNodes / avgMs / cardCount / ratePct を median)。
+const perfMedian: Partial<
+  Record<Difficulty, { avgDepth: number; avgNodes: number; avgMs: number; positions: number }>
+> = {};
+const cardMedian: Partial<
+  Record<
+    Difficulty,
+    { cardCount: number; ratePct: number; totalScenarios: number; breakdownPerRun: string[] }
+  >
+> = {};
+
+for (const d of DIFFICULTIES) {
+  const perfs = runs.map((r) => r.perf[d]).filter(Boolean) as PerfMetric[];
+  const cards = runs.map((r) => r.card[d]).filter(Boolean) as CardMetric[];
+  if (perfs.length > 0) {
+    perfMedian[d] = {
+      avgDepth: median(perfs.map((p) => p.avgDepth)),
+      avgNodes: median(perfs.map((p) => p.avgNodes)),
+      avgMs: median(perfs.map((p) => p.avgMs)),
+      positions: perfs[0].positions,
+    };
+  }
+  if (cards.length > 0) {
+    cardMedian[d] = {
+      cardCount: median(cards.map((c) => c.cardCount)),
+      ratePct: median(cards.map((c) => c.ratePct)),
+      totalScenarios: cards[0].totalScenarios,
+      breakdownPerRun: cards.map((c) => c.breakdown),
+    };
+  }
+}
+
+const commitSHA = execSync("git rev-parse HEAD").toString().trim();
+const difficultyParams = Object.fromEntries(
+  ALL_DIFFICULTIES.map((d) => [
+    d,
+    { maxDepth: DIFFICULTY_PARAMS[d].maxDepth, timeLimitMs: DIFFICULTY_PARAMS[d].timeLimitMs },
+  ]),
+);
+
+const result = {
+  schema: "issue-235-before-baseline/v1",
+  description:
+    "Issue #235 S0 before-baseline: canonical main (PR3-3 マージ済) の探索性能・カード使用率。" +
+    "以降の全段 DoD はこの中央値を基準に判定する。",
+  measuredAt: new Date().toISOString(),
+  commitSHA,
+  runs: RUNS,
+  difficulties: DIFFICULTIES,
+  aggregation: "median",
+  conditions: {
+    harness: "scripts/measure-baseline-235.ts (standalone tsx、vitest 非依存)",
+    command: `npx tsx scripts/measure-baseline-235.ts ${RUNS}`,
+    difficultyParams,
+    note:
+      "findBestMoveWithStats を直接呼び bench fixture を再現。depthCompleted は time-budget " +
+      "探索のため計測機 CPU 性能依存 → 各段/PoC の ±10% 比較は同一機・同一条件で取得すること。",
+    metrics: {
+      perfBench:
+        "makeBenchPositions() の 9 局面 (initial + 8 ply) を全難易度で探索し、" +
+        "stats.depthCompleted / nodes / elapsedMs の局面平均。",
+      cardUsage:
+        "makeScenarios() の isolation 局面 7 シナリオで action 種別を集計。" +
+        "cardCount = move/none 以外 (draw / playCard) の件数、ratePct = cardCount/7。",
+      scope:
+        "S0 before-baseline は depthCompleted / nodes / card-usage の三軸。rootMoveScore 等の " +
+        "棋力スコア指標は本段では scope 外 (PoC-1 以降で必要に応じ engine 拡張)。",
+    },
+  },
+  perfBench: perfMedian,
+  cardUsage: cardMedian,
+  rawRuns: runs,
+};
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, JSON.stringify(result, null, 2) + "\n");
+process.stderr.write(`\n[measure] wrote ${OUT}\n`);
+console.log(JSON.stringify({ perfBench: perfMedian, cardUsage: cardMedian }, null, 2));

--- a/src/app/api/ai-move/route.ts
+++ b/src/app/api/ai-move/route.ts
@@ -211,6 +211,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         // 深い zod-like 検証 (型不一致時 400 返却) は PR1d-2/3/4 のいずれかで
         // `src/lib/shogi/cards/validate.ts` 新規追加時に格上げ予定。
         cardState: body.cardState,
+        // Issue #235 S1d (cutover): production AI 探索を L0 カーネル applyTurnAction 経由に切替
+        // (root カード/ドロー評価を単一権威カーネルへ統一、DP-1〜7 適用)。engine 既定は OFF のままで
+        // production 入口の本 route のみ明示 ON にする (案B = default 依存 test/bench の baseline を不変に保つ)。
+        // rollback は本行削除のみ。探索は仮想局面評価のため kernel 内で spectatorMode=true 固定 (search.ts、決定論化)。
+        useKernelSearch: true,
       },
     );
     // client abort の場合は 499 相当だが、Next.js では client がもう listen して

--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -4,7 +4,7 @@ import { createInitialGameState } from "@/lib/shogi/board";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import type { GameState } from "@/lib/shogi/types";
 import type { CardGameState, CardInstance, GameEvent } from "@/lib/shogi/cards/types";
-import { MANA_CAP, DRAW_COST, AUTO_DRAW_INTERVAL } from "@/lib/shogi/cards/definitions";
+import { MANA_CAP, DRAW_COST, AUTO_DRAW_INTERVAL, CARD_DEFS } from "@/lib/shogi/cards/definitions";
 
 import { reducer, type CardShogiGameStateInternal } from "../reducer";
 
@@ -2162,5 +2162,97 @@ describe("CARD_DEFS / checkUsage 必須化 (Issue #82)", () => {
         expect(def.checkUsage).toBe("forbidden");
       }
     }
+  });
+});
+
+// Issue #235 S1d (cutover): reducer の cardState 遷移を kernel building-block へ委譲した後も、
+// 演出オーケストレーション (閾値到達→自動ドロー発火→駒選択クリア、CONFIRM カード効果→演出 flag)
+// が不変であることを直接 pin する。これらの UI 演出 flag (isDrawing/pendingDrawSource/selectedSquare)
+// は world-kernel-equivalence の射影 (cardState/events のみ比較) では捕捉されない reducer 固有挙動。
+describe("reducer / 演出オーケストレーション統合 (S1d cutover)", () => {
+  it("applyTurnEndEffects 委譲: drawProgress 閾値到達で auto-draw 発火 + isDrawing/source=auto + 駒選択クリア", () => {
+    const manualCard = card("draw-manual", "mana_up");
+    const autoCard = card("draw-auto", "mana_up");
+    // 手動ドロー演出完了直前の state (DRAW_CARD 適用後相当)。drawProgress[sente]=閾値-1。
+    // COMMIT_DRAW → flip + applyTurnEndEffects で +1 = 閾値到達 → advanceDrawProgress が auto drawEvent を返す。
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState(
+        createInitialGameState(CARD_SHOGI_VARIANT),
+        makeInitialCardState({
+          drawProgress: { sente: AUTO_DRAW_INTERVAL - 1, gote: 0 },
+          deck: { sente: [autoCard], gote: [] },
+          hand: { sente: [manualCard], gote: [] },
+        }),
+      ),
+      isDrawing: true,
+      pendingDrawPlayer: "sente",
+      pendingDrawSource: "manual",
+      selectedSquare: { row: 6, col: 0 },
+    };
+    const next = reducer(state, { type: "COMMIT_DRAW" });
+    // event-driven に auto-draw 演出 flag がセットされる
+    expect(next.isDrawing).toBe(true);
+    expect(next.pendingDrawSource).toBe("auto");
+    expect(next.pendingDrawPlayer).toBe("sente");
+    // drawProgress リセット + deck top が hand へ
+    expect(next.cardState.drawProgress.sente).toBe(0);
+    expect(next.cardState.hand.sente).toContainEqual(autoCard);
+    expect(next.cardState.deck.sente).toHaveLength(0);
+    // 駒選択クリア (auto-draw 時の selection clear は reducer 責務、M1 B-5)
+    expect(next.selectedSquare).toBeNull();
+    expect(next.legalMoves).toEqual([]);
+    // auto drawEvent が eventLog 末尾に積まれる
+    const last = next.eventLog[next.eventLog.length - 1];
+    expect(last.kind).toBe("drawEvent");
+    expect((last as Extract<GameEvent, { kind: "drawEvent" }>).source).toBe("auto");
+  });
+
+  it("applyTurnEndEffects 委譲: drawProgress 閾値未到達なら auto-draw 非発火 + 進捗のみ加算 + 駒選択保持", () => {
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState(
+        createInitialGameState(CARD_SHOGI_VARIANT),
+        makeInitialCardState({
+          drawProgress: { sente: 0, gote: 0 },
+          deck: { sente: [card("x", "mana_up")], gote: [] },
+        }),
+      ),
+      isDrawing: true,
+      pendingDrawPlayer: "sente",
+      pendingDrawSource: "manual",
+      selectedSquare: { row: 6, col: 0 },
+    };
+    const next = reducer(state, { type: "COMMIT_DRAW" });
+    // auto-draw 非発火: isDrawing は COMMIT_DRAW でクリアされたまま
+    expect(next.isDrawing).toBe(false);
+    expect(next.pendingDrawSource).toBeNull();
+    // drawProgress のみ +1、deck 不変
+    expect(next.cardState.drawProgress.sente).toBe(1);
+    expect(next.cardState.deck.sente).toHaveLength(1);
+    // 駒選択は保持 (auto-draw 非発火時はクリアしない)
+    expect(next.selectedSquare).toEqual({ row: 6, col: 0 });
+  });
+
+  it("CONFIRM_PLAY_CARD (trap) 委譲: applyCardEffectLogic で trapSetEvent + trap セット + mana 消費 + isPlayingCard", () => {
+    const trapCard = card("trap-1", "no_promote");
+    const def = CARD_DEFS["no_promote"];
+    const state = makeInitialState(
+      undefined,
+      makeInitialCardState({
+        mana: { sente: 5, gote: 0 },
+        hand: { sente: [trapCard], gote: [] },
+        pendingCard: { instance: trapCard, player: "sente", phase: "confirm" },
+      }),
+    );
+    const next = reducer(state, { type: "CONFIRM_PLAY_CARD" });
+    // trap セット (hand→trap、graveyard 不変 DP-3) + mana 消費
+    expect(next.cardState.trap.sente?.defId).toBe("no_promote");
+    expect(next.cardState.mana.sente).toBe(5 - def.cost);
+    expect(next.cardState.graveyard.sente).toEqual([]);
+    expect(next.cardState.pendingCard).toBeNull();
+    // 演出 flag (event-driven)
+    expect(next.isPlayingCard).toBe(true);
+    expect(next.pendingPlayCardOpponent).toBe("gote");
+    const last = next.eventLog[next.eventLog.length - 1];
+    expect(last.kind).toBe("trapSetEvent");
   });
 });

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -236,7 +236,9 @@ function pushUndoSnapshot(state: CardShogiGameStateInternal): UndoSnapshot[] {
 
 // 移動 + マナチャージ + トラップフィルタ を一括適用。
 // CONFIRM_PROMOTION と MAKE_MOVE の両方から呼ばれる。
-function makeMoveWithEffects(
+// Issue #235 S1a: world-kernel.ts が move ロジックを reuse するため export。
+// 振る舞い不変 (関数本体・呼出経路は一切変更なし)。物理移設と reducer 薄ラッパ化は S1c。
+export function makeMoveWithEffects(
   gameState: GameState,
   cardState: CardGameState,
   move: Move,

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -5,10 +5,13 @@
 // このファイルが持つ責務:
 // - Action 型 (ShogiAction / Action)
 // - CardShogiGameStateInternal 型 (useReducer 内部 state)
-// - makeMoveWithEffects / isKingInCheckAfterMove (reducer 内部 helper)
+// - isKingInCheckAfterMove (reducer 内部 helper)
 // - reducer 関数本体
 //
 // 移管時にロジックは 1 行も変えず、ファイル境界のみ引いた (move-only)。
+// Issue #235 S1c: move 効果適用 (makeMoveWithEffects / MakeMoveMode) は
+// src/lib/shogi/kernel/move-effects.ts へ物理移設済。reducer は import して呼ぶ
+// (下部 import 参照、振る舞い不変)。
 
 import type { GameState, Move, Player, Position } from "@/lib/shogi/types";
 import { applyMove, cloneGameState } from "@/lib/shogi/board";
@@ -21,7 +24,6 @@ import {
   isCheckmate,
   isInCheck,
 } from "@/lib/shogi/moves";
-import { evaluateGameEnd } from "@/lib/shogi/rules";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import { unpromotePieceType } from "@/lib/shogi/variants/standard";
 
@@ -30,9 +32,6 @@ import {
   CARD_DEFS,
   CARD_USE_CONDITIONS,
   DRAW_COST,
-  MANA_PER_TURN,
-  MANA_FAST_BONUS,
-  FAST_THRESHOLD_MS,
   AUTO_DRAW_INTERVAL,
 } from "@/lib/shogi/cards/definitions";
 import {
@@ -40,17 +39,16 @@ import {
   applyPawnReturn,
   applyPieceReturn,
   applyDoublePawn,
-  applyCheckBreak,
   getCheckEscapingSquares,
   applyTrapSet,
-  applyTrapClear,
   consumeNormalCard,
   hasNoPromoteMark,
-  addNoPromoteMark,
   removeNoPromoteMark,
-  moveNoPromoteMark,
   hasSameKindTrapPlaced,
 } from "@/lib/shogi/cards/effects";
+// Issue #235 S1c: move 効果適用ロジックは lib/kernel へ物理移設済 (旧 reducer 内定義)。
+// reducer は本関数を import して従来どおり直接呼ぶ (呼出経路・ロジック不変)。
+import { makeMoveWithEffects } from "@/lib/shogi/kernel/move-effects";
 import { canUndoFromState } from "./undo-policy";
 
 export type ShogiAction =
@@ -186,14 +184,6 @@ export interface UndoSnapshot {
   eventLog: GameEvent[];
 }
 
-// 移動処理のモード切替 (Issue #82 二手指し)。
-// - "normal": 通常の指し手 (マナチャージ + 早指しタイマークリア)
-// - "double_move_first": 二手指しの 1手目 (マナチャージなし + タイマークリアなし、ターン継続中)
-// - "double_move_second": 二手指しの 2手目 (マナチャージなし、タイマークリアあり、ターン交代)
-// 二手指しはカード使用扱いのため、1手目・2手目とも通常のマナチャージ (+1〜+2) は発生しない
-// (カードコスト -6 のみ消費、これは CONFIRM_PLAY_CARD 側で処理済み)。
-export type MakeMoveMode = "normal" | "double_move_first" | "double_move_second";
-
 // Issue #132: 待ったスナップショットのリング最大サイズ (= 直近何 ply 分を保持するか)。
 // 待った仕様は「直近 2 ply 巻き戻し」なので 2 で十分。これ以上は保持しない (メモリ節約)。
 const UNDO_SNAPSHOT_RING_MAX = 2;
@@ -232,199 +222,6 @@ function pushUndoSnapshot(state: CardShogiGameStateInternal): UndoSnapshot[] {
   };
   // ring size を UNDO_SNAPSHOT_RING_MAX で頭打ち。古い snapshot は evict。
   return [...state.undoSnapshots.slice(-(UNDO_SNAPSHOT_RING_MAX - 1)), snap];
-}
-
-// 移動 + マナチャージ + トラップフィルタ を一括適用。
-// CONFIRM_PROMOTION と MAKE_MOVE の両方から呼ばれる。
-// Issue #235 S1a: world-kernel.ts が move ロジックを reuse するため export。
-// 振る舞い不変 (関数本体・呼出経路は一切変更なし)。物理移設と reducer 薄ラッパ化は S1c。
-export function makeMoveWithEffects(
-  gameState: GameState,
-  cardState: CardGameState,
-  move: Move,
-  // Issue #193 / PR1a: spectatorMode は CPU vs CPU 観戦モード時に true。
-  // 早指し判定 (FAST_THRESHOLD_MS) を完全 disable し、両 CPU の連続指しによる
-  // マナ蓄積異常を防ぐ。spectatorMode=false の人間プレイ時は完全に従来挙動を保持。
-  options?: { mode?: MakeMoveMode; spectatorMode?: boolean },
-): {
-  gameState: GameState;
-  cardState: CardGameState;
-  events: GameEvent[];
-  finalMove: Move;
-  // 王手崩しトラップが発動した場合のみ true。MAKE_MOVE 側で isCheckBreakAnimating をセットする。
-  triggeredCheckBreak: boolean;
-} {
-  const mode: MakeMoveMode = options?.mode ?? "normal";
-  const spectatorMode = options?.spectatorMode ?? false;
-  const opponent: Player = move.player === "sente" ? "gote" : "sente";
-  const events: GameEvent[] = [];
-
-  // 1. 成り宣言フィルタ
-  //   (a) 自分の駒に既に「成り不可」マークがあれば silent ブロック (新規トラップは発火させない)
-  //   (b) (a) でなく、相手が no_promote トラップをセット中なら新規発動
-  //       → 成りブロック + 移動先位置にマーク追加 + トラップ消費
-  let finalMove = move;
-  let cardStateNext = cardState;
-  let pendingMarkAdd: Position | null = null;
-
-  const opponentTrap = cardState.trap[opponent];
-  const ownMarkAtFrom =
-    move.from !== undefined &&
-    move.from !== null &&
-    hasNoPromoteMark(cardState, move.player, move.from);
-
-  if (move.promote && ownMarkAtFrom) {
-    // 既マーク済み駒の成り宣言 → silent ブロック (トラップは無関係、消費しない)
-    finalMove = { ...move, promote: false };
-  } else if (move.promote && opponentTrap && opponentTrap.defId === "no_promote") {
-    // 新規発動: 成り宣言を無効化し、移動後位置に永続マーク付与、トラップ消費
-    finalMove = { ...move, promote: false };
-    cardStateNext = applyTrapClear(cardStateNext, opponent);
-    pendingMarkAdd = move.to;
-    events.push({
-      kind: "trapTriggerEvent",
-      player: opponent,
-      instance: opponentTrap,
-      reason: "promotion_declared",
-      at: Date.now(),
-    });
-  }
-
-  // 2. 駒移動
-  const nextGameState = applyMove(gameState, finalMove);
-
-  // 3. 成り不可マークの追従処理 (move 系のみ。drop は対象外)
-  if (finalMove.type === "move" && finalMove.from) {
-    // (a) 取られた相手駒のマークがあれば削除 (case A: 取られたら消失)
-    if (hasNoPromoteMark(cardStateNext, opponent, finalMove.to)) {
-      cardStateNext = removeNoPromoteMark(cardStateNext, opponent, finalMove.to);
-    }
-    // (b) 自分の駒のマークを from → to に移動
-    if (hasNoPromoteMark(cardStateNext, finalMove.player, finalMove.from)) {
-      cardStateNext = moveNoPromoteMark(
-        cardStateNext,
-        finalMove.player,
-        finalMove.from,
-        finalMove.to,
-      );
-    }
-  }
-
-  // 4. トラップ発動分のマーク追加 (成り宣言を無効化した直後の駒位置に付与)
-  if (pendingMarkAdd) {
-    cardStateNext = addNoPromoteMark(cardStateNext, finalMove.player, pendingMarkAdd);
-  }
-
-  // 4.5 王手崩しトラップ (#82)
-  // 移動の結果、相手 (= トラップ所有者候補) が王手中になり、かつ check_break
-  // トラップがセットされていれば自動発動。王手駒すべてを盤上から除去し、
-  // トラップ所有者の持ち駒に unpromote 加算する。
-  let postTrapGameState = nextGameState;
-  let triggeredCheckBreak = false;
-  const opponentTrapPostMove = cardStateNext.trap[opponent];
-  // この手の結果、相手の check_break トラップが発動条件 (相手玉が王手中) を満たすか。
-  const wouldTriggerCheckBreak =
-    !!opponentTrapPostMove &&
-    opponentTrapPostMove.defId === "check_break" &&
-    isInCheck(nextGameState, opponent, CARD_SHOGI_VARIANT);
-  // Issue #220 / #222 検証修正: 二手指しの一手目 (double_move_first) は中間局面。
-  // トラップはターン完了 (二手目) の最終局面でのみ発動すべきで、一手目では常に保留する。
-  // 旧実装は「一手目が (トラップ未考慮の盤面で) 詰みなら例外的に発動」していたが、
-  // check_break トラップがセットされている限り真の詰みは成立しない (トラップが王手駒を
-  // 奪い王手を解除するため)。よって一手目発動は誤りで、二手目を指す前にトラップが暴発し、
-  // 最終局面で王手している駒ではなく一手目の駒が奪われる不具合になっていた (検証で判明)。
-  const deferCheckBreak = mode === "double_move_first";
-  if (!deferCheckBreak && wouldTriggerCheckBreak) {
-    const result = applyCheckBreak(nextGameState, opponent);
-    if (result) {
-      postTrapGameState = result.gameState;
-      // 取られた相手 (= move.player) の駒に no_promote マークがあれば消失
-      for (const cap of result.capturedPieces) {
-        if (hasNoPromoteMark(cardStateNext, finalMove.player, { row: cap.row, col: cap.col })) {
-          cardStateNext = removeNoPromoteMark(cardStateNext, finalMove.player, {
-            row: cap.row,
-            col: cap.col,
-          });
-        }
-      }
-      cardStateNext = applyTrapClear(cardStateNext, opponent);
-      events.push({
-        kind: "trapTriggerEvent",
-        player: opponent,
-        instance: opponentTrapPostMove,
-        reason: "check_declared",
-        capturedPieces: result.capturedPieces,
-        at: Date.now(),
-      });
-      triggeredCheckBreak = true;
-    }
-  }
-
-  // 5. ゲーム終了判定 + 移動イベントログ
-  const evaluated = evaluateGameEnd(postTrapGameState, CARD_SHOGI_VARIANT);
-  // Issue #220 / #222 検証修正: 二手指し一手目で check_break を保留した場合、形式上の
-  // 詰み (トラップ未適用の盤面) は真の終局ではない (ターン完了後にトラップが王手を解除
-  // する)。中間局面として active を維持し二手目を継続させる。これがないと MAKE_MOVE 側
-  // gameOver 判定が偽の詰みで二手指しを打ち切り、二手目を指せなくなる。
-  // (nextGameState は applyMove 直後で status="active"。evaluateGameEnd を通す前の値。)
-  const resultGameState =
-    deferCheckBreak && wouldTriggerCheckBreak ? nextGameState : evaluated;
-  events.push({ kind: "moveEvent", move: finalMove, at: Date.now() });
-
-  // 6. マナチャージ + lastTurnStartedAt クリア (mode で挙動を切替)
-  if (mode === "normal") {
-    // 通常の指し手: マナチャージ + 早指し判定 + タイマークリア
-    const lastStarted = cardStateNext.lastTurnStartedAt[move.player];
-    // Issue #193 / PR1a: 観戦モード時は早指し判定を完全スキップ (両 CPU が常に <4 秒で
-    // 指してマナ蓄積が異常になることを防ぐ)。spectatorMode=false の人間プレイ時は
-    // 完全に従来挙動を保持する。
-    const isFastMove =
-      !spectatorMode &&
-      lastStarted !== null &&
-      Date.now() - lastStarted < FAST_THRESHOLD_MS;
-    const manaAmount =
-      MANA_PER_TURN + (isFastMove ? MANA_FAST_BONUS : 0);
-    cardStateNext = {
-      ...cardStateNext,
-      mana: {
-        ...cardStateNext.mana,
-        [move.player]: Math.min(
-          cardStateNext.manaCap,
-          cardStateNext.mana[move.player] + manaAmount,
-        ),
-      },
-      lastTurnStartedAt: {
-        ...cardStateNext.lastTurnStartedAt,
-        [move.player]: null,
-      },
-    };
-    events.push({
-      kind: "manaChargeEvent",
-      player: move.player,
-      amount: manaAmount,
-      reason: "turn",
-      fastMove: isFastMove,
-      at: Date.now(),
-    });
-  } else if (mode === "double_move_second") {
-    // 二手指しの 2手目: マナチャージなし。lastTurnStartedAt のみクリア (ターン交代)
-    cardStateNext = {
-      ...cardStateNext,
-      lastTurnStartedAt: {
-        ...cardStateNext.lastTurnStartedAt,
-        [move.player]: null,
-      },
-    };
-  }
-  // mode === "double_move_first": どちらもしない (ターン継続中のため)
-
-  return {
-    gameState: resultGameState,
-    cardState: cardStateNext,
-    events,
-    finalMove,
-    triggeredCheckBreak,
-  };
 }
 
 function isKingInCheckAfterMove(gameState: GameState, move: Move): boolean {

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -25,30 +25,31 @@ import {
   isInCheck,
 } from "@/lib/shogi/moves";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
-import { unpromotePieceType } from "@/lib/shogi/variants/standard";
 
 import type { CardAction, CardGameState, CardInstance, GameEvent } from "@/lib/shogi/cards/types";
 import {
   CARD_DEFS,
   CARD_USE_CONDITIONS,
   DRAW_COST,
-  AUTO_DRAW_INTERVAL,
 } from "@/lib/shogi/cards/definitions";
 import {
-  applyManaUp,
-  applyPawnReturn,
-  applyPieceReturn,
-  applyDoublePawn,
   getCheckEscapingSquares,
-  applyTrapSet,
-  consumeNormalCard,
   hasNoPromoteMark,
-  removeNoPromoteMark,
   hasSameKindTrapPlaced,
 } from "@/lib/shogi/cards/effects";
 // Issue #235 S1c: move 効果適用ロジックは lib/kernel へ物理移設済 (旧 reducer 内定義)。
 // reducer は本関数を import して従来どおり直接呼ぶ (呼出経路・ロジック不変)。
 import { makeMoveWithEffects } from "@/lib/shogi/kernel/move-effects";
+// Issue #235 S1d (cutover): reducer の cardState 遷移を L0 カーネル building-block へ委譲
+// (二重実装解消 P4)。flip/turn-end タイミングは reducer が演出フェーズで制御し続けるため
+// atomic applyTurnAction ではなく building-block を採用する (UX 不変)。
+import {
+  advanceDrawProgress,
+  finalizeDoubleMoveLogic,
+  applyCardEffectLogic,
+  type WorldState,
+  type KernelDoubleMove,
+} from "@/lib/shogi/kernel/world-kernel";
 import { canUndoFromState } from "./undo-policy";
 
 export type ShogiAction =
@@ -247,28 +248,23 @@ function applyTurnEndEffects(
   state: CardShogiGameStateInternal,
   player: Player,
 ): CardShogiGameStateInternal {
-  // Issue #170: 詰み・投了など対局終了後はドロー進捗加算と自動ドロー発火を行わない。
-  // 詰ます手で同時にしきい値到達した場合に詰み演出と自動ドロー演出が同時実行される
-  // のを防ぐ。終局後は進捗が動いても UI 上で意味がないため、ここで止めてよい。
-  if (state.gameState.status !== "active") return state;
+  // Issue #235 S1d: drawProgress 加算・自動ドロー発火の cardState 遷移を kernel building-block
+  // (advanceDrawProgress) へ委譲。kernel は cardState/events のみ返し、UI 演出 flag は
+  // reducer が返り値 events (auto drawEvent) を読んで event-driven にセットする。
+  //   - status≠active → events=[]・cardState 同一参照 (Issue #170 の no-op、kernel が判定)。
+  //   - 閾値未到達/deck 枯渇 → drawProgress のみ加算 (events=[]、flag 不変)。
+  //   - 閾値到達∧deck非空 → auto drawEvent 発火 → isDrawing/pendingDrawPlayer/pendingDrawSource
+  //     をセット + 駒選択状態クリア (DRAW_CARD と同じ挙動、selection clear は reducer 責務 §3-1)。
+  const { cardState, events } = advanceDrawProgress(state.cardState, state.gameState, player);
+  const autoDrew = events.some(
+    (e) => e.kind === "drawEvent" && e.source === "auto",
+  );
 
-  const current = state.cardState.drawProgress[player];
-  const next = current + 1;
-  const deck = state.cardState.deck[player];
-
-  if (next < AUTO_DRAW_INTERVAL || deck.length === 0) {
-    // しきい値未到達、または deck 枯渇で発火不可: 進捗のみ加算
-    return {
-      ...state,
-      cardState: {
-        ...state.cardState,
-        drawProgress: { ...state.cardState.drawProgress, [player]: next },
-      },
-    };
+  if (!autoDrew) {
+    // status≠active (同一参照) なら state 不変。進捗のみ加算なら cardState だけ差し替え。
+    return cardState === state.cardState ? state : { ...state, cardState };
   }
 
-  // しきい値到達 + deck あり: 自動ドロー発火
-  const [top, ...rest] = deck;
   return {
     ...state,
     // 自動ドロー発火時は駒選択状態をクリア (DRAW_CARD と同じ挙動)
@@ -276,16 +272,8 @@ function applyTurnEndEffects(
     selectedHandPiece: null,
     legalMoves: [],
     forbiddenMateMoves: [],
-    cardState: {
-      ...state.cardState,
-      drawProgress: { ...state.cardState.drawProgress, [player]: 0 },
-      deck: { ...state.cardState.deck, [player]: rest },
-      hand: { ...state.cardState.hand, [player]: [...state.cardState.hand[player], top] },
-    },
-    eventLog: [
-      ...state.eventLog,
-      { kind: "drawEvent", player, instance: top, source: "auto", at: Date.now() },
-    ],
+    cardState,
+    eventLog: [...state.eventLog, ...events],
     isDrawing: true,
     pendingDrawPlayer: player,
     pendingDrawSource: "auto",
@@ -466,29 +454,30 @@ function finalizeDoubleMoveCardConsumption(
   state: CardShogiGameStateInternal,
   dm: NonNullable<CardShogiGameStateInternal["doubleMove"]>,
 ): CardShogiGameStateInternal {
-  const consumed = consumeNormalCard(
-    state.cardState,
-    dm.active,
-    dm.cardInstance.instanceId,
-    dm.cardCost,
-  );
-  if (!consumed) {
-    // 異常系: 二手指し中に手札からカードが消えるケース (バグ or 競合)。
+  // 前提 (M1 B-4): 呼び出し元 (MAKE_MOVE / CONFIRM_PROMOTION の 2手目) で
+  // makeMoveWithEffects(mode="double_move_second") が applyMove 済 = currentPlayer は既に
+  // dm.active の反対へ flip 済。よって pendingPlayCardOpponent=null とし、COMMIT_PLAY_CARD では再 flip しない。
+  //
+  // Issue #235 S1d: 二手指しカード本体の遅延消費 (consume + cardPlayEvent) を kernel building-block
+  // (finalizeDoubleMoveLogic) へ委譲。isPlayingCard / pendingPlayCardOpponent は reducer 責務として維持。
+  const kernelDm: KernelDoubleMove = {
+    active: dm.active,
+    movesLeft: dm.movesLeft,
+    cardInstance: dm.cardInstance,
+    cardCost: dm.cardCost,
+  };
+  const { cardState, events } = finalizeDoubleMoveLogic(state.cardState, kernelDm);
+  if (events.length === 0) {
+    // 異常系: 二手指し中に手札からカードが消えるケース (consume 失敗)。
     // 防御的に演出だけスキップして state はそのまま返す (二手指し終了は維持)。
     return state;
   }
-  const event: GameEvent = {
-    kind: "cardPlayEvent",
-    player: dm.active,
-    instance: dm.cardInstance,
-    at: Date.now(),
-  };
   return {
     ...state,
-    cardState: consumed,
-    eventLog: [...state.eventLog, event],
+    cardState,
+    eventLog: [...state.eventLog, ...events],
     isPlayingCard: true,
-    pendingPlayCardOpponent: null, // currentPlayer は既に flip 済なので COMMIT_PLAY_CARD で再 flip しない
+    pendingPlayCardOpponent: null,
   };
 }
 
@@ -1022,87 +1011,15 @@ export function reducer(
         };
       }
 
-      // 効果適用
-      let nextCardState = state.cardState;
-      let nextGameState = state.gameState;
-      // pawn_return / piece_return が盤上 → 持ち駒に戻した駒の情報。
-      // 適用前の盤面から捕捉し cardPlayEvent に載せる (相手 AI 使用時の
-      // 駒フライト演出再現用、Issue #193 / card-apply)。
-      let returnedPieceInfo: { row: number; col: number; pieceType: string } | undefined;
-
-      if (def.kind === "trap") {
-        // トラップは consumeNormalCard を使わず、マナ消費 + applyTrapSet
-        const card = pending.instance;
-        if (state.cardState.mana[player] < def.cost) return state;
-        const afterMana = {
-          ...state.cardState,
-          mana: { ...state.cardState.mana, [player]: state.cardState.mana[player] - def.cost },
-        };
-        const afterSet = applyTrapSet(afterMana, player, card.instanceId);
-        if (!afterSet) return state;
-        nextCardState = afterSet;
-      } else if (def.effectId === "mana_up") {
-        const afterConsume = consumeNormalCard(state.cardState, player, pending.instance.instanceId, def.cost);
-        if (!afterConsume) return state;
-        nextCardState = applyManaUp(afterConsume, player);
-      } else if (def.effectId === "pawn_return") {
-        if (!pending.target || pending.target.kind !== "square") return state;
-        const targetPos = { row: pending.target.row, col: pending.target.col };
-        const returnedPiece = state.gameState.board[targetPos.row]?.[targetPos.col];
-        const newGameState = applyPawnReturn(state.gameState, player, targetPos);
-        if (!newGameState) return state;
-        nextGameState = newGameState;
-        if (returnedPiece) {
-          returnedPieceInfo = {
-            row: targetPos.row,
-            col: targetPos.col,
-            pieceType: unpromotePieceType(returnedPiece.type),
-          };
-        }
-        const afterConsume = consumeNormalCard(state.cardState, player, pending.instance.instanceId, def.cost);
-        if (!afterConsume) return state;
-        // 持ち駒に戻った駒は no_promote マークを失う (案A 仕様)
-        nextCardState = removeNoPromoteMark(afterConsume, player, targetPos);
-      } else if (def.effectId === "piece_return") {
-        if (!pending.target || pending.target.kind !== "square") return state;
-        const targetPos = { row: pending.target.row, col: pending.target.col };
-        const returnedPiece = state.gameState.board[targetPos.row]?.[targetPos.col];
-        const newGameState = applyPieceReturn(state.gameState, player, targetPos);
-        if (!newGameState) return state;
-        nextGameState = newGameState;
-        if (returnedPiece) {
-          returnedPieceInfo = {
-            row: targetPos.row,
-            col: targetPos.col,
-            pieceType: unpromotePieceType(returnedPiece.type),
-          };
-        }
-        const afterConsume = consumeNormalCard(state.cardState, player, pending.instance.instanceId, def.cost);
-        if (!afterConsume) return state;
-        // 持ち駒に戻った駒は no_promote マークを失う (案A 仕様、pawn_return と同じ)
-        nextCardState = removeNoPromoteMark(afterConsume, player, targetPos);
-      } else if (def.effectId === "double_pawn") {
-        if (!pending.target || pending.target.kind !== "square") return state;
-        const targetPos = { row: pending.target.row, col: pending.target.col };
-        const newGameState = applyDoublePawn(state.gameState, player, targetPos);
-        if (!newGameState) return state;
-        nextGameState = newGameState;
-        const afterConsume = consumeNormalCard(state.cardState, player, pending.instance.instanceId, def.cost);
-        if (!afterConsume) return state;
-        nextCardState = afterConsume;
-      } else if (def.effectId === "double_move") {
-        // Issue #82 (二手指し / 新仕様): CONFIRM 時点ではカード消費・マナ減算・
-        // cardPlayEvent push を一切行わず、二手指しモードに突入するだけ。
-        // 1手目までの操作はキャンセル可能 (CANCEL_DOUBLE_MOVE で preCardState から復元)。
-        // 実際のカード消費・mana 減算・cardPlayEvent push・カード使用演出 (isPlayingCard=true)
-        // は 2手目完了時に MAKE_MOVE 内で finalize する。
-        // 王手中の使用可否は既に BEGIN_PLAY_CARD の use condition で判定済。
-        // pendingCard クリア + doubleMove セット のみで return する (下の共通処理は通らない)。
-        //
+      // Issue #235 S1d: double_move (二手指し) は building-block 対象外。UI snapshot
+      // (preFirstMoveState/preCardState/mateInOneAvailable) を持つため reducer に残す。
+      // CONFIRM 時点ではカード消費・マナ減算・cardPlayEvent を行わず二手指しモードに突入するのみ
+      // (1手目までキャンセル可)。実消費・演出は 2手目完了時 finalizeDoubleMoveCardConsumption で確定。
+      // 王手中の使用可否は BEGIN_PLAY_CARD の use condition で判定済。
+      if (def.effectId === "double_move") {
         // 重要: snapshot 用 cardState は **必ず pendingCard を null にした状態** で記録する。
-        // そうしないと CANCEL_DOUBLE_MOVE / UNDO_DOUBLE_MOVE_FIRST で復元した際に
-        // pendingCard が再セットされ、CardPlayDialog が再表示されてしまう。
-        // 「BEGIN_PLAY_CARD 前の状態と等価」になるよう pendingCard を落として保存する。
+        // そうしないと CANCEL_DOUBLE_MOVE / UNDO_DOUBLE_MOVE_FIRST で復元時に pendingCard が再セット
+        // され CardPlayDialog が再表示される。「BEGIN_PLAY_CARD 前の状態と等価」に落として保存する。
         const cardStateWithoutPending = { ...state.cardState, pendingCard: null };
         const preCardSnapshot = {
           gameState: state.gameState,
@@ -1128,55 +1045,43 @@ export function reducer(
             preCardState: preCardSnapshot,
           },
         };
-      } else {
-        return state;
       }
 
-      // 王手中の最終ガード (Issue #82): 王手中だった場合、適用後の盤面で
-      // 王手が解除されている必要がある。解除されない手は不正なので状態変更しない。
-      if (isInCheck(state.gameState, player, CARD_SHOGI_VARIANT)) {
-        if (isInCheck(nextGameState, player, CARD_SHOGI_VARIANT)) {
-          return state;
-        }
-      }
-
-      // カード使用 = 1手相当。currentPlayer 反転と lastTurnStartedAt クリアは
-      // 演出完了 (COMMIT_PLAY_CARD) まで保留する (AI が演出中に動かないようにする)。
-      nextCardState = {
-        ...nextCardState,
-        pendingCard: null,
+      // Issue #235 S1d: trap / mana_up / pawn_return / piece_return / double_pawn の効果適用 +
+      // 王手解除ガード + event (cardPlayEvent/trapSetEvent, returnedPiece 込み) 構築を kernel
+      // building-block (applyCardEffectLogic) へ委譲 (二重実装解消 P4)。
+      // currentPlayer 反転と lastTurnStartedAt クリアは演出完了 (COMMIT_PLAY_CARD) まで保留するため、
+      // flip しない building-block を採用する (AI が演出中に動かないようにする)。
+      const world: WorldState = {
+        gameState: state.gameState,
+        cardState: state.cardState,
+        doubleMove: null,
       };
-
-      // pendingCard クリア + イベントログ
-      const event: GameEvent =
-        def.kind === "trap"
-          ? {
-              kind: "trapSetEvent",
-              player,
-              instance: { instanceId: pending.instance.instanceId, defId: pending.instance.defId, owner: player },
-              at: Date.now(),
-            }
-          : {
-              kind: "cardPlayEvent",
-              player,
-              instance: pending.instance,
-              target: pending.target,
-              returnedPiece: returnedPieceInfo,
-              at: Date.now(),
-            };
-
-      const nextEventLog = [...state.eventLog, event];
+      const applied = applyCardEffectLogic(
+        world,
+        {
+          kind: "playCard",
+          defId: pending.instance.defId,
+          cardInstanceId: pending.instance.instanceId,
+          target: pending.target,
+        },
+        player,
+      );
+      // 不正 (未対応 effectId / マナ不足 / 王手未解除 / 効果適用失敗) は状態変更しない
+      // (王手解除ガードは applyCardEffectLogic 内蔵)。
+      if (!applied) return state;
 
       return {
         ...state,
-        gameState: nextGameState,
-        cardState: nextCardState,
+        gameState: applied.gameState,
+        // kernel は pendingCard を変更しないため明示クリア (カード使用 = pendingCard 解消)。
+        cardState: { ...applied.cardState, pendingCard: null },
         // 駒選択状態もクリア
         selectedSquare: null,
         selectedHandPiece: null,
         legalMoves: [],
         forbiddenMateMoves: [],
-        eventLog: nextEventLog,
+        eventLog: [...state.eventLog, applied.event],
         isPlayingCard: true,
         pendingPlayCardOpponent: opponent,
       };
@@ -1264,7 +1169,14 @@ export function reducer(
         legalMoves: [],
         forbiddenMateMoves: [],
         promotionPendingMove: null,
-        // 演出系フラグも明示リセット (preFirstMoveState 時点では当然 false)
+        // 演出系フラグを UNDO と対称に明示リセット (Issue #235 S1d M1 B-1)。preFirstMoveState
+        // 時点では当然 false (movesLeft=1 窓では isDrawing/isPlayingCard は構造上 false) だが、
+        // snapshot に演出フラグが含まれないため UNDO ケースと同一の防御に揃えて stuck-flag を防ぐ。
+        isDrawing: false,
+        pendingDrawPlayer: null,
+        pendingDrawSource: null,
+        isPlayingCard: false,
+        pendingPlayCardOpponent: null,
         isCheckBreakAnimating: false,
         doubleMove: { ...dm, movesLeft: 2 },
       };
@@ -1291,6 +1203,12 @@ export function reducer(
         legalMoves: [],
         forbiddenMateMoves: [],
         promotionPendingMove: null,
+        // 演出系フラグを UNDO と対称に明示リセット (Issue #235 S1d M1 B-1、防御強化)。
+        isDrawing: false,
+        pendingDrawPlayer: null,
+        pendingDrawSource: null,
+        isPlayingCard: false,
+        pendingPlayCardOpponent: null,
         isCheckBreakAnimating: false,
         doubleMove: null,
       };

--- a/src/lib/shogi/ai/__tests__/kernel-search-equivalence.test.ts
+++ b/src/lib/shogi/ai/__tests__/kernel-search-equivalence.test.ts
@@ -1,0 +1,558 @@
+// Issue #235 S1b: AI root カード/ドロー評価の OFF (旧近似) vs ON (L0 カーネル applyTurnAction)
+// 特性化テスト。
+//
+// 位置づけ (計画 docs/plans/issue-235-s1b-ai-wiring.md §3/§5 S1b-4):
+//   S1b は useKernelSearch フラグ裏で applyActionForLookahead (OFF) を applyTurnActionForLookahead
+//   (ON = kernel) に切替える。ON の「正しさ」自体は S1a の reducer-vs-kernel 等価テストで担保済の
+//   ため、本テストは「OFF と ON が §3 の既知差分のみで食い違う (= ON は production 等価への是正)」
+//   ことを pin する特性化テスト。strict 等価ではなく、一致すべき次元 (board 駒配置 = trap 非発火時) と
+//   既知 divergence 次元 (currentPlayer flip / mana manaCharge / drawProgress lazy / graveyard /
+//   noPromoteMarks / status mate score / trap 発火 move の board・trap) を分離して assert する。
+//
+// 決定論化: spectatorMode=true 固定 (ON の manaCharge を早指し非依存 = MANA_PER_TURN に固定)。
+
+import { describe, expect, it } from "vitest";
+
+import { serializePosition } from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { MANA_CAP, MANA_PER_TURN } from "@/lib/shogi/cards/definitions";
+import { createSearchContext } from "../search-context";
+import { evaluate } from "../evaluate";
+import {
+  applyActionForLookahead,
+  applyTurnActionForLookahead,
+  evaluateActionWithLookahead,
+} from "../search";
+import { getCardActions } from "../turn/action-generator";
+import type { AiTurnState, TurnAction } from "../turn/types";
+import type { Board, GameState, PieceType, Player } from "@/lib/shogi/types";
+import type { CardGameState, CardInstance } from "@/lib/shogi/cards/types";
+
+// ===== 盤面/状態ビルダー (world-kernel-equivalence.test.ts と同方式) =====
+
+function emptyBoard(): Board {
+  return Array.from({ length: 9 }, () =>
+    Array.from({ length: 9 }, () => null as Board[number][number]),
+  );
+}
+
+function pc(type: PieceType, owner: Player) {
+  return { type, owner };
+}
+
+function buildGameState(
+  place: (b: Board) => void,
+  currentPlayer: Player,
+): GameState {
+  const board = emptyBoard();
+  place(board);
+  const state: GameState = {
+    board,
+    hand: { sente: {}, gote: {} },
+    currentPlayer,
+    moveHistory: [],
+    positionHistory: [],
+    status: "active",
+    moveCount: 0,
+  };
+  state.positionHistory = [serializePosition(state)];
+  return state;
+}
+
+function minimalCardState(over: Partial<CardGameState> = {}): CardGameState {
+  return {
+    mana: { sente: 10, gote: 10 },
+    manaCap: MANA_CAP,
+    hand: { sente: [], gote: [] },
+    deck: { sente: [], gote: [] },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: null, gote: null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    drawProgress: { sente: 0, gote: 0 },
+    ...over,
+  };
+}
+
+function aiState(gameState: GameState, cardState: CardGameState): AiTurnState {
+  return { gameState, cardState, doubleMove: null, isRoot: true };
+}
+
+// OFF / ON の applied state を両方計算 (ON は spectatorMode=true)。
+function applyBoth(state: AiTurnState, action: TurnAction, player: Player) {
+  const off = applyActionForLookahead(state, action, player);
+  const on = applyTurnActionForLookahead(
+    state,
+    action,
+    CARD_SHOGI_VARIANT,
+    true,
+  );
+  return { off, on };
+}
+
+// 盤面 (駒配置) のみ比較 (currentPlayer/status/moveCount/history は除外)。
+function expectBoardPlacementEqual(a: GameState, b: GameState) {
+  expect(a.board).toEqual(b.board);
+  expect(a.hand).toEqual(b.hand); // 取り駒 (komadai) も駒配置の一部
+}
+
+// ===== 共通配置: 両陣に玉 + 先手歩 =====
+const placeKingsAndPawn = (b: Board) => {
+  b[0][0] = pc("king", "gote");
+  b[8][8] = pc("king", "sente");
+  b[6][4] = pc("pawn", "sente");
+};
+
+describe("S1b: OFF (applyActionForLookahead) vs ON (applyTurnActionForLookahead) 特性化", () => {
+  it("move (trap 非発火・境界未満): board 一致 / ON は manaCharge+1 / drawProgress 両者 +1", () => {
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        drawProgress: { sente: 1, gote: 0 },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const action: TurnAction = {
+      kind: "move",
+      move: {
+        type: "move",
+        from: { row: 6, col: 4 },
+        to: { row: 5, col: 4 },
+        piece: "pawn",
+        player: "sente",
+      },
+    };
+    const { off, on } = applyBoth(state, action, "sente");
+    expect(off).not.toBeNull();
+    expect(on).not.toBeNull();
+    // board (駒配置) 一致。
+    expectBoardPlacementEqual(off!.gameState, on!.gameState);
+    // ON 是正: manaCharge +MANA_PER_TURN (OFF は加算なし)。
+    expect(off!.cardState.mana.sente).toBe(5);
+    expect(on!.cardState.mana.sente).toBe(5 + MANA_PER_TURN);
+    // drawProgress: 境界未満は両者 +1。
+    expect(off!.cardState.drawProgress.sente).toBe(2);
+    expect(on!.cardState.drawProgress.sente).toBe(2);
+    // currentPlayer: 両者とも flip (move は OFF/ON 共に applyMove で flip)。
+    expect(off!.gameState.currentPlayer).toBe("gote");
+    expect(on!.gameState.currentPlayer).toBe("gote");
+  });
+
+  it("draw (境界未満): mana/hand/deck/drawProgress 一致、board 駒配置一致 (ON は currentPlayer flip)", () => {
+    const card: CardInstance = { instanceId: "s-pr-1", defId: "pawn_return" };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        deck: { sente: [card], gote: [] },
+        drawProgress: { sente: 1, gote: 0 },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const { off, on } = applyBoth(state, { kind: "draw" }, "sente");
+    expect(off).not.toBeNull();
+    expect(on).not.toBeNull();
+    expect(on!.cardState.mana.sente).toBe(off!.cardState.mana.sente); // 両者 -2
+    expect(on!.cardState.hand.sente).toEqual(off!.cardState.hand.sente); // 引いたカード追加
+    expect(on!.cardState.deck.sente).toEqual(off!.cardState.deck.sente); // deck -1
+    expect(on!.cardState.drawProgress.sente).toBe(
+      off!.cardState.drawProgress.sente,
+    ); // 境界未満 両者 +1
+    expectBoardPlacementEqual(off!.gameState, on!.gameState);
+    // 既知 divergence: ON は currentPlayer flip、OFF は不変。
+    expect(off!.gameState.currentPlayer).toBe("sente");
+    expect(on!.gameState.currentPlayer).toBe("gote");
+  });
+
+  it("draw (境界 drawProgress=4): ON は lazy で auto-draw 連鎖 (hand+2/reset)、OFF は単純 +1 (hand+1)", () => {
+    const manualCard: CardInstance = {
+      instanceId: "s-pr-1",
+      defId: "pawn_return",
+    };
+    const autoCard: CardInstance = {
+      instanceId: "s-dp-1",
+      defId: "double_pawn",
+    };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        deck: { sente: [manualCard, autoCard], gote: [] },
+        drawProgress: { sente: 4, gote: 0 },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const { off, on } = applyBoth(state, { kind: "draw" }, "sente");
+    // OFF: drawProgress=5 (単純 +1)、hand に manual の 1 枚のみ。
+    expect(off!.cardState.drawProgress.sente).toBe(5);
+    expect(off!.cardState.hand.sente).toHaveLength(1);
+    // ON: 境界到達で reset + auto-draw → drawProgress=0、hand に manual+auto の 2 枚。
+    expect(on!.cardState.drawProgress.sente).toBe(0);
+    expect(on!.cardState.hand.sente).toHaveLength(2);
+    expect(on!.cardState.deck.sente).toHaveLength(0); // 2 枚引いて空
+  });
+
+  it("trap set (check_break・境界未満): cardState 完全一致 (DP-3 graveyard 不変)、board 一致", () => {
+    const trapCard: CardInstance = {
+      instanceId: "s-cb-1",
+      defId: "check_break",
+    };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 6, gote: 6 },
+        hand: { sente: [trapCard], gote: [] },
+        drawProgress: { sente: 1, gote: 0 },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: trapCard.instanceId,
+      defId: "check_break",
+    };
+    const { off, on } = applyBoth(state, action, "sente");
+    // trap 系は境界未満で cardState の digest 次元 (mana/hand/trap/graveyard/drawProgress) が完全一致。
+    expect(on!.cardState.mana.sente).toBe(off!.cardState.mana.sente); // 両者 -4
+    expect(on!.cardState.hand.sente).toEqual(off!.cardState.hand.sente); // 両者 空
+    expect(on!.cardState.trap.sente).toEqual(off!.cardState.trap.sente); // 両者 set
+    expect(on!.cardState.graveyard.sente).toEqual(
+      off!.cardState.graveyard.sente,
+    ); // DP-3: 両者 空
+    expect(on!.cardState.drawProgress.sente).toBe(
+      off!.cardState.drawProgress.sente,
+    );
+    expectBoardPlacementEqual(off!.gameState, on!.gameState);
+  });
+
+  it("modifyBoard (pawn_return): board 一致 / ON は hand→graveyard (DP-3) / OFF は graveyard 追加なし", () => {
+    const card: CardInstance = { instanceId: "s-pr-1", defId: "pawn_return" };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        hand: { sente: [card], gote: [] },
+        drawProgress: { sente: 1, gote: 0 },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: card.instanceId,
+      defId: "pawn_return",
+      target: { kind: "square", row: 6, col: 4 },
+    };
+    const { off, on } = applyBoth(state, action, "sente");
+    // board: 両者とも applyPawnReturn (= simulateCardEffect が同じ effect fn を呼ぶ) → 一致。
+    expectBoardPlacementEqual(off!.gameState, on!.gameState);
+    expect(on!.gameState.board[6][4]).toBeNull();
+    expect(on!.cardState.mana.sente).toBe(off!.cardState.mana.sente); // 両者 -1
+    expect(on!.cardState.hand.sente).toEqual(off!.cardState.hand.sente); // 両者 card 除去
+    // 既知 divergence: ON は consumeNormalCard で hand→graveyard、OFF は graveyard 追加なし。
+    expect(on!.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+      "pawn_return",
+    ]);
+    expect(off!.cardState.graveyard.sente).toHaveLength(0);
+  });
+
+  it("modifyBoard (pawn_return) で no_promote マーク付き駒: ON は removeNoPromoteMark / OFF は不変", () => {
+    const card: CardInstance = { instanceId: "s-pr-1", defId: "pawn_return" };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        hand: { sente: [card], gote: [] },
+        noPromoteMarks: { sente: [{ row: 6, col: 4 }], gote: [] },
+      });
+    const state = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: card.instanceId,
+      defId: "pawn_return",
+      target: { kind: "square", row: 6, col: 4 },
+    };
+    const { off, on } = applyBoth(state, action, "sente");
+    // 既知 divergence: ON は戻した駒のマークを削除、OFF は近似のため残る。
+    expect(on!.cardState.noPromoteMarks.sente).toHaveLength(0);
+    expect(off!.cardState.noPromoteMarks.sente).toEqual([{ row: 6, col: 4 }]);
+  });
+
+  it("double_move: evaluateActionWithLookahead が OFF/ON 双方で有限スコア (ON 連鎖が throw せず成立)", () => {
+    // ON 経路の cardState 消費 (double_move を hand→graveyard / mana-5 / lazy drawProgress) の
+    // 正しさ自体は S1a world-kernel-equivalence.test.ts (DP-2 = applyTurnAction ≡ reducer) が担保済。
+    // 本ケースは S1b 配線として「ON super-action 連鎖 (playCard→move→move) が turnEnded 不変条件で
+    // throw せず有限スコアを返す」ことの smoke。終局 (1手目 mate) の分岐は下の専用ケースで pin。
+    const dmCard: CardInstance = { instanceId: "s-dm-1", defId: "double_move" };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 8, gote: 8 },
+        hand: { sente: [dmCard], gote: [] },
+      });
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: dmCard.instanceId,
+      defId: "double_move",
+    };
+
+    const ctxOff = createSearchContext({
+      timeLimitMs: 1000,
+      useKernelSearch: false,
+    });
+    const ctxOn = createSearchContext({
+      timeLimitMs: 1000,
+      useKernelSearch: true,
+      spectatorMode: true,
+    });
+
+    const stateOff = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+    const stateOn = aiState(buildGameState(placeKingsAndPawn, "sente"), cs());
+
+    const scoreOff = evaluateActionWithLookahead(
+      stateOff,
+      action,
+      "sente",
+      CARD_SHOGI_VARIANT,
+      ctxOff,
+      false,
+      1,
+    );
+    const scoreOn = evaluateActionWithLookahead(
+      stateOn,
+      action,
+      "sente",
+      CARD_SHOGI_VARIANT,
+      ctxOn,
+      false,
+      1,
+    );
+
+    expect(Number.isFinite(scoreOff)).toBe(true);
+    expect(Number.isFinite(scoreOn)).toBe(true);
+    expect(scoreOff).toBeGreaterThan(Number.NEGATIVE_INFINITY);
+    expect(scoreOn).toBeGreaterThan(Number.NEGATIVE_INFINITY);
+  });
+});
+
+// ===== ON 是正 divergence (trap 発火 move / 終局手): M2 レビュー S1b-M2-001/OBS3-T1/T2/T3 反映 =====
+// §3 が列挙する「move の trap 発火」「着手後/double_move 終局 (status/mate score)」は OFF (軽量近似) が
+// 無視し ON (production 等価 kernel) のみ反映する是正 divergence。これらを既知差分として明示 pin する。
+
+describe("S1b: ON 是正 divergence (trap 発火 move / 終局)", () => {
+  it("trap 発火 move: 相手 check_break 保持下で王手すると ON は board/trap を是正・OFF は無視", () => {
+    // 後手玉(3,4) に先手金(5,4)→(4,4) で王手。後手は check_break をセット済。
+    // OFF=applyMoveForSearch は trap を見ず金を (4,4) に置くだけ。ON=makeMoveWithEffects は
+    // check_break を発火させ王手駒(金)を盤上から除去 + 後手の持ち駒へ + trap clear (DP-7)。
+    const place = (b: Board) => {
+      b[3][4] = pc("king", "gote");
+      b[8][8] = pc("king", "sente");
+      b[5][4] = pc("gold", "sente");
+    };
+    const goteTrap = {
+      instanceId: "g-cb",
+      defId: "check_break" as const,
+      owner: "gote" as const,
+    };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 5, gote: 5 },
+        trap: { sente: null, gote: goteTrap },
+      });
+    const state = aiState(buildGameState(place, "sente"), cs());
+    const action: TurnAction = {
+      kind: "move",
+      move: {
+        type: "move",
+        from: { row: 5, col: 4 },
+        to: { row: 4, col: 4 },
+        piece: "gold",
+        player: "sente",
+      },
+    };
+    const off = applyActionForLookahead(state, action, "sente");
+    const on = applyTurnActionForLookahead(
+      state,
+      action,
+      CARD_SHOGI_VARIANT,
+      true,
+    );
+    expect(off).not.toBeNull();
+    expect(on).not.toBeNull();
+    // 既知 divergence (ON 是正): OFF は金が (4,4) に残り trap 不変、ON は金除去 + trap clear + 後手持ち駒。
+    expect(off!.gameState.board[4][4]).toEqual(pc("gold", "sente"));
+    expect(on!.gameState.board[4][4]).toBeNull();
+    expect(off!.cardState.trap.gote).toEqual(goteTrap);
+    expect(on!.cardState.trap.gote).toBeNull();
+    expect(on!.gameState.hand.gote["gold"]).toBe(1); // check_break で取った金が後手持ち駒へ
+  });
+
+  it("終局手 (通常 move で詰み): ON は status=checkmate + mate score、OFF は status=active + material", () => {
+    // 頭金詰み: 後手玉(0,4)、先手金(2,4)→(1,4)、先手飛(8,4) が金を支える、先手玉(8,8)。
+    const place = (b: Board) => {
+      b[0][4] = pc("king", "gote");
+      b[2][4] = pc("gold", "sente");
+      b[8][4] = pc("rook", "sente");
+      b[8][8] = pc("king", "sente");
+    };
+    const cs = () => minimalCardState({ mana: { sente: 5, gote: 5 } });
+    const state = aiState(buildGameState(place, "sente"), cs());
+    const action: TurnAction = {
+      kind: "move",
+      move: {
+        type: "move",
+        from: { row: 2, col: 4 },
+        to: { row: 1, col: 4 },
+        piece: "gold",
+        player: "sente",
+      },
+    };
+    const off = applyActionForLookahead(state, action, "sente");
+    const on = applyTurnActionForLookahead(
+      state,
+      action,
+      CARD_SHOGI_VARIANT,
+      true,
+    );
+    // board 駒配置は一致 (どちらも金が (1,4) へ)。status / 評価値が既知 divergence。
+    expect(on!.gameState.board[1][4]).toEqual(pc("gold", "sente"));
+    expect(off!.gameState.board[1][4]).toEqual(pc("gold", "sente"));
+    expect(off!.gameState.status).toBe("active"); // OFF は game-end 非評価
+    expect(on!.gameState.status).toBe("checkmate"); // ON は evaluateGameEnd で終局検出
+    expect(on!.gameState.winner).toBe("sente");
+    // evaluate: ON は mate score ±100000、OFF は material 評価 (mate 未満)。
+    expect(evaluate(on!.gameState, CARD_SHOGI_VARIANT)).toBe(100000);
+    expect(evaluate(off!.gameState, CARD_SHOGI_VARIANT)).toBeLessThan(100000);
+  });
+
+  it("double_move 1手目 mate: ON super-action は終局 (turnEnded=true) 分岐で mate score を採用", () => {
+    // 1手目で詰む double_move。捕獲手で mate を構成し scoreMoveForOrdering 上位 (DOUBLE_MOVE_TOP_K=10) を保証。
+    // 後手玉(0,0)、後手歩(1,1) を先手金(2,1)が捕獲して詰み (先手香(8,1)が (1,1) を支える)、先手玉(8,8)。
+    const place = (b: Board) => {
+      b[0][0] = pc("king", "gote");
+      b[1][1] = pc("pawn", "gote"); // 捕獲対象 (capture move → 上位 ordering)
+      b[2][1] = pc("gold", "sente");
+      b[8][1] = pc("lance", "sente"); // (1,1) を縦に支える
+      b[8][8] = pc("king", "sente");
+    };
+    const dmCard: CardInstance = { instanceId: "s-dm-1", defId: "double_move" };
+    const cs = () =>
+      minimalCardState({
+        mana: { sente: 8, gote: 8 },
+        hand: { sente: [dmCard], gote: [] },
+      });
+    const action: TurnAction = {
+      kind: "playCard",
+      cardInstanceId: dmCard.instanceId,
+      defId: "double_move",
+    };
+
+    const ctxOn = createSearchContext({
+      timeLimitMs: 1000,
+      useKernelSearch: true,
+      spectatorMode: true,
+    });
+    const state = aiState(buildGameState(place, "sente"), cs());
+    const scoreOn = evaluateActionWithLookahead(
+      state,
+      action,
+      "sente",
+      CARD_SHOGI_VARIANT,
+      ctxOn,
+      false,
+      1,
+    );
+    // 1手目で詰めば kernel が turnEnded=true で finalize し、その局面 (status=checkmate) を評価 → mate score。
+    expect(scoreOn).toBe(100000);
+  });
+});
+
+// ===== seeded harness: card/draw アクションの board 駒配置不変性 =====
+// 旧コード無改変の OFF と ON で、draw/trap/modifyBoard の board 駒配置が常に一致することを
+// 複数局面で確認 (本 harness は move を除外。move は trap 非発火を「ON 是正 divergence」describe の
+// trap 発火 move ケースで OFF/ON 乖離を、trap 非発火を targeted の move ケースで一致を、それぞれ pin 済)。
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("S1b: seeded harness — card/draw の board 駒配置は OFF/ON 一致", () => {
+  it("複数 seed × カード手札構成で board 駒配置不変 + cardState 差分は既知次元のみ", () => {
+    const ALL_DEFS = [
+      "pawn_return",
+      "piece_return",
+      "double_pawn",
+      "no_promote",
+      "check_break",
+    ] as const;
+    for (let seed = 1; seed <= 40; seed++) {
+      const rng = mulberry32(seed * 2654435761);
+      // 先手に複数種カードを持たせ、盤上に歩・銀を配置 (modifyBoard 対象)。
+      const hand: CardInstance[] = ALL_DEFS.map((defId, i) => ({
+        instanceId: `s-${defId}-${i}`,
+        defId,
+      }));
+      const drawProgress = { sente: seed % 5, gote: 0 };
+      const place = (b: Board) => {
+        b[0][0] = pc("king", "gote");
+        b[8][8] = pc("king", "sente");
+        b[6][4] = pc("pawn", "sente");
+        b[6][2] = pc("pawn", "sente");
+        b[7][1] = pc("silver", "sente");
+      };
+      const handPawnForDoublePawn = {
+        sente: { pawn: 1 } as Record<string, number>,
+        gote: {} as Record<string, number>,
+      };
+      const cs = (): CardGameState =>
+        minimalCardState({
+          mana: { sente: 12, gote: 12 },
+          hand: { sente: hand.map((c) => ({ ...c })), gote: [] },
+          deck: {
+            sente: [
+              { instanceId: "s-deck-1", defId: "pawn_return" },
+              { instanceId: "s-deck-2", defId: "double_pawn" },
+            ],
+            gote: [],
+          },
+          drawProgress: { ...drawProgress },
+        });
+      const gs = () => {
+        const g = buildGameState(place, "sente");
+        g.hand = handPawnForDoublePawn; // double_pawn の持ち駒歩
+        return g;
+      };
+      const state = aiState(gs(), cs());
+
+      // 全カードアクション (double_move 以外) を列挙して比較。
+      const cardActions = [
+        ...getCardActions(state, "sente", CARD_SHOGI_VARIANT),
+      ].filter((a) => !(a.kind === "playCard" && a.defId === "double_move"));
+      // draw も含める。
+      const actions: TurnAction[] = [...cardActions, { kind: "draw" }];
+      // seeded に最大 8 アクションをサンプル (全件でもよいが時間短縮)。
+      const sample =
+        actions.length > 8
+          ? [...actions].sort(() => rng() - 0.5).slice(0, 8)
+          : actions;
+
+      for (const action of sample) {
+        const off = applyActionForLookahead(state, action, "sente");
+        const on = applyTurnActionForLookahead(
+          state,
+          action,
+          CARD_SHOGI_VARIANT,
+          true,
+        );
+        if (!off || !on) continue; // 両者 null は同条件 (mana 不足等) でスキップ
+        // board 駒配置 (盤 + 取り駒) は OFF/ON で常に一致 (draw/trap=不変、modifyBoard=同 effect fn)。
+        expect(on.gameState.board).toEqual(off.gameState.board);
+        expect(on.gameState.hand).toEqual(off.gameState.hand);
+        // cardState の mana は trap/modifyBoard/draw では一致 (move のみ ON は manaCharge、ここは move 除外)。
+        expect(on.cardState.mana.sente).toBe(off.cardState.mana.sente);
+        // drawProgress は境界未満で一致、境界 (=4) では ON が reset しうる (既知 divergence)。
+        if (state.cardState.drawProgress.sente < 4) {
+          expect(on.cardState.drawProgress.sente).toBe(
+            off.cardState.drawProgress.sente,
+          );
+        }
+      }
+    }
+  });
+});

--- a/src/lib/shogi/ai/__tests__/perf-bench-card-usage.test.ts
+++ b/src/lib/shogi/ai/__tests__/perf-bench-card-usage.test.ts
@@ -187,7 +187,15 @@ function makeScenarios(): BenchScenario[] {
 describe.skipIf(!RUN_PERF_BENCH)(
   "perf-bench card 使用率 (PR3-3 calibration discriminator)",
   () => {
-    const difficulties: Difficulty[] = ["beginner", "advanced", "expert"];
+    // Issue #235 S0: before-baseline で全4難易度のカード使用率を測るため intermediate を追加。
+    // 設計 doc §8.2「全4難易度 = 中級含む」/ PR3-3-2 レビュー「中級未測定」の是正。
+    // intermediate は telemetry のみ (cardCount>=1 の sanity assert は全難易度共通)。
+    const difficulties: Difficulty[] = [
+      "beginner",
+      "intermediate",
+      "advanced",
+      "expert",
+    ];
     const scenarios = makeScenarios();
 
     for (const difficulty of difficulties) {

--- a/src/lib/shogi/ai/__tests__/perf-bench-kernel-search.test.ts
+++ b/src/lib/shogi/ai/__tests__/perf-bench-kernel-search.test.ts
@@ -1,0 +1,164 @@
+// Issue #235 S1b: useKernelSearch OFF vs ON の bench 比較 (計画 §5 S1b-5)。
+//
+// 目的: AI root カード/ドロー評価を kernel applyTurnAction 経由 (ON) に切替えたときの
+//   ① root カード評価フェーズの overhead (= 全体 elapsedMs の OFF/ON 差。findBestMove は
+//      move-only で本変更の影響を受けないため、差分が概ね root カード評価フェーズの増分)、
+//   ② カード使用率 (usedCardAction) の変化 (DP-1 lazy drawProgress / manaCharge / cost 正確消費
+//      / 終局 mate score の是正がアクション選択に与える影響)
+//   を測定・記録する。ユーザー確認済 (2026-06-07): 逸脱は記録に留め、係数再校正は S3。
+//
+// 実行: npm run test:ci -- perf-bench-kernel-search でも skip。RUN_PERF_BENCH=true で起動:
+//   RUN_PERF_BENCH=true npx vitest run src/lib/shogi/ai/__tests__/perf-bench-kernel-search.test.ts
+//
+// 公平性 (計画 F-6):
+//   - maxDepth 固定 → depthCompleted は CPU 非依存で OFF/ON 同値 (findBestMove 非改変の sanity)。
+//   - spectator=true → ON の makeMoveWithEffects manaCharge を早指し非依存 (決定的) + beginner の
+//     Math.random ノイズを避けるため難易度は advanced/expert のみ。
+
+import { describe, test, expect } from "vitest";
+import { findBestMoveWithStats } from "../engine";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { createInitialGameState, applyMove } from "@/lib/shogi/board";
+import { MANA_CAP } from "@/lib/shogi/cards/definitions";
+import type { Difficulty, GameState, Move, Player } from "@/lib/shogi/types";
+import type { CardGameState, CardId, CardInstance } from "@/lib/shogi/cards/types";
+
+const RUN_PERF_BENCH = process.env.RUN_PERF_BENCH === "true";
+
+function instances(defIds: CardId[], prefix: string): CardInstance[] {
+  return defIds.map((defId, i) => ({ instanceId: `${prefix}-${defId}-${i}`, defId }));
+}
+
+function cardState(over: Partial<CardGameState> = {}): CardGameState {
+  return {
+    mana: { sente: 14, gote: 14 },
+    manaCap: MANA_CAP,
+    hand: { sente: [], gote: [] },
+    deck: { sente: [], gote: [] },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: null, gote: null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    drawProgress: { sente: 0, gote: 0 },
+    ...over,
+  };
+}
+
+// 初手をいくつか進めた midgame 風局面を作る (決定的な手列)。
+function playMoves(state: GameState, moves: Move[]): GameState {
+  let s = state;
+  for (const m of moves) s = applyMove(s, m);
+  return s;
+}
+
+interface Scenario {
+  label: string;
+  state: GameState;
+  player: Player;
+  cardState: CardGameState;
+}
+
+function makeScenarios(): Scenario[] {
+  const init = createInitialGameState(CARD_SHOGI_VARIANT);
+  // 数手進めた局面 (先手番) を 1 つ用意。
+  const midMoves: Move[] = [
+    { type: "move", from: { row: 6, col: 6 }, to: { row: 5, col: 6 }, piece: "pawn", player: "sente" },
+    { type: "move", from: { row: 2, col: 2 }, to: { row: 3, col: 2 }, piece: "pawn", player: "gote" },
+  ];
+  const mid = playMoves(init, midMoves); // currentPlayer = sente
+
+  const fullHand: CardId[] = ["pawn_return", "piece_return", "double_pawn", "no_promote", "check_break", "double_move"];
+
+  return [
+    {
+      label: "init_fullhand",
+      state: init,
+      player: "sente",
+      cardState: cardState({ hand: { sente: instances(fullHand, "s"), gote: instances(fullHand, "g") } }),
+    },
+    {
+      label: "mid_fullhand",
+      state: mid,
+      player: "sente",
+      cardState: cardState({ hand: { sente: instances(fullHand, "s"), gote: instances(fullHand, "g") } }),
+    },
+    {
+      label: "mid_traps",
+      state: mid,
+      player: "sente",
+      cardState: cardState({ hand: { sente: instances(["check_break", "no_promote", "pawn_return"], "s"), gote: [] } }),
+    },
+    {
+      label: "mid_drawboundary",
+      state: mid,
+      player: "sente",
+      cardState: cardState({
+        hand: { sente: instances(["pawn_return", "double_move"], "s"), gote: [] },
+        deck: { sente: instances(["pawn_return", "double_pawn", "piece_return"], "sd"), gote: [] },
+        drawProgress: { sente: 4, gote: 0 }, // auto-draw 境界
+      }),
+    },
+  ];
+}
+
+describe.skipIf(!RUN_PERF_BENCH)("perf-bench: useKernelSearch OFF vs ON", () => {
+  const difficulties: Difficulty[] = ["advanced", "expert"];
+  const scenarios = makeScenarios();
+  const MAX_DEPTH = 4; // 決定的 depth (CPU 非依存)。
+
+  for (const difficulty of difficulties) {
+    test(
+      `${difficulty}: OFF/ON の elapsedMs・depthCompleted・カード使用率を測定`,
+      () => {
+        let offCardCount = 0;
+        let onCardCount = 0;
+        const rows: string[] = [];
+        for (const sc of scenarios) {
+          const optsBase = {
+            cardState: sc.cardState,
+            spectator: true,
+            maxDepth: MAX_DEPTH,
+          } as const;
+
+          const t0 = performance.now();
+          const off = findBestMoveWithStats(sc.state, sc.player, difficulty, CARD_SHOGI_VARIANT, {
+            ...optsBase,
+            useKernelSearch: false,
+          });
+          const tOff = performance.now() - t0;
+
+          const t1 = performance.now();
+          const on = findBestMoveWithStats(sc.state, sc.player, difficulty, CARD_SHOGI_VARIANT, {
+            ...optsBase,
+            useKernelSearch: true,
+          });
+          const tOn = performance.now() - t1;
+
+          const offKind = off.action?.kind === "playCard" ? `card(${off.action.defId})` : off.action?.kind ?? "none";
+          const onKind = on.action?.kind === "playCard" ? `card(${on.action.defId})` : on.action?.kind ?? "none";
+          if (off.stats.usedCardAction) offCardCount++;
+          if (on.stats.usedCardAction) onCardCount++;
+
+          rows.push(
+            `${sc.label}: OFF=${offKind}/d${off.stats.depthCompleted}/${tOff.toFixed(0)}ms ` +
+              `ON=${onKind}/d${on.stats.depthCompleted}/${tOn.toFixed(0)}ms`,
+          );
+
+          // sanity: 両者とも合法アクションを返す。
+          expect(off.action).not.toBeNull();
+          expect(on.action).not.toBeNull();
+          // F-4: depthCompleted は findBestMove (move-only、本変更非影響) が決めるため OFF/ON 同値
+          // (maxDepth 固定で CPU 非依存)。kernel 切替が深い探索に影響しないことの sanity。
+          expect(on.stats.depthCompleted).toBe(off.stats.depthCompleted);
+        }
+        console.log(
+          `[kernel-search] ${difficulty}: cardRate OFF=${offCardCount}/${scenarios.length} ` +
+            `ON=${onCardCount}/${scenarios.length}\n  ` +
+            rows.join("\n  "),
+        );
+      },
+      60_000,
+    );
+  }
+});

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -140,6 +140,10 @@ export interface FindBestMoveOptions {
   // 指定時かつ variant.id === "card-shogi" のとき、findBestMoveWithStats 内で root で 1 回
   // computeCardDigest を呼び、cardDigest を引数として evaluate に伝播する (W-1 root スカラー方式)。
   cardState?: CardGameState;
+  // Issue #235 S1b: AI root カード/ドロー評価を L0 カーネル applyTurnAction 経由に切替えるフラグ。
+  // 未指定時 false (= 旧経路、production 完全不変)。test/bench から ON にして OFF と比較する。
+  // production (route.ts) は S1d cutover まで本フラグを渡さない (= 常に OFF)。
+  useKernelSearch?: boolean;
 }
 
 export interface FindBestMoveResult {
@@ -194,6 +198,10 @@ export function findBestMoveWithStats(
     timeLimitMs: effectiveTimeLimitMs,
     signal: options.signal,
     cardDigest,
+    // Issue #235 S1b: kernel 経路フラグ (既定 OFF) と spectatorMode を ctx に伝播。
+    // root カード/ドロー評価 (evaluateActionWithLookahead / searchDoubleMoveSuperAction) が ctx 経由で読む。
+    useKernelSearch: options.useKernelSearch ?? false,
+    spectatorMode: options.spectator ?? false,
   });
 
   // 定石ブック (序盤のみ)。

--- a/src/lib/shogi/ai/search-context.ts
+++ b/src/lib/shogi/ai/search-context.ts
@@ -53,12 +53,24 @@ export interface SearchContext {
   // byte-level equality を維持)。指定時は quiescence / negamax 内の evaluate 呼出にそのまま渡す
   // (= ホットパスでの再計算を構造的に禁止)。
   cardDigest?: CardDigest;
+  // Issue #235 S1b: AI root カード/ドロー評価を L0 カーネル applyTurnAction 経由に切替えるフラグ。
+  // 既定 false (= 旧経路 applyActionForLookahead / 手動 wiring を使う = production 完全不変)。
+  // true のとき evaluateActionWithLookahead / searchDoubleMoveSuperAction が kernel 経路に分岐する
+  // (card-shogi のみ、DP-1〜7 を自動適用)。S1d cutover まで production は false 固定。
+  useKernelSearch?: boolean;
+  // Issue #235 S1b: kernel applyTurnAction へ渡す spectatorMode (DP-4 決定論化、早指し無効)。
+  // 既定 false。AI 探索の lookahead は手番時間を持たないため manaCharge の早指し判定は
+  // 本来不要だが、kernel の makeMoveWithEffects に正しく伝播するため保持する。
+  spectatorMode?: boolean;
 }
 
 export interface CreateSearchContextOptions {
   timeLimitMs: number;
   signal?: AbortSignal;
   cardDigest?: CardDigest;
+  // Issue #235 S1b: 下記 2 フラグ。既定 false (= 既存挙動完全保持)。
+  useKernelSearch?: boolean;
+  spectatorMode?: boolean;
 }
 
 export function createSearchContext(opts: CreateSearchContextOptions): SearchContext {
@@ -75,6 +87,8 @@ export function createSearchContext(opts: CreateSearchContextOptions): SearchCon
     killerMoves: Array.from({ length: MAX_DEPTH }, () => [null, null] as [Move | null, Move | null]),
     historyTable: Array.from({ length: 81 }, () => new Array<number>(81).fill(0)),
     cardDigest: opts.cardDigest,
+    useKernelSearch: opts.useKernelSearch ?? false,
+    spectatorMode: opts.spectatorMode ?? false,
   };
 }
 

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -969,7 +969,11 @@ function searchDoubleMoveSuperActionKernel(
   ctx: SearchContext,
   excludeTadasute: boolean,
 ): number {
-  const spectatorMode = ctx.spectatorMode ?? false;
+  // Issue #235 S1d (decision i): AI 探索は仮想局面の評価であり、wall-clock 早指しボーナス
+  // (時刻依存) は探索の意味論上無意味かつ非決定的。kernel lookahead は常に spectatorMode=true で
+  // 呼び決定論化する (OFF 近似 applyActionForLookahead が move に mana ボーナスを付けないことと整合)。
+  // ctx.spectatorMode はゲームレベルの観戦判定であり、探索 lookahead の決定論化とは別概念として分離する。
+  const spectatorMode = true;
 
   // 計画 OBS3-2: double_move カードが手札にあることを実 lookup で確認 (候補生成で除外済の前提)。
   // 未発見なら NEG_INF (?? "" 空文字 fallback は kernel consumeNormalCard を null 化し OFF と
@@ -1280,8 +1284,10 @@ export function evaluateActionWithLookahead(
     return searchDoubleMoveSuperAction(state, player, variant, ctx, excludeTadasute);
   }
   // Issue #235 S1b: useKernelSearch ON で kernel 経路 (applyTurnAction) に分岐。OFF は旧近似のまま。
+  // Issue #235 S1d (decision i): 探索 lookahead は常に決定論化 (spectatorMode=true)。仮想局面評価では
+  // wall-clock 早指しボーナスは無意味かつ非決定のため game-level spectatorMode に依存させない。
   const applied = ctx?.useKernelSearch
-    ? applyTurnActionForLookahead(state, action, variant, ctx.spectatorMode ?? false)
+    ? applyTurnActionForLookahead(state, action, variant, true)
     : applyActionForLookahead(state, action, player);
   if (!applied) return Number.NEGATIVE_INFINITY;
 

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -18,6 +18,8 @@ import { CurrentRules } from "./turn/current-rules";
 import type { AiTurnState, TurnAction } from "./turn/types";
 import type { CardGameState } from "../cards/types";
 import { CARD_DEFS, DRAW_COST } from "../cards/definitions";
+// Issue #235 S1b: AI root カード/ドロー評価を useKernelSearch フラグ裏で L0 カーネル経由に切替える。
+import { applyTurnAction, type WorldState } from "../kernel/world-kernel";
 import {
   type CardDigest,
   computeCardDigest,
@@ -838,6 +840,12 @@ function searchDoubleMoveSuperAction(
   ctx?: SearchContext,
   excludeTadasute = false,
 ): number {
+  // Issue #235 S1b: useKernelSearch ON で kernel 連鎖 (applyTurnAction) 経路へ分岐。
+  // OFF は以下の旧実装 (CurrentRules.applyAction + 手動 wiring) を完全保持 = バイト等価。
+  if (ctx?.useKernelSearch) {
+    return searchDoubleMoveSuperActionKernel(state, player, variant, ctx, excludeTadasute);
+  }
+
   const rules = new CurrentRules(variant);
 
   // Step 1: double_move カード適用 (doubleMove フラグ ON、turnEnded=false)
@@ -949,6 +957,101 @@ function searchDoubleMoveSuperAction(
   return bestScore;
 }
 
+// Issue #235 S1b: searchDoubleMoveSuperAction の useKernelSearch ON 版。
+// double_move を L0 カーネル applyTurnAction の連鎖 (playCard → move → move) で評価し、
+// cost 正確消費 (hand→graveyard) / lazy drawProgress / flip 抑止を kernel が一元処理する
+// (OFF の手動 wiring 近似を解消、DP-2/DP-1 適用)。OFF 版と同じ構造 (TOP_K 絞り・excludeTadasute・
+// bestScoreIgnoringTadasute フォールバック) を維持し、状態遷移のみ kernel に置換する。
+function searchDoubleMoveSuperActionKernel(
+  state: AiTurnState,
+  player: Player,
+  variant: RuleVariant,
+  ctx: SearchContext,
+  excludeTadasute: boolean,
+): number {
+  const spectatorMode = ctx.spectatorMode ?? false;
+
+  // 計画 OBS3-2: double_move カードが手札にあることを実 lookup で確認 (候補生成で除外済の前提)。
+  // 未発見なら NEG_INF (?? "" 空文字 fallback は kernel consumeNormalCard を null 化し OFF と
+  // 非対称になるため使わない)。
+  const dmCard = state.cardState.hand[player].find((c) => c.defId === "double_move");
+  if (!dmCard) return NEG_INF;
+
+  const world0 = aiTurnStateToWorldState(state); // root: doubleMove = null
+  // Step 1: double_move 発動 (kernel が KernelDoubleMove を cardInstanceId + cost から構築、遅延消費)
+  const worldDM = applyTurnAction(
+    world0,
+    { kind: "playCard", cardInstanceId: dmCard.instanceId, defId: "double_move" },
+    { spectatorMode },
+  ).world;
+
+  // digest prev (root)。ctx 未渡フォールバックは OFF 版 (computeCardDigest) と同方針。
+  const prevDigest =
+    ctx.cardDigest ??
+    (variant.id === "card-shogi" ? computeCardDigest(state.cardState) : undefined);
+
+  // Step 2: 1 手目候補生成 (move-only)。OFF 同様 heuristic 上位 K 手に絞る。
+  const firstMovesAll = getSearchLegalMoves(worldDM.gameState, player, variant);
+  if (firstMovesAll.length === 0) return NEG_INF;
+  const firstMoves =
+    firstMovesAll.length > DOUBLE_MOVE_TOP_K
+      ? [...firstMovesAll]
+          .sort((a, b) => scoreMoveForOrdering(b) - scoreMoveForOrdering(a))
+          .slice(0, DOUBLE_MOVE_TOP_K)
+      : firstMovesAll;
+
+  let bestScore = NEG_INF;
+  let bestScoreIgnoringTadasute = NEG_INF;
+
+  for (const firstMove of firstMoves) {
+    const afterFirst = applyTurnAction(worldDM, { kind: "move", move: firstMove }, { spectatorMode });
+    const worldF = afterFirst.world;
+
+    // 計画 R3/OBS3-1: 1 手目で終局 (mate 等) なら kernel が gameOver 分岐で turnEnded=true +
+    // finalize 済 (world-kernel.ts:258-274)。その局面を直接評価し 2 手目ループを skip
+    // (OFF の CurrentRules.applyAction は game-end 評価せず turnEnded=false で続行する非対称、ON 是正)。
+    if (afterFirst.turnEnded) {
+      const innerDigest =
+        prevDigest !== undefined
+          ? updateCardDigest(prevDigest, state.cardState, worldF.cardState)
+          : undefined;
+      const raw = evaluate(worldF.gameState, variant, innerDigest);
+      const score = player === "sente" ? raw : -raw;
+      if (score > bestScoreIgnoringTadasute) bestScoreIgnoringTadasute = score;
+      // 1 手目詰みは「タダ捨て」ではないので excludeTadasute に関わらず採用候補。
+      if (score > bestScore) bestScore = score;
+      continue;
+    }
+
+    const secondMoves = getSearchLegalMoves(worldF.gameState, player, variant);
+    if (secondMoves.length === 0) continue;
+    for (const secondMove of secondMoves) {
+      const afterSecond = applyTurnAction(worldF, { kind: "move", move: secondMove }, { spectatorMode });
+      const worldS = afterSecond.world;
+      // 不変条件: 2 手目で turnEnded=true (ターン終了)。
+      if (!afterSecond.turnEnded) {
+        throw new Error(
+          "Invariant violation: double_move 2 手目で turnEnded が false (kernel 経路)",
+        );
+      }
+      // per-combo digest (kernel の worldS.cardState = cost 正確消費 + lazy drawProgress 反映済)。
+      const innerDigest =
+        prevDigest !== undefined
+          ? updateCardDigest(prevDigest, state.cardState, worldS.cardState)
+          : undefined;
+      const raw = evaluate(worldS.gameState, variant, innerDigest);
+      const score = player === "sente" ? raw : -raw;
+      if (score > bestScoreIgnoringTadasute) bestScoreIgnoringTadasute = score;
+      if (excludeTadasute && hasHangingPiece(worldS.gameState, player, variant)) {
+        continue;
+      }
+      if (score > bestScore) bestScore = score;
+    }
+  }
+  if (bestScore === NEG_INF) return bestScoreIgnoringTadasute;
+  return bestScore;
+}
+
 // =========================================================================
 // PR3-3a: TurnAction lookahead 評価 (= 相手 1 ply 最善応答後のスコア)
 // =========================================================================
@@ -997,7 +1100,9 @@ function searchDoubleMoveSuperAction(
  * applyTurnEndEffects は呼ばれるため +=1 が必要。3 種すべてで +1 統一することで
  * action 間の比較対称性を確保 (production-equivalent な post-action state)。
  */
-function applyActionForLookahead(
+// Issue #235 S1b: OFF-vs-ON 特性化テスト (kernel-search-equivalence.test.ts) から直接比較するため export。
+// production の呼出経路・振る舞いは不変 (export 付与のみ)。
+export function applyActionForLookahead(
   state: AiTurnState,
   action: TurnAction,
   player: Player,
@@ -1088,6 +1193,51 @@ function applyActionForLookahead(
   return { gameState: nextGameState, cardState: baseCardState };
 }
 
+// =========================================================================
+// Issue #235 S1b: useKernelSearch ON 経路の変換ヘルパ
+// =========================================================================
+// applyActionForLookahead (上、OFF 近似) の kernel 版。useKernelSearch フラグが ON のとき
+// evaluateActionWithLookahead が本関数を呼び、L0 カーネル applyTurnAction で正確な遷移を得る。
+// OFF との差分は docs/plans/issue-235-s1b-ai-wiring.md §3 (すべて「ON が production 等価」方向)。
+// 戻り値型は applyActionForLookahead と同一 ({gameState, cardState}) = 後段 updateCardDigest /
+// getOpponentResponseScore に無改変で流れる (events は AI 評価で不要のため捨象)。
+
+// AiTurnState → WorldState 変換 (純粋)。doubleMove は optional な cardInstance/cardCost を
+// kernel 必須型へ narrowing (S1b 経路では root doubleMove=null のため fallback は保険)。
+// Issue #235 S1b: 特性化テストから比較するため export (純粋関数)。
+export function aiTurnStateToWorldState(state: AiTurnState): WorldState {
+  const dm = state.doubleMove;
+  return {
+    gameState: state.gameState,
+    cardState: state.cardState,
+    doubleMove:
+      dm === null
+        ? null
+        : {
+            active: dm.active,
+            movesLeft: dm.movesLeft,
+            cardInstance: dm.cardInstance ?? { instanceId: "", defId: "double_move" },
+            cardCost: dm.cardCost ?? CARD_DEFS["double_move"].cost,
+          },
+  };
+}
+
+// Issue #235 S1b: 特性化テストから OFF (applyActionForLookahead) と比較するため export。
+export function applyTurnActionForLookahead(
+  state: AiTurnState,
+  action: TurnAction,
+  variant: RuleVariant,
+  spectatorMode: boolean,
+): { gameState: GameState; cardState: CardGameState } | null {
+  // standard variant は kernel 非経由 (防御的二重ガード、計画 R6)。
+  if (variant.id !== "card-shogi") return null;
+  // double_move は searchDoubleMoveSuperAction に delegate (呼出側で分岐済、ここは保険)。
+  if (action.kind === "playCard" && action.defId === "double_move") return null;
+  const world = aiTurnStateToWorldState(state);
+  const result = applyTurnAction(world, action, { spectatorMode });
+  return { gameState: result.world.gameState, cardState: result.world.cardState };
+}
+
 function getOpponentResponseScore(
   stateAfterOurAction: GameState,
   ourPlayer: Player,
@@ -1129,7 +1279,10 @@ export function evaluateActionWithLookahead(
   if (action.kind === "playCard" && action.defId === "double_move") {
     return searchDoubleMoveSuperAction(state, player, variant, ctx, excludeTadasute);
   }
-  const applied = applyActionForLookahead(state, action, player);
+  // Issue #235 S1b: useKernelSearch ON で kernel 経路 (applyTurnAction) に分岐。OFF は旧近似のまま。
+  const applied = ctx?.useKernelSearch
+    ? applyTurnActionForLookahead(state, action, variant, ctx.spectatorMode ?? false)
+    : applyActionForLookahead(state, action, player);
   if (!applied) return Number.NEGATIVE_INFINITY;
 
   // 通常カードのタダ捨て除外 (action 適用後の盤面で判定、既存 evaluateAction 同型)

--- a/src/lib/shogi/ai/turn/types.ts
+++ b/src/lib/shogi/ai/turn/types.ts
@@ -9,7 +9,7 @@
 // 最後に必ず駒1手」のように move を含むまでターン継続する形に切替えられる。
 // TurnRules.isTurnTerminating の実装差替だけでルール変更耐性を担保する。
 
-import type { CardGameState, CardId, CardTarget, GameEvent } from "@/lib/shogi/cards/types";
+import type { CardGameState, CardId, CardInstance, CardTarget, GameEvent } from "@/lib/shogi/cards/types";
 import type { GameState, Move, Player } from "@/lib/shogi/types";
 
 // AI 探索内で扱う統一行動型。
@@ -31,12 +31,19 @@ export type TurnAction =
 //   DrawAction / PlayCardAction 候補を root のみで含める制御に使う。
 //   未指定時は false 扱い (= 子ノード)。本フィールドの実際の有効化は PR1d-2 で
 //   search.ts/findBestMove root 経路から getLegalActions を呼ぶ統合時に行う。
+// - doubleMove.cardInstance/cardCost: Issue #235 S1b で追加 (optional)。L0 カーネル
+//   KernelDoubleMove (world-kernel.ts) と橋渡しするための遅延消費パラメータ。OFF 経路
+//   (current-rules.ts の doubleMove 生成) は本フィールドを省略 (= 既存挙動・既存テスト・
+//   toEqual 完全保持)。ON 経路 (useKernelSearch) は aiTurnStateToWorldState の変換で
+//   未指定時に CARD_DEFS から fallback 補完する。詳細は docs/plans/issue-235-s1b-ai-wiring.md §4。
 export interface AiTurnState {
   gameState: GameState;
   cardState: CardGameState;
   doubleMove: {
     active: Player;
     movesLeft: 1 | 2;
+    cardInstance?: CardInstance;
+    cardCost?: number;
   } | null;
   isRoot?: boolean;
 }

--- a/src/lib/shogi/kernel/__tests__/world-kernel-equivalence.test.ts
+++ b/src/lib/shogi/kernel/__tests__/world-kernel-equivalence.test.ts
@@ -1,0 +1,1211 @@
+// Issue #235 S1a (part2): world-kernel.ts の applyTurnAction が reducer 経路と振る舞い等価で
+// あることを検証する property-based 等価テスト。
+//
+// 位置づけ (S1 計画 docs/plans/issue-235-s1-kernel.md §7 / epic §8.3.4):
+//   S1a part1 で新設した applyTurnAction (production 未配線) の唯一の正当性検証。これが green に
+//   なるまで applyTurnAction は「未検証・production 未配線」扱い。S1a は additive のみのため、
+//   reducer は完全不変 = 本テストは「既存 reducer 経路 vs 新カーネル経路」の独立2実装の等価検証
+//   (= 委譲で自明ではなく真の regression guard。flip / turn-end / finalize 合成の orchestration 差を検出)。
+//
+// 方式 (依存追加なし):
+//   - fast-check は使わず、hand-rolled seeded PRNG (mulberry32) + 手書き generator で完結 (AGENTS.md §7)。
+//   - seeded WorldState から各ステップで合法 TurnAction を seeded PRNG で 1 つ選び、reducer (dispatch 駆動)
+//     と applyTurnAction の両方へ同一 action を適用し、§8.3.1 の must-match 12 射影を deep-equal 比較。
+//
+// 決定論化 (DP-4):
+//   - spectatorMode=true 固定 → 早指しボーナス無効 (fastMove=false 確定) で mana 増分が決定的。
+//   - event の `at` (Date.now()) と manaChargeEvent は射影から除外するため Date.now stub は不要。
+//
+// 射影 (must-match):
+//   - gameState 全体 (board 駒種/owner/promoted + 取り駒 hand + currentPlayer + status + winner +
+//     moveCount + moveHistory + positionHistory = zobrist 相当を包含) を deep-equal。
+//   - cardState の {mana, manaCap, hand[順序], deck[順序], graveyard[順序], trap, noPromoteMarks[{row,col}集合 DP-5],
+//     drawProgress}。must-not-match (pendingCard / lastTurnStartedAt / 演出flag / UI / undoSnapshots) は捨象。
+//   - events (kind + ドメインフィールド、`at` 除外・manaChargeEvent 除外 DP-4)。
+//
+// 王手中のカード/ドロー使用は本ランダム harness では生成しない (王手中 card は reducer 側で
+// 「BEGIN 通過後 CONFIRM 最終ガードで no-op (pendingCard 残置)」など中間状態が絡み、射影は一致するが
+// 生成器の決定性確保が煩雑なため)。王手回避以外のカードはそもそも reducer が拒否する。王手中 double_move
+// (checkUsage="unconditional") の等価は末尾 targeted describe で固定盤面により別途 pin する。
+//
+// 終局 (status≠active) 系の合成分岐 (advanceDrawProgress の status guard / double_move 1手目詰みの即
+// finalize) と DP-5×カード (removeNoPromoteMark) / DP-7 (check_break defer→2手目発火) も、ランダム
+// harness が現実的に到達しないため末尾 targeted describe で固定盤面により pin する (実装後レビュー反映)。
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyMove,
+  createInitialGameState,
+  serializePosition,
+} from "@/lib/shogi/board";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { getFullLegalMoves, isCheckmate, isInCheck } from "@/lib/shogi/moves";
+import { MANA_CAP } from "@/lib/shogi/cards/definitions";
+import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
+import { getCardActions } from "@/lib/shogi/ai/turn/action-generator";
+import { canDraw } from "@/lib/shogi/ai/turn/current-rules";
+import type { TurnAction, AiTurnState } from "@/lib/shogi/ai/turn/types";
+import type {
+  Board,
+  GameState,
+  Move,
+  PieceType,
+  Player,
+} from "@/lib/shogi/types";
+import type {
+  CardGameState,
+  CardId,
+  CardInstance,
+  GameEvent,
+  TrapInstance,
+} from "@/lib/shogi/cards/types";
+
+import {
+  reducer,
+  type Action,
+  type CardShogiGameStateInternal,
+} from "@/hooks/card-shogi/reducer";
+import { applyTurnAction, type WorldState } from "../world-kernel";
+
+// ===== seeded PRNG (Mulberry32、scripts/utils/prng.ts と同一実装をインライン) =====
+// 外部依存・cross-boundary import を避けるため 10 行をインライン化する (AGENTS.md §7)。
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, items: readonly T[]): T {
+  return items[Math.floor(rng() * items.length)];
+}
+
+// ===== 決定論的な初期 CardGameState 構築 =====
+// createInitialCardState は Math.random でシャッフルするため非決定的。seed 駆動で同一の山札/手札を
+// 2 回構築できる自前 builder を使う (reducer 経路・カーネル経路それぞれに独立コピーを渡す)。
+
+// mana_up (deprecated) を除く全カードを混ぜたデッキ構成。double_move / トラップ / modifyBoard を網羅。
+const DECK_SPEC: ReadonlyArray<{ defId: CardId; count: number }> = [
+  { defId: "pawn_return", count: 2 },
+  { defId: "piece_return", count: 1 },
+  { defId: "no_promote", count: 2 },
+  { defId: "check_break", count: 2 },
+  { defId: "double_move", count: 3 },
+  { defId: "double_pawn", count: 1 },
+];
+
+function buildDeckDeterministic(
+  player: Player,
+  rng: () => number,
+): CardInstance[] {
+  const cards: CardInstance[] = [];
+  let counter = 0;
+  for (const { defId, count } of DECK_SPEC) {
+    for (let i = 0; i < count; i++) {
+      counter++;
+      cards.push({ instanceId: `${player}-${defId}-${counter}`, defId });
+    }
+  }
+  // seeded Fisher-Yates
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [cards[i], cards[j]] = [cards[j], cards[i]];
+  }
+  return cards;
+}
+
+function buildCardState(seed: number): CardGameState {
+  const rng = mulberry32(seed);
+  const senteDeck = buildDeckDeterministic("sente", rng);
+  const goteDeck = buildDeckDeterministic("gote", rng);
+  const senteHand = senteDeck.splice(0, 2);
+  const goteHand = goteDeck.splice(0, 2);
+  // カード経路を厚く踏むため初期マナを高めに振る (double_move=5 を即使用できる水準)。
+  const baseMana = Math.min(8 + (seed % 11), MANA_CAP);
+  return {
+    mana: { sente: baseMana, gote: Math.min(baseMana + 1, MANA_CAP) },
+    manaCap: MANA_CAP,
+    hand: { sente: senteHand, gote: goteHand },
+    deck: { sente: senteDeck, gote: goteDeck },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: null, gote: null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    // 自動ドロー境界 (4→5) を早期に踏ませるため seed で 0..4 に散らす。
+    drawProgress: { sente: seed % 5, gote: (seed * 3 + 1) % 5 },
+  };
+}
+
+function makeReducerState(
+  gameState: GameState,
+  cardState: CardGameState,
+): CardShogiGameStateInternal {
+  return {
+    gameState,
+    selectedSquare: null,
+    selectedHandPiece: null,
+    legalMoves: [],
+    forbiddenMateMoves: [],
+    isAiThinking: false,
+    promotionPendingMove: null,
+    cardState,
+    eventLog: [],
+    isDrawing: false,
+    pendingDrawPlayer: null,
+    pendingDrawSource: null,
+    isPlayingCard: false,
+    pendingPlayCardOpponent: null,
+    isCheckBreakAnimating: false,
+    doubleMove: null,
+    undoSnapshots: [],
+    spectatorMode: true, // DP-4 決定論化
+    isPaused: false,
+  };
+}
+
+function makeWorld(gameState: GameState, cardState: CardGameState): WorldState {
+  return { gameState, cardState, doubleMove: null };
+}
+
+// ===== reducer 経路の駆動 (dispatch 列) =====
+// 1 つの TurnAction を reducer の演出フェーズ分割に展開して適用し、演出 flag を精算して安定状態に落とす。
+// 戻り値: 適用後 state と、この適用で eventLog に積まれた差分イベント。
+
+function dispatch(
+  state: CardShogiGameStateInternal,
+  action: Action,
+): CardShogiGameStateInternal {
+  return reducer(state, action);
+}
+
+// 演出フェーズ flag を精算して安定状態へ。
+// - isPlayingCard: COMMIT_PLAY_CARD (flip + drawProgress、double_move finalize 経路も含む)
+// - isDrawing: COMMIT_DRAW (manual は flip+turnEnd、auto は flag cleanup。manual→auto 連鎖を drain)
+// - isCheckBreakAnimating: COMMIT_CHECK_BREAK (flag cleanup)
+function settleAnimations(
+  state: CardShogiGameStateInternal,
+): CardShogiGameStateInternal {
+  let s = state;
+  if (s.isPlayingCard) s = dispatch(s, { type: "COMMIT_PLAY_CARD" });
+  let guard = 0;
+  while (s.isDrawing && guard++ < 4) s = dispatch(s, { type: "COMMIT_DRAW" });
+  if (s.isCheckBreakAnimating) s = dispatch(s, { type: "COMMIT_CHECK_BREAK" });
+  return s;
+}
+
+function applyToReducer(
+  state: CardShogiGameStateInternal,
+  action: TurnAction,
+): { state: CardShogiGameStateInternal; events: GameEvent[] } {
+  const prevLen = state.eventLog.length;
+  let s = state;
+
+  if (action.kind === "move") {
+    s = dispatch(s, { type: "MAKE_MOVE", move: action.move });
+    s = settleAnimations(s);
+  } else if (action.kind === "draw") {
+    const player = state.gameState.currentPlayer;
+    s = dispatch(s, { type: "DRAW_CARD", player });
+    s = settleAnimations(s);
+  } else {
+    const player = state.gameState.currentPlayer;
+    const def = CARD_DEFS[action.defId];
+    s = dispatch(s, {
+      type: "BEGIN_PLAY_CARD",
+      player,
+      instanceId: action.cardInstanceId,
+    });
+    s = dispatch(s, { type: "CONFIRM_PLAY_CARD" });
+    if (action.defId === "double_move") {
+      // ターン継続 (1手目・2手目は後続の move TurnAction として別ステップで処理)。COMMIT しない。
+    } else {
+      // targeting あり (modifyBoard) は CONFIRM で selectTarget フェーズへ → SELECT_CARD_TARGET で効果適用。
+      // targeting=none (trap / mana_up) は CONFIRM で効果適用済。
+      if (def.targeting !== "none" && def.kind !== "trap") {
+        if (!action.target)
+          throw new Error("targeted card action requires target");
+        s = dispatch(s, { type: "SELECT_CARD_TARGET", target: action.target });
+      }
+      s = settleAnimations(s);
+    }
+  }
+
+  return { state: s, events: s.eventLog.slice(prevLen) };
+}
+
+// ===== 合法 TurnAction 生成 =====
+
+function legalActions(world: WorldState): TurnAction[] {
+  const gs = world.gameState;
+  if (gs.status !== "active") return [];
+  const player = gs.currentPlayer;
+  const moves = getFullLegalMoves(gs, player, CARD_SHOGI_VARIANT);
+  const moveActions: TurnAction[] = moves.map((move) => ({
+    kind: "move",
+    move,
+  }));
+
+  // double_move 継続中は move のみ (1手目/2手目)。
+  if (world.doubleMove) return moveActions;
+
+  const cardActions: TurnAction[] = [];
+  // 王手中はドロー禁止 (reducer DRAW_CARD ガード) + カード使用は中間 no-op が絡むため harness では除外。
+  if (!isInCheck(gs, player, CARD_SHOGI_VARIANT)) {
+    if (canDraw(world.cardState, player)) cardActions.push({ kind: "draw" });
+    const aiState: AiTurnState = {
+      gameState: gs,
+      cardState: world.cardState,
+      doubleMove: null,
+    };
+    for (const ca of getCardActions(aiState, player, CARD_SHOGI_VARIANT))
+      cardActions.push(ca);
+  }
+  return [...moveActions, ...cardActions];
+}
+
+// move / card を程よく混ぜて選択 (カード経路を厚く踏むため card に bias)。
+function chooseAction(rng: () => number, world: WorldState): TurnAction | null {
+  if (world.doubleMove) {
+    const moves = getFullLegalMoves(
+      world.gameState,
+      world.gameState.currentPlayer,
+      CARD_SHOGI_VARIANT,
+    );
+    if (moves.length === 0) return null;
+    return { kind: "move", move: pick(rng, moves) };
+  }
+  const all = legalActions(world);
+  if (all.length === 0) return null;
+  const cards = all.filter((a) => a.kind !== "move");
+  const moves = all.filter((a) => a.kind === "move");
+  if (cards.length > 0 && (moves.length === 0 || rng() < 0.5))
+    return pick(rng, cards);
+  if (moves.length === 0) return pick(rng, cards);
+  return pick(rng, moves);
+}
+
+// ===== 射影 =====
+
+function sortMarks(
+  marks: ReadonlyArray<{ row: number; col: number }>,
+): Array<{ row: number; col: number }> {
+  return [...marks].sort((a, b) => a.row - b.row || a.col - b.col);
+}
+
+function projectCardState(cs: CardGameState) {
+  return {
+    mana: cs.mana,
+    manaCap: cs.manaCap,
+    hand: cs.hand, // instanceId 順序込み
+    deck: cs.deck, // 順序込み
+    graveyard: cs.graveyard, // 順序込み
+    trap: cs.trap, // {instanceId, defId, owner} | null
+    noPromoteMarks: {
+      sente: sortMarks(cs.noPromoteMarks.sente), // DP-5: {row,col} 集合一致
+      gote: sortMarks(cs.noPromoteMarks.gote),
+    },
+    drawProgress: cs.drawProgress,
+  };
+}
+
+// event 射影: `at` (Date.now) を全階層から除去 + manaChargeEvent を除外 (DP-4)。
+// instance/target/capturedPieces 等のドメインフィールドは両経路で構造一致 (kernel/reducer 検証済) のため残す。
+function stripAt(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(stripAt);
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      if (k === "at") continue;
+      out[k] = stripAt(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+function projectEvents(events: GameEvent[]): unknown[] {
+  return events
+    .filter((e) => e.kind !== "manaChargeEvent")
+    .map((e) => stripAt(e));
+}
+
+// ===== 等価比較 =====
+
+function expectEquivalent(
+  rstate: CardShogiGameStateInternal,
+  world: WorldState,
+  rEvents?: GameEvent[],
+  kEvents?: GameEvent[],
+): void {
+  // gameState 全体 (board/取り駒hand/currentPlayer/status/winner/moveCount/moveHistory/positionHistory)。
+  expect(world.gameState).toEqual(rstate.gameState);
+  // cardState 12 射影。
+  expect(projectCardState(world.cardState)).toEqual(
+    projectCardState(rstate.cardState),
+  );
+  // events (差分) 射影。
+  if (rEvents && kEvents) {
+    expect(projectEvents(kEvents)).toEqual(projectEvents(rEvents));
+  }
+  // サニティ不変量 (DP-6 mana∈[0,manaCap] / drawProgress≥0)。
+  for (const p of ["sente", "gote"] as const) {
+    expect(world.cardState.mana[p]).toBeGreaterThanOrEqual(0);
+    expect(world.cardState.mana[p]).toBeLessThanOrEqual(
+      world.cardState.manaCap,
+    );
+    expect(world.cardState.drawProgress[p]).toBeGreaterThanOrEqual(0);
+  }
+}
+
+// ===== ランダム等価 harness =====
+
+describe("world-kernel applyTurnAction ≡ reducer 経路 (property-based 等価)", () => {
+  const SEEDS = 180;
+  const MAX_PLIES = 40;
+  // property テストは多数の局面を回すため vitest 既定 5s を超える。決定的・非 flaky なので
+  // 余裕を持たせた明示 timeout を与える (実測 ~6s、CI でも安定動作する 30s に設定)。
+  const HARNESS_TIMEOUT_MS = 30_000;
+
+  it(
+    `${SEEDS} seed × 最大 ${MAX_PLIES} ply のランダム対局で全ステップ等価`,
+    () => {
+      for (let seed = 1; seed <= SEEDS; seed++) {
+        const rng = mulberry32(seed * 2654435761);
+        const gs0 = createInitialGameState(CARD_SHOGI_VARIANT);
+        // reducer 経路・カーネル経路に独立コピーを渡す (両者とも immutable 更新だが念のため分離)。
+        let rstate = makeReducerState(
+          createInitialGameState(CARD_SHOGI_VARIANT),
+          buildCardState(seed),
+        );
+        let world = makeWorld(gs0, buildCardState(seed));
+
+        // 初期状態が等価であること。
+        expectEquivalent(rstate, world);
+
+        for (let ply = 0; ply < MAX_PLIES; ply++) {
+          if (world.gameState.status !== "active") break;
+          const action = chooseAction(rng, world);
+          if (!action) break;
+
+          const before = world.gameState.currentPlayer;
+          const r = applyToReducer(rstate, action);
+          const k = applyTurnAction(world, action, { spectatorMode: true });
+
+          expectEquivalent(r.state, k.world, r.events, k.events);
+
+          // turnEnded は「currentPlayer 反転」の射影 (DP-2)。
+          const flipped = before !== k.world.gameState.currentPlayer;
+          expect(k.turnEnded).toBe(flipped);
+
+          // doubleMove 継続状態の同期 (KernelDoubleMove vs reducer doubleMove)。
+          expect(!!k.world.doubleMove).toBe(!!r.state.doubleMove);
+          if (k.world.doubleMove && r.state.doubleMove) {
+            expect(k.world.doubleMove.movesLeft).toBe(
+              r.state.doubleMove.movesLeft,
+            );
+            expect(k.world.doubleMove.active).toBe(r.state.doubleMove.active);
+            // 遅延消費パラメータ (finalize で使う instanceId / cost) も同期していること (OBS4-5)。
+            expect(k.world.doubleMove.cardInstance.instanceId).toBe(
+              r.state.doubleMove.cardInstance.instanceId,
+            );
+            expect(k.world.doubleMove.cardCost).toBe(
+              r.state.doubleMove.cardCost,
+            );
+          }
+
+          rstate = r.state;
+          world = k.world;
+        }
+      }
+    },
+    HARNESS_TIMEOUT_MS,
+  );
+});
+
+// ===== targeted エッジケース (DP-1〜7 を明示値で固定) =====
+// ランダム harness が「reducer ≡ kernel」を保証するのに対し、こちらは各 DP の期待値そのものを pin する
+// (両経路が同時に同じ間違いをするケースを防ぐ spec チェック)。
+
+describe("world-kernel applyTurnAction — DP 固定 (targeted)", () => {
+  // 共通: 単一 TurnAction を両経路に適用して比較し、カーネル結果を返すヘルパ。
+  function applyBoth(
+    rstate: CardShogiGameStateInternal,
+    world: WorldState,
+    action: TurnAction,
+  ) {
+    const r = applyToReducer(rstate, action);
+    const k = applyTurnAction(world, action, { spectatorMode: true });
+    expectEquivalent(r.state, k.world, r.events, k.events);
+    return { r, k };
+  }
+
+  it("DP-1: 通常 move でターン終了 drawProgress +1 (境界未満)", () => {
+    const cs = buildCardState(101);
+    cs.drawProgress = { sente: 1, gote: 0 };
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      buildCardState(101),
+    );
+    rstate.cardState.drawProgress = { sente: 1, gote: 0 };
+    const world = makeWorld(gs, cs);
+
+    const moves = getFullLegalMoves(gs, "sente", CARD_SHOGI_VARIANT);
+    const { k } = applyBoth(rstate, world, { kind: "move", move: moves[0] });
+
+    expect(k.world.cardState.drawProgress.sente).toBe(2); // +1
+    expect(k.world.gameState.currentPlayer).toBe("gote"); // flip
+    expect(k.turnEnded).toBe(true);
+  });
+
+  it("DP-1: 自動ドロー境界 (drawProgress 4→5) で 0 reset + auto-draw 1 枚", () => {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const csR = buildCardState(102);
+    csR.drawProgress = { sente: 4, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(102);
+    csK.drawProgress = { sente: 4, gote: 0 };
+    const world = makeWorld(gs, csK);
+
+    const deckBefore = world.cardState.deck.sente.length;
+    const handBefore = world.cardState.hand.sente.length;
+    const topCard = world.cardState.deck.sente[0];
+
+    const moves = getFullLegalMoves(gs, "sente", CARD_SHOGI_VARIANT);
+    const { k } = applyBoth(rstate, world, { kind: "move", move: moves[0] });
+
+    expect(k.world.cardState.drawProgress.sente).toBe(0); // reset
+    expect(k.world.cardState.deck.sente.length).toBe(deckBefore - 1);
+    expect(k.world.cardState.hand.sente.length).toBe(handBefore + 1);
+    expect(k.world.cardState.hand.sente[handBefore]).toEqual(topCard); // 山札先頭が手札末尾へ
+    // auto drawEvent が出る。
+    const drawEvents = k.events.filter((e) => e.kind === "drawEvent");
+    expect(drawEvents).toHaveLength(1);
+    expect(
+      (drawEvents[0] as Extract<GameEvent, { kind: "drawEvent" }>).source,
+    ).toBe("auto");
+  });
+
+  it("DP-1: 山札空で境界到達しても発火せず drawProgress は 5 へ加算 (reset しない)", () => {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const csR = buildCardState(103);
+    csR.deck = { sente: [], gote: csR.deck.gote };
+    csR.drawProgress = { sente: 4, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(103);
+    csK.deck = { sente: [], gote: csK.deck.gote };
+    csK.drawProgress = { sente: 4, gote: 0 };
+    const world = makeWorld(gs, csK);
+
+    const moves = getFullLegalMoves(gs, "sente", CARD_SHOGI_VARIANT);
+    const { k } = applyBoth(rstate, world, { kind: "move", move: moves[0] });
+
+    expect(k.world.cardState.drawProgress.sente).toBe(5); // reset せず加算
+    expect(k.world.cardState.hand.sente.length).toBe(
+      world.cardState.hand.sente.length,
+    ); // 不変
+    expect(k.events.filter((e) => e.kind === "drawEvent")).toHaveLength(0);
+  });
+
+  it("DP-1: 手動ドロー → manual + 連鎖 auto-draw (drawProgress 4 起点で 2 枚増える)", () => {
+    // canDraw は drawProgress<4 を要求するが、reducer DRAW_CARD 自体は drawProgress に依存しないため
+    // drawProgress=4 起点の manual→auto 連鎖を直接構築して検証する。
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const csR = buildCardState(104);
+    csR.mana = { sente: 5, gote: 5 };
+    csR.drawProgress = { sente: 4, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(104);
+    csK.mana = { sente: 5, gote: 5 };
+    csK.drawProgress = { sente: 4, gote: 0 };
+    const world = makeWorld(gs, csK);
+
+    const handBefore = world.cardState.hand.sente.length;
+    const { k } = applyBoth(rstate, world, { kind: "draw" });
+
+    expect(k.world.cardState.mana.sente).toBe(3); // -DRAW_COST(2)
+    expect(k.world.cardState.hand.sente.length).toBe(handBefore + 2); // manual + auto
+    expect(k.world.cardState.drawProgress.sente).toBe(0); // 連鎖 auto で reset
+    expect(k.world.gameState.currentPlayer).toBe("gote"); // flip
+    const drawEvents = k.events.filter((e) => e.kind === "drawEvent") as Array<
+      Extract<GameEvent, { kind: "drawEvent" }>
+    >;
+    expect(drawEvents.map((e) => e.source)).toEqual(["manual", "auto"]);
+  });
+
+  it("DP-3: トラップ設置は hand→trap (graveyard 不変) + mana-=cost", () => {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    // 手札に check_break を確定配置 (cost 4)。
+    const trapCard: CardInstance = {
+      instanceId: "sente-check_break-x",
+      defId: "check_break",
+    };
+    const csR = buildCardState(105);
+    csR.hand = { sente: [trapCard], gote: csR.hand.gote };
+    csR.mana = { sente: 6, gote: 6 };
+    csR.drawProgress = { sente: 0, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(105);
+    csK.hand = { sente: [{ ...trapCard }], gote: csK.hand.gote };
+    csK.mana = { sente: 6, gote: 6 };
+    csK.drawProgress = { sente: 0, gote: 0 };
+    const world = makeWorld(gs, csK);
+
+    const { k } = applyBoth(rstate, world, {
+      kind: "playCard",
+      cardInstanceId: trapCard.instanceId,
+      defId: "check_break",
+    });
+
+    expect(k.world.cardState.trap.sente).toEqual({
+      instanceId: trapCard.instanceId,
+      defId: "check_break",
+      owner: "sente",
+    });
+    expect(k.world.cardState.hand.sente).toHaveLength(0); // hand から除去
+    expect(k.world.cardState.graveyard.sente).toHaveLength(0); // DP-3: graveyard 不変
+    expect(k.world.cardState.mana.sente).toBe(2); // 6 - 4
+    expect(k.world.cardState.drawProgress.sente).toBe(1); // turn-end +1
+    expect(k.world.gameState.currentPlayer).toBe("gote"); // flip
+    const ev = k.events.find((e) => e.kind === "trapSetEvent");
+    expect(ev).toBeDefined();
+  });
+
+  it("DP-3: modifyBoard (pawn_return) は盤上歩→取り駒 + card hand→graveyard + mana-=cost", () => {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const pawnCard: CardInstance = {
+      instanceId: "sente-pawn_return-x",
+      defId: "pawn_return",
+    };
+    const csR = buildCardState(106);
+    csR.hand = { sente: [pawnCard], gote: csR.hand.gote };
+    csR.mana = { sente: 5, gote: 5 };
+    csR.drawProgress = { sente: 0, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(106);
+    csK.hand = { sente: [{ ...pawnCard }], gote: csK.hand.gote };
+    csK.mana = { sente: 5, gote: 5 };
+    csK.drawProgress = { sente: 0, gote: 0 };
+    const world = makeWorld(gs, csK);
+
+    // 先手の歩 (初期配置 row=6 のいずれか) を対象に戻す。
+    const target = { kind: "square" as const, row: 6, col: 4 };
+    expect(gs.board[6][4]?.type).toBe("pawn"); // 前提確認
+
+    const { k } = applyBoth(rstate, world, {
+      kind: "playCard",
+      cardInstanceId: pawnCard.instanceId,
+      defId: "pawn_return",
+      target,
+    });
+
+    expect(k.world.gameState.board[6][4]).toBeNull(); // 盤上から除去
+    expect(k.world.gameState.hand.sente["pawn"]).toBe(1); // 取り駒へ
+    expect(k.world.cardState.hand.sente).toHaveLength(0);
+    expect(k.world.cardState.graveyard.sente).toHaveLength(1); // hand→graveyard
+    expect(k.world.cardState.graveyard.sente[0].defId).toBe("pawn_return");
+    expect(k.world.cardState.mana.sente).toBe(4); // 5 - 1
+    expect(k.world.cardState.drawProgress.sente).toBe(1);
+    expect(k.world.gameState.currentPlayer).toBe("gote");
+  });
+
+  it("DP-2: double_move は CONFIRM=遅延消費 / 2手目 finalize で hand→graveyard + drawProgress+1", () => {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const dmCard: CardInstance = {
+      instanceId: "sente-double_move-x",
+      defId: "double_move",
+    };
+    const csR = buildCardState(107);
+    csR.hand = { sente: [dmCard], gote: csR.hand.gote };
+    csR.mana = { sente: 8, gote: 8 };
+    csR.drawProgress = { sente: 0, gote: 0 };
+    const rstate = makeReducerState(
+      createInitialGameState(CARD_SHOGI_VARIANT),
+      csR,
+    );
+    const csK = buildCardState(107);
+    csK.hand = { sente: [{ ...dmCard }], gote: csK.hand.gote };
+    csK.mana = { sente: 8, gote: 8 };
+    csK.drawProgress = { sente: 0, gote: 0 };
+    let world = makeWorld(gs, csK);
+    let rcur = rstate;
+
+    // (1) playCard double_move: フラグ set のみ・mana/hand/graveyard 不変・turnEnded=false。
+    {
+      const action: TurnAction = {
+        kind: "playCard",
+        cardInstanceId: dmCard.instanceId,
+        defId: "double_move",
+      };
+      const r = applyToReducer(rcur, action);
+      const k = applyTurnAction(world, action, { spectatorMode: true });
+      expectEquivalent(r.state, k.world, r.events, k.events);
+      expect(k.turnEnded).toBe(false);
+      expect(k.world.gameState.currentPlayer).toBe("sente"); // 反転しない
+      expect(k.world.cardState.mana.sente).toBe(8); // 遅延消費 = 不変
+      expect(k.world.cardState.hand.sente).toHaveLength(1); // 不変
+      expect(k.world.cardState.graveyard.sente).toHaveLength(0);
+      expect(k.world.doubleMove?.movesLeft).toBe(2);
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (2) 1手目: currentPlayer は sente のまま・turnEnded=false・movesLeft 2→1・drawProgress 不変。
+    {
+      const moves1 = getFullLegalMoves(
+        world.gameState,
+        "sente",
+        CARD_SHOGI_VARIANT,
+      );
+      const action: TurnAction = { kind: "move", move: moves1[0] };
+      const r = applyToReducer(rcur, action);
+      const k = applyTurnAction(world, action, { spectatorMode: true });
+      expectEquivalent(r.state, k.world, r.events, k.events);
+      expect(k.turnEnded).toBe(false);
+      expect(k.world.gameState.currentPlayer).toBe("sente");
+      expect(k.world.doubleMove?.movesLeft).toBe(1);
+      expect(k.world.cardState.drawProgress.sente).toBe(0); // 継続中は加算なし
+      expect(k.world.cardState.mana.sente).toBe(8); // チャージなし
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (3) 2手目: finalize で hand→graveyard + mana-=5 + cardPlayEvent + drawProgress+1 + flip。
+    {
+      const moves2 = getFullLegalMoves(
+        world.gameState,
+        "sente",
+        CARD_SHOGI_VARIANT,
+      );
+      const action: TurnAction = { kind: "move", move: moves2[0] };
+      const r = applyToReducer(rcur, action);
+      const k = applyTurnAction(world, action, { spectatorMode: true });
+      expectEquivalent(r.state, k.world, r.events, k.events);
+      expect(k.turnEnded).toBe(true);
+      expect(k.world.gameState.currentPlayer).toBe("gote"); // flip
+      expect(k.world.doubleMove).toBeNull();
+      expect(k.world.cardState.mana.sente).toBe(3); // 8 - 5 (遅延消費)
+      expect(k.world.cardState.hand.sente).toHaveLength(0);
+      expect(k.world.cardState.graveyard.sente).toHaveLength(1);
+      expect(k.world.cardState.graveyard.sente[0].defId).toBe("double_move");
+      expect(k.world.cardState.drawProgress.sente).toBe(1); // 2手目完了で +1 (1回のみ)
+      const cardPlay = k.events.filter((e) => e.kind === "cardPlayEvent");
+      expect(cardPlay).toHaveLength(1);
+    }
+  });
+});
+
+// ===== 終局・カード×マーク・DP-7 (targeted、実装後レビュー反映) =====
+// マイルストーン2 adversarial レビュー (16 findings / 11 confirmed) で「計画 §8.3.4 の必須エッジ
+// (終局手後 turn-end スキップ / double_move 1手目詰み / removeNoPromoteMark / check_break defer→2手目発火 /
+// 捕獲駒の no_promote マーク削除) が random でも targeted でも未踏」と判明したため追加。
+// これらは applyTurnAction の固有合成分岐 (world-kernel.ts:88 status guard / 258-274 double_move 詰み即
+// finalize) を踏み、reducer 経路との等価を pin する。固定盤面で構築するため決定的。
+
+// 空の 9×9 盤を生成。
+function emptyBoard(): Board {
+  return Array.from({ length: 9 }, () =>
+    Array.from({ length: 9 }, () => null as Board[number][number]),
+  );
+}
+
+function pc(type: PieceType, owner: Player) {
+  return { type, owner };
+}
+
+// 固定盤面の GameState を構築 (positionHistory は serializePosition で初期化、千日手誤検出を避ける)。
+function buildGameState(
+  place: (b: Board) => void,
+  currentPlayer: Player,
+): GameState {
+  const board = emptyBoard();
+  place(board);
+  const state: GameState = {
+    board,
+    hand: { sente: {}, gote: {} },
+    currentPlayer,
+    moveHistory: [],
+    positionHistory: [],
+    status: "active",
+    moveCount: 0,
+  };
+  state.positionHistory = [serializePosition(state)];
+  return state;
+}
+
+// targeted 用の最小 CardGameState。
+function minimalCardState(over: Partial<CardGameState> = {}): CardGameState {
+  return {
+    mana: { sente: 10, gote: 10 },
+    manaCap: MANA_CAP,
+    hand: { sente: [], gote: [] },
+    deck: { sente: [], gote: [] },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: null, gote: null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    drawProgress: { sente: 0, gote: 0 },
+    ...over,
+  };
+}
+
+// 単一 TurnAction を両経路に適用して等価比較し、カーネル結果を返す (module-level 版)。
+function applyAndCompare(
+  rstate: CardShogiGameStateInternal,
+  world: WorldState,
+  action: TurnAction,
+) {
+  const r = applyToReducer(rstate, action);
+  const k = applyTurnAction(world, action, { spectatorMode: true });
+  expectEquivalent(r.state, k.world, r.events, k.events);
+  return { r, k };
+}
+
+// 頭金 (head-gold) 詰み盤: 後手玉(0,4) を、先手金(2,4)→(1,4) で詰ます。金は先手飛(8,4)が支える。
+// 先手玉(8,8) を置いて盤面を well-formed に保つ。後手は玉のみ = 合駒・取りで回避不可。
+const placeHeadGoldMate = (b: Board) => {
+  b[0][4] = pc("king", "gote");
+  b[2][4] = pc("gold", "sente");
+  b[8][4] = pc("rook", "sente");
+  b[8][8] = pc("king", "sente");
+};
+const HEAD_GOLD_MATE_MOVE: Move = {
+  type: "move",
+  from: { row: 2, col: 4 },
+  to: { row: 1, col: 4 },
+  piece: "gold",
+  player: "sente",
+};
+
+describe("world-kernel applyTurnAction — 終局・マーク・DP-7 (targeted)", () => {
+  it("前提: head-gold 盤で金(2,4)→(1,4) は後手玉を詰ます", () => {
+    const gs = buildGameState(placeHeadGoldMate, "sente");
+    expect(isInCheck(gs, "gote", CARD_SHOGI_VARIANT)).toBe(false); // 手前は王手でない
+    const after = applyMove(gs, HEAD_GOLD_MATE_MOVE);
+    expect(isCheckmate(after, "gote", CARD_SHOGI_VARIANT)).toBe(true);
+  });
+
+  it("終局: 通常 move で詰ます手は turn-end をスキップ (drawProgress 境界でも reset/auto-draw しない)", () => {
+    // drawProgress=4 起点でも、詰む手では advanceDrawProgress (world-kernel.ts:88) が status≠active で no-op。
+    const rstate = makeReducerState(
+      buildGameState(placeHeadGoldMate, "sente"),
+      minimalCardState({ drawProgress: { sente: 4, gote: 0 } }),
+    );
+    const world = makeWorld(
+      buildGameState(placeHeadGoldMate, "sente"),
+      minimalCardState({ drawProgress: { sente: 4, gote: 0 } }),
+    );
+
+    const { k } = applyAndCompare(rstate, world, {
+      kind: "move",
+      move: HEAD_GOLD_MATE_MOVE,
+    });
+
+    expect(k.world.gameState.status).toBe("checkmate");
+    expect(k.world.gameState.winner).toBe("sente");
+    expect(k.world.gameState.currentPlayer).toBe("gote"); // flip
+    expect(k.turnEnded).toBe(true);
+    // 終局でドロー進捗は加算されない (境界 4 のままで reset/auto-draw なし)。
+    expect(k.world.cardState.drawProgress.sente).toBe(4);
+    expect(k.events.filter((e) => e.kind === "drawEvent")).toHaveLength(0);
+  });
+
+  it("終局: double_move 1手目で詰むと即 finalize (flip 戻さず・カード消費・drawProgress スキップ)", () => {
+    // world-kernel.ts:258-274 の double_move 1手目詰み専用分岐を踏む。
+    const dmCard: CardInstance = {
+      instanceId: "sente-double_move-mate",
+      defId: "double_move",
+    };
+    const rstate = makeReducerState(
+      buildGameState(placeHeadGoldMate, "sente"),
+      minimalCardState({
+        hand: { sente: [dmCard], gote: [] },
+        mana: { sente: 8, gote: 8 },
+        drawProgress: { sente: 4, gote: 0 },
+      }),
+    );
+    let world = makeWorld(
+      buildGameState(placeHeadGoldMate, "sente"),
+      minimalCardState({
+        hand: { sente: [{ ...dmCard }], gote: [] },
+        mana: { sente: 8, gote: 8 },
+        drawProgress: { sente: 4, gote: 0 },
+      }),
+    );
+    let rcur = rstate;
+
+    // (1) double_move 発動 (遅延消費 → mana/hand 不変、継続)。
+    {
+      const action: TurnAction = {
+        kind: "playCard",
+        cardInstanceId: dmCard.instanceId,
+        defId: "double_move",
+      };
+      const { r, k } = applyAndCompare(rcur, world, action);
+      expect(k.turnEnded).toBe(false);
+      expect(k.world.doubleMove?.movesLeft).toBe(2);
+      expect(k.world.cardState.mana.sente).toBe(8);
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (2) 1手目 = 詰み手。即 finalize で turn 終了。
+    {
+      const action: TurnAction = { kind: "move", move: HEAD_GOLD_MATE_MOVE };
+      const { k } = applyAndCompare(rcur, world, action);
+      expect(k.world.gameState.status).toBe("checkmate");
+      expect(k.world.gameState.winner).toBe("sente");
+      expect(k.turnEnded).toBe(true);
+      expect(k.world.gameState.currentPlayer).toBe("gote"); // 詰みでは flip 戻さない (applyMove の flip を維持)
+      expect(k.world.doubleMove).toBeNull();
+      // double_move カードは詰み finalize で消費される (DP-2 遅延消費)。
+      expect(k.world.cardState.mana.sente).toBe(3); // 8 - 5
+      expect(k.world.cardState.hand.sente).toHaveLength(0);
+      expect(k.world.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+        "double_move",
+      ]);
+      // 終局なので drawProgress は加算されない (境界 4 のまま)。
+      expect(k.world.cardState.drawProgress.sente).toBe(4);
+      const cardPlay = k.events.filter((e) => e.kind === "cardPlayEvent");
+      expect(cardPlay).toHaveLength(1);
+      expect(k.events.filter((e) => e.kind === "drawEvent")).toHaveLength(0);
+    }
+  });
+
+  it("DP-5×カード: pawn_return で戻した駒の no_promote マークが消える", () => {
+    const pawnCard: CardInstance = {
+      instanceId: "sente-pawn_return-mk",
+      defId: "pawn_return",
+    };
+    const placePawn = (b: Board) => {
+      b[0][0] = pc("king", "gote");
+      b[8][8] = pc("king", "sente");
+      b[5][4] = pc("pawn", "sente"); // マーク付き歩
+    };
+    const csOver = {
+      hand: { sente: [pawnCard], gote: [] as CardInstance[] },
+      mana: { sente: 5, gote: 5 },
+      noPromoteMarks: { sente: [{ row: 5, col: 4 }], gote: [] },
+    };
+    const rstate = makeReducerState(
+      buildGameState(placePawn, "sente"),
+      minimalCardState({ ...csOver, hand: { sente: [pawnCard], gote: [] } }),
+    );
+    const world = makeWorld(
+      buildGameState(placePawn, "sente"),
+      minimalCardState({
+        ...csOver,
+        hand: { sente: [{ ...pawnCard }], gote: [] },
+      }),
+    );
+
+    const { k } = applyAndCompare(rstate, world, {
+      kind: "playCard",
+      cardInstanceId: pawnCard.instanceId,
+      defId: "pawn_return",
+      target: { kind: "square", row: 5, col: 4 },
+    });
+
+    expect(k.world.gameState.board[5][4]).toBeNull(); // 盤上から退去
+    expect(k.world.gameState.hand.sente["pawn"]).toBe(1); // 取り駒へ
+    expect(k.world.cardState.noPromoteMarks.sente).toHaveLength(0); // マーク削除 (案A 仕様)
+    expect(k.world.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+      "pawn_return",
+    ]);
+    expect(k.world.cardState.mana.sente).toBe(4); // 5 - 1
+  });
+
+  it("OBS5-2: 駒取りで相手の no_promote マークが消える (capture removes opponent mark)", () => {
+    // makeMoveWithEffects 内 (共有) の挙動だが、カーネルが move を通す合成で同値になることを pin。
+    const placeCapture = (b: Board) => {
+      b[0][0] = pc("king", "gote");
+      b[8][8] = pc("king", "sente");
+      b[3][4] = pc("pawn", "gote"); // マーク付き後手歩
+      b[3][8] = pc("rook", "sente"); // 横利きで取る
+    };
+    const csOver = {
+      noPromoteMarks: {
+        sente: [] as Array<{ row: number; col: number }>,
+        gote: [{ row: 3, col: 4 }],
+      },
+    };
+    const rstate = makeReducerState(
+      buildGameState(placeCapture, "sente"),
+      minimalCardState(csOver),
+    );
+    const world = makeWorld(
+      buildGameState(placeCapture, "sente"),
+      minimalCardState(csOver),
+    );
+
+    const captureMove: Move = {
+      type: "move",
+      from: { row: 3, col: 8 },
+      to: { row: 3, col: 4 },
+      piece: "rook",
+      player: "sente",
+      captured: "pawn",
+    };
+    const { k } = applyAndCompare(rstate, world, {
+      kind: "move",
+      move: captureMove,
+    });
+
+    expect(k.world.gameState.board[3][4]).toEqual(pc("rook", "sente"));
+    expect(k.world.gameState.hand.sente["pawn"]).toBe(1);
+    expect(k.world.cardState.noPromoteMarks.gote).toHaveLength(0); // 取られた駒のマーク消失
+  });
+
+  it("DP-7: double_move 中の check_break は 1手目で defer・2手目で発火", () => {
+    // 後手が check_break をセット。先手が double_move で 1手目に王手 (defer)、2手目維持で発火。
+    const dmCard: CardInstance = {
+      instanceId: "sente-double_move-cb",
+      defId: "double_move",
+    };
+    const goteTrap: TrapInstance = {
+      instanceId: "gote-check_break",
+      defId: "check_break",
+      owner: "gote",
+    };
+    const placeCb = (b: Board) => {
+      b[4][4] = pc("king", "gote");
+      b[8][8] = pc("king", "sente");
+      b[0][0] = pc("rook", "sente"); // 1手目で (4,0) へ動かし王手
+      b[8][2] = pc("gold", "sente"); // 2手目の filler (王手は維持)
+    };
+    const csOver = (dm: CardInstance) => ({
+      hand: { sente: [dm], gote: [] as CardInstance[] },
+      mana: { sente: 8, gote: 8 },
+      trap: { sente: null, gote: goteTrap },
+    });
+    const rstate = makeReducerState(
+      buildGameState(placeCb, "sente"),
+      minimalCardState(csOver(dmCard)),
+    );
+    let world = makeWorld(
+      buildGameState(placeCb, "sente"),
+      minimalCardState(csOver({ ...dmCard })),
+    );
+    let rcur = rstate;
+
+    // 前提: 開始局面で後手玉は王手でない。
+    expect(isInCheck(world.gameState, "gote", CARD_SHOGI_VARIANT)).toBe(false);
+
+    // (1) double_move 発動。
+    {
+      const action: TurnAction = {
+        kind: "playCard",
+        cardInstanceId: dmCard.instanceId,
+        defId: "double_move",
+      };
+      const { r, k } = applyAndCompare(rcur, world, action);
+      expect(k.world.doubleMove?.movesLeft).toBe(2);
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (2) 1手目: 飛(0,0)→(4,0) で後手玉に王手。check_break は defer (発火しない・トラップ残置)。
+    {
+      const move1: Move = {
+        type: "move",
+        from: { row: 0, col: 0 },
+        to: { row: 4, col: 0 },
+        piece: "rook",
+        player: "sente",
+      };
+      const { r, k } = applyAndCompare(rcur, world, {
+        kind: "move",
+        move: move1,
+      });
+      expect(k.turnEnded).toBe(false);
+      expect(k.world.doubleMove?.movesLeft).toBe(1);
+      expect(k.world.cardState.trap.gote).not.toBeNull(); // defer = トラップ未発火
+      expect(isInCheck(k.world.gameState, "gote", CARD_SHOGI_VARIANT)).toBe(
+        true,
+      ); // 王手継続
+      expect(
+        k.events.filter((e) => e.kind === "trapTriggerEvent"),
+      ).toHaveLength(0); // 1手目で発火せず
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (3) 2手目: 金(8,2)→(7,2) (王手は維持) → check_break 発火し王手駒(飛)を後手が捕獲。
+    {
+      const move2: Move = {
+        type: "move",
+        from: { row: 8, col: 2 },
+        to: { row: 7, col: 2 },
+        piece: "gold",
+        player: "sente",
+      };
+      const { k } = applyAndCompare(rcur, world, { kind: "move", move: move2 });
+      expect(k.turnEnded).toBe(true);
+      expect(k.world.doubleMove).toBeNull();
+      expect(k.world.cardState.trap.gote).toBeNull(); // 発火で消費
+      expect(k.world.gameState.board[4][0]).toBeNull(); // 王手していた飛が除去
+      expect(k.world.gameState.hand.gote["rook"]).toBe(1); // 後手の持ち駒へ
+      expect(isInCheck(k.world.gameState, "gote", CARD_SHOGI_VARIANT)).toBe(
+        false,
+      ); // 王手解除
+      // double_move 消費 + 2手目で trapTrigger(check_declared) 発火。
+      expect(k.world.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+        "double_move",
+      ]);
+      const triggers = k.events.filter(
+        (e) => e.kind === "trapTriggerEvent",
+      ) as Array<Extract<GameEvent, { kind: "trapTriggerEvent" }>>;
+      expect(triggers).toHaveLength(1);
+      expect(triggers[0].reason).toBe("check_declared");
+    }
+  });
+
+  it("F-4/OBS4-3: 王手中の double_move (checkUsage=unconditional) — RELAXED 1手目→2手目で解消", () => {
+    // 先手玉が後手飛に王手された状態で double_move を使用 (王手中でも unconditional で許可)。
+    // 1手目は王手を解消しない RELAXED 手、2手目で玉を逃して解消。
+    const dmCard: CardInstance = {
+      instanceId: "sente-double_move-chk",
+      defId: "double_move",
+    };
+    const placeChk = (b: Board) => {
+      b[4][4] = pc("king", "sente"); // 先手玉が王手される
+      b[4][0] = pc("rook", "gote"); // 後手飛が横利きで王手
+      b[0][8] = pc("king", "gote");
+      b[8][2] = pc("gold", "sente"); // RELAXED 1手目の駒
+    };
+    const csOver = (dm: CardInstance) => ({
+      hand: { sente: [dm], gote: [] as CardInstance[] },
+      mana: { sente: 8, gote: 8 },
+    });
+    const rstate = makeReducerState(
+      buildGameState(placeChk, "sente"),
+      minimalCardState(csOver(dmCard)),
+    );
+    let world = makeWorld(
+      buildGameState(placeChk, "sente"),
+      minimalCardState(csOver({ ...dmCard })),
+    );
+    let rcur = rstate;
+
+    expect(isInCheck(world.gameState, "sente", CARD_SHOGI_VARIANT)).toBe(true); // 前提: 王手中
+
+    // (1) 王手中に double_move 発動 (unconditional で許可)。
+    {
+      const action: TurnAction = {
+        kind: "playCard",
+        cardInstanceId: dmCard.instanceId,
+        defId: "double_move",
+      };
+      const { r, k } = applyAndCompare(rcur, world, action);
+      expect(k.world.doubleMove?.movesLeft).toBe(2);
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (2) RELAXED 1手目: 王手を解消しない手 (金(8,2)→(7,2))。1手目では自玉王手のまま許容。
+    {
+      const move1: Move = {
+        type: "move",
+        from: { row: 8, col: 2 },
+        to: { row: 7, col: 2 },
+        piece: "gold",
+        player: "sente",
+      };
+      const { r, k } = applyAndCompare(rcur, world, {
+        kind: "move",
+        move: move1,
+      });
+      expect(k.turnEnded).toBe(false);
+      expect(k.world.doubleMove?.movesLeft).toBe(1);
+      expect(isInCheck(k.world.gameState, "sente", CARD_SHOGI_VARIANT)).toBe(
+        true,
+      ); // まだ王手
+      rcur = r.state;
+      world = k.world;
+    }
+
+    // (3) 2手目: 玉(4,4)→(3,4) で飛の利きから逃れ王手解消。
+    {
+      const move2: Move = {
+        type: "move",
+        from: { row: 4, col: 4 },
+        to: { row: 3, col: 4 },
+        piece: "king",
+        player: "sente",
+      };
+      const { k } = applyAndCompare(rcur, world, { kind: "move", move: move2 });
+      expect(k.turnEnded).toBe(true);
+      expect(k.world.doubleMove).toBeNull();
+      expect(isInCheck(k.world.gameState, "sente", CARD_SHOGI_VARIANT)).toBe(
+        false,
+      ); // 解消
+      expect(k.world.gameState.currentPlayer).toBe("gote");
+      expect(k.world.cardState.mana.sente).toBe(3); // 8 - 5 (遅延消費)
+      expect(k.world.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+        "double_move",
+      ]);
+    }
+  });
+
+  it("OBS5-3: mana_up (deprecated) 分岐の等価 — consume(-2) 後 applyManaUp(+3) で純 +1", () => {
+    // mana_up は deprecated でデッキ非投入のためランダム harness では未到達。kernel:applyCardEffectLogic
+    // の mana_up 分岐 (reducer CONFIRM と対) を targeted で踏み、デッドカバレッジを解消する。
+    const manaCard: CardInstance = {
+      instanceId: "sente-mana_up-x",
+      defId: "mana_up",
+    };
+    const placeMinimal = (b: Board) => {
+      b[0][0] = pc("king", "gote");
+      b[8][8] = pc("king", "sente");
+    };
+    const csOver = (c: CardInstance) => ({
+      hand: { sente: [c], gote: [] as CardInstance[] },
+      mana: { sente: 5, gote: 5 },
+    });
+    const rstate = makeReducerState(
+      buildGameState(placeMinimal, "sente"),
+      minimalCardState(csOver(manaCard)),
+    );
+    const world = makeWorld(
+      buildGameState(placeMinimal, "sente"),
+      minimalCardState(csOver({ ...manaCard })),
+    );
+
+    const { k } = applyAndCompare(rstate, world, {
+      kind: "playCard",
+      cardInstanceId: manaCard.instanceId,
+      defId: "mana_up",
+    });
+
+    expect(k.world.cardState.mana.sente).toBe(6); // 5 - 2 (consume) + 3 (manaUp)
+    expect(k.world.cardState.hand.sente).toHaveLength(0);
+    expect(k.world.cardState.graveyard.sente.map((c) => c.defId)).toEqual([
+      "mana_up",
+    ]);
+    expect(k.world.cardState.drawProgress.sente).toBe(1); // turn-end +1
+    expect(k.world.gameState.currentPlayer).toBe("gote");
+  });
+});

--- a/src/lib/shogi/kernel/move-effects.ts
+++ b/src/lib/shogi/kernel/move-effects.ts
@@ -1,0 +1,240 @@
+// Issue #235 S1c: move 効果適用ロジックの物理移設 (reducer.ts → lib/kernel)。
+//
+// 背景・目的:
+//   makeMoveWithEffects は「駒移動 + マナチャージ + トラップ発動/フィルタ + no_promote マーク
+//   追従 + 王手崩しトラップ + 終局判定」を一括適用するロジックで、reducer (UI) と
+//   world-kernel (L0 カーネル / AI 探索) の双方から呼ばれる。S1a では reducer.ts に
+//   置いたまま export して world-kernel が import 再利用していたが、これは
+//   lib(world-kernel) → hooks(reducer) の逆依存 (層違反) を生んでいた。
+//   S1c でこの関数 (+ MakeMoveMode 型) を lib 層の本モジュールへ物理移設し、逆依存を解消する。
+//
+// 移設方針 (純粋リファクタ・挙動完全不変):
+//   関数本体は 1 行も変えていない (reducer.ts:241-428 からの lift)。依存はすべて lib 層
+//   (board/moves/rules/variants/cards/effects/定数) で hooks 非依存。
+//   reducer は本モジュールから makeMoveWithEffects を import して従来どおり直接呼ぶ
+//   (呼出経路・ロジック不変)。等価は S1a property test + reducer.test/undo/effects で担保。
+//
+// 注意 (非純粋性): 本関数は Date.now() に依存する (早指しボーナス isFastMove 判定 + イベント at)。
+//   決定論が必要な経路 (AI 探索 / property test) は spectatorMode=true を渡し、event の at は
+//   射影で除外する (epic §8.3 DP-4)。物理移設はこの契約を変えない (メモ化・キャッシュ禁止)。
+
+import type { GameState, Move, Player, Position } from "@/lib/shogi/types";
+import { applyMove } from "@/lib/shogi/board";
+import { isInCheck } from "@/lib/shogi/moves";
+import { evaluateGameEnd } from "@/lib/shogi/rules";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import {
+  MANA_PER_TURN,
+  MANA_FAST_BONUS,
+  FAST_THRESHOLD_MS,
+} from "@/lib/shogi/cards/definitions";
+import {
+  applyCheckBreak,
+  applyTrapClear,
+  hasNoPromoteMark,
+  addNoPromoteMark,
+  removeNoPromoteMark,
+  moveNoPromoteMark,
+} from "@/lib/shogi/cards/effects";
+import type { CardGameState, GameEvent } from "@/lib/shogi/cards/types";
+
+// 移動処理のモード切替 (Issue #82 二手指し)。
+// - "normal": 通常の指し手 (マナチャージ + 早指しタイマークリア)
+// - "double_move_first": 二手指しの 1手目 (マナチャージなし + タイマークリアなし、ターン継続中)
+// - "double_move_second": 二手指しの 2手目 (マナチャージなし、タイマークリアあり、ターン交代)
+// 二手指しはカード使用扱いのため、1手目・2手目とも通常のマナチャージ (+1〜+2) は発生しない
+// (カードコスト -6 のみ消費、これは CONFIRM_PLAY_CARD 側で処理済み)。
+export type MakeMoveMode = "normal" | "double_move_first" | "double_move_second";
+
+// 移動 + マナチャージ + トラップフィルタ を一括適用。
+// reducer の CONFIRM_PROMOTION / MAKE_MOVE、および world-kernel の applyTurnAction から呼ばれる。
+// Issue #235 S1c: reducer.ts から本 lib モジュールへ物理移設し、world-kernel → reducer の
+// 逆依存を解消した (振る舞い不変・関数本体は無改変)。
+export function makeMoveWithEffects(
+  gameState: GameState,
+  cardState: CardGameState,
+  move: Move,
+  // Issue #193 / PR1a: spectatorMode は CPU vs CPU 観戦モード時に true。
+  // 早指し判定 (FAST_THRESHOLD_MS) を完全 disable し、両 CPU の連続指しによる
+  // マナ蓄積異常を防ぐ。spectatorMode=false の人間プレイ時は完全に従来挙動を保持。
+  options?: { mode?: MakeMoveMode; spectatorMode?: boolean },
+): {
+  gameState: GameState;
+  cardState: CardGameState;
+  events: GameEvent[];
+  finalMove: Move;
+  // 王手崩しトラップが発動した場合のみ true。MAKE_MOVE 側で isCheckBreakAnimating をセットする。
+  triggeredCheckBreak: boolean;
+} {
+  const mode: MakeMoveMode = options?.mode ?? "normal";
+  const spectatorMode = options?.spectatorMode ?? false;
+  const opponent: Player = move.player === "sente" ? "gote" : "sente";
+  const events: GameEvent[] = [];
+
+  // 1. 成り宣言フィルタ
+  //   (a) 自分の駒に既に「成り不可」マークがあれば silent ブロック (新規トラップは発火させない)
+  //   (b) (a) でなく、相手が no_promote トラップをセット中なら新規発動
+  //       → 成りブロック + 移動先位置にマーク追加 + トラップ消費
+  let finalMove = move;
+  let cardStateNext = cardState;
+  let pendingMarkAdd: Position | null = null;
+
+  const opponentTrap = cardState.trap[opponent];
+  const ownMarkAtFrom =
+    move.from !== undefined &&
+    move.from !== null &&
+    hasNoPromoteMark(cardState, move.player, move.from);
+
+  if (move.promote && ownMarkAtFrom) {
+    // 既マーク済み駒の成り宣言 → silent ブロック (トラップは無関係、消費しない)
+    finalMove = { ...move, promote: false };
+  } else if (move.promote && opponentTrap && opponentTrap.defId === "no_promote") {
+    // 新規発動: 成り宣言を無効化し、移動後位置に永続マーク付与、トラップ消費
+    finalMove = { ...move, promote: false };
+    cardStateNext = applyTrapClear(cardStateNext, opponent);
+    pendingMarkAdd = move.to;
+    events.push({
+      kind: "trapTriggerEvent",
+      player: opponent,
+      instance: opponentTrap,
+      reason: "promotion_declared",
+      at: Date.now(),
+    });
+  }
+
+  // 2. 駒移動
+  const nextGameState = applyMove(gameState, finalMove);
+
+  // 3. 成り不可マークの追従処理 (move 系のみ。drop は対象外)
+  if (finalMove.type === "move" && finalMove.from) {
+    // (a) 取られた相手駒のマークがあれば削除 (case A: 取られたら消失)
+    if (hasNoPromoteMark(cardStateNext, opponent, finalMove.to)) {
+      cardStateNext = removeNoPromoteMark(cardStateNext, opponent, finalMove.to);
+    }
+    // (b) 自分の駒のマークを from → to に移動
+    if (hasNoPromoteMark(cardStateNext, finalMove.player, finalMove.from)) {
+      cardStateNext = moveNoPromoteMark(
+        cardStateNext,
+        finalMove.player,
+        finalMove.from,
+        finalMove.to,
+      );
+    }
+  }
+
+  // 4. トラップ発動分のマーク追加 (成り宣言を無効化した直後の駒位置に付与)
+  if (pendingMarkAdd) {
+    cardStateNext = addNoPromoteMark(cardStateNext, finalMove.player, pendingMarkAdd);
+  }
+
+  // 4.5 王手崩しトラップ (#82)
+  // 移動の結果、相手 (= トラップ所有者候補) が王手中になり、かつ check_break
+  // トラップがセットされていれば自動発動。王手駒すべてを盤上から除去し、
+  // トラップ所有者の持ち駒に unpromote 加算する。
+  let postTrapGameState = nextGameState;
+  let triggeredCheckBreak = false;
+  const opponentTrapPostMove = cardStateNext.trap[opponent];
+  // この手の結果、相手の check_break トラップが発動条件 (相手玉が王手中) を満たすか。
+  const wouldTriggerCheckBreak =
+    !!opponentTrapPostMove &&
+    opponentTrapPostMove.defId === "check_break" &&
+    isInCheck(nextGameState, opponent, CARD_SHOGI_VARIANT);
+  // Issue #220 / #222 検証修正: 二手指しの一手目 (double_move_first) は中間局面。
+  // トラップはターン完了 (二手目) の最終局面でのみ発動すべきで、一手目では常に保留する。
+  // 旧実装は「一手目が (トラップ未考慮の盤面で) 詰みなら例外的に発動」していたが、
+  // check_break トラップがセットされている限り真の詰みは成立しない (トラップが王手駒を
+  // 奪い王手を解除するため)。よって一手目発動は誤りで、二手目を指す前にトラップが暴発し、
+  // 最終局面で王手している駒ではなく一手目の駒が奪われる不具合になっていた (検証で判明)。
+  const deferCheckBreak = mode === "double_move_first";
+  if (!deferCheckBreak && wouldTriggerCheckBreak) {
+    const result = applyCheckBreak(nextGameState, opponent);
+    if (result) {
+      postTrapGameState = result.gameState;
+      // 取られた相手 (= move.player) の駒に no_promote マークがあれば消失
+      for (const cap of result.capturedPieces) {
+        if (hasNoPromoteMark(cardStateNext, finalMove.player, { row: cap.row, col: cap.col })) {
+          cardStateNext = removeNoPromoteMark(cardStateNext, finalMove.player, {
+            row: cap.row,
+            col: cap.col,
+          });
+        }
+      }
+      cardStateNext = applyTrapClear(cardStateNext, opponent);
+      events.push({
+        kind: "trapTriggerEvent",
+        player: opponent,
+        instance: opponentTrapPostMove,
+        reason: "check_declared",
+        capturedPieces: result.capturedPieces,
+        at: Date.now(),
+      });
+      triggeredCheckBreak = true;
+    }
+  }
+
+  // 5. ゲーム終了判定 + 移動イベントログ
+  const evaluated = evaluateGameEnd(postTrapGameState, CARD_SHOGI_VARIANT);
+  // Issue #220 / #222 検証修正: 二手指し一手目で check_break を保留した場合、形式上の
+  // 詰み (トラップ未適用の盤面) は真の終局ではない (ターン完了後にトラップが王手を解除
+  // する)。中間局面として active を維持し二手目を継続させる。これがないと MAKE_MOVE 側
+  // gameOver 判定が偽の詰みで二手指しを打ち切り、二手目を指せなくなる。
+  // (nextGameState は applyMove 直後で status="active"。evaluateGameEnd を通す前の値。)
+  const resultGameState =
+    deferCheckBreak && wouldTriggerCheckBreak ? nextGameState : evaluated;
+  events.push({ kind: "moveEvent", move: finalMove, at: Date.now() });
+
+  // 6. マナチャージ + lastTurnStartedAt クリア (mode で挙動を切替)
+  if (mode === "normal") {
+    // 通常の指し手: マナチャージ + 早指し判定 + タイマークリア
+    const lastStarted = cardStateNext.lastTurnStartedAt[move.player];
+    // Issue #193 / PR1a: 観戦モード時は早指し判定を完全スキップ (両 CPU が常に <4 秒で
+    // 指してマナ蓄積が異常になることを防ぐ)。spectatorMode=false の人間プレイ時は
+    // 完全に従来挙動を保持する。
+    const isFastMove =
+      !spectatorMode &&
+      lastStarted !== null &&
+      Date.now() - lastStarted < FAST_THRESHOLD_MS;
+    const manaAmount =
+      MANA_PER_TURN + (isFastMove ? MANA_FAST_BONUS : 0);
+    cardStateNext = {
+      ...cardStateNext,
+      mana: {
+        ...cardStateNext.mana,
+        [move.player]: Math.min(
+          cardStateNext.manaCap,
+          cardStateNext.mana[move.player] + manaAmount,
+        ),
+      },
+      lastTurnStartedAt: {
+        ...cardStateNext.lastTurnStartedAt,
+        [move.player]: null,
+      },
+    };
+    events.push({
+      kind: "manaChargeEvent",
+      player: move.player,
+      amount: manaAmount,
+      reason: "turn",
+      fastMove: isFastMove,
+      at: Date.now(),
+    });
+  } else if (mode === "double_move_second") {
+    // 二手指しの 2手目: マナチャージなし。lastTurnStartedAt のみクリア (ターン交代)
+    cardStateNext = {
+      ...cardStateNext,
+      lastTurnStartedAt: {
+        ...cardStateNext.lastTurnStartedAt,
+        [move.player]: null,
+      },
+    };
+  }
+  // mode === "double_move_first": どちらもしない (ターン継続中のため)
+
+  return {
+    gameState: resultGameState,
+    cardState: cardStateNext,
+    events,
+    finalMove,
+    triggeredCheckBreak,
+  };
+}

--- a/src/lib/shogi/kernel/world-kernel.ts
+++ b/src/lib/shogi/kernel/world-kernel.ts
@@ -143,7 +143,9 @@ export function finalizeDoubleMoveLogic(
 // modifyBoard 系は direct-apply (simulateCardEffect は returnedPiece / removeNoPromoteMark を
 // 落とすため使わない、計画 §4 訂正)。double_move は本関数の対象外 (applyTurnAction で別扱い)。
 // 返り値: 効果適用後の {gameState, cardState, event}。不正 (王手未解除等) は null。
-function applyCardEffectLogic(
+// Issue #235 S1d: reducer の CONFIRM_PLAY_CARD が効果適用を本関数へ委譲するため export
+// (double_move/selectTarget は reducer に残し、trap/mana_up/pawn_return/piece_return/double_pawn を委譲)。
+export function applyCardEffectLogic(
   world: WorldState,
   action: Extract<TurnAction, { kind: "playCard" }>,
   player: Player,

--- a/src/lib/shogi/kernel/world-kernel.ts
+++ b/src/lib/shogi/kernel/world-kernel.ts
@@ -1,0 +1,381 @@
+// Issue #235 S1a: L0 ルール/状態カーネル (WorldState + applyTurnAction)。
+//
+// 目的 (epic doc §3 L0 / S1 計画 docs/plans/issue-235-s1-kernel.md):
+//   カード将棋のルール/状態遷移を単一権威 applyTurnAction に集約し、reducer (UI) と AI 探索が
+//   同一ロジックを呼ぶ構造の土台を作る (P4 二重実装の解消)。
+//
+// 戦略 (再実装せず抽出して委譲、計画 §1):
+//   - move の純粋ロジックは reducer の makeMoveWithEffects を **reuse** (export して import)。
+//     ※ S1a では reducer 側は makeMoveWithEffects に export を付与するのみで振る舞い不変。
+//       makeMoveWithEffects の kernel への物理移設と reducer 薄ラッパ化は S1c (clean な層構造化)。
+//       それまで lib/kernel → hooks/reducer の暫定依存が残る (循環なし、reducer は React 非依存)。
+//   - draw/playCard/turnEnd は UI state 結合の reducer ロジックから cardState 変換部のみを抽出して
+//     kernel に新規実装 (advanceDrawProgress / applyCardEffectLogic / finalizeDoubleMoveLogic)。
+//     これらと reducer 経路の等価性は property-based 等価テスト (S1a part2) で担保する。
+//
+// 設計判断 (S1 計画 §2/§4、DP-1〜7):
+//   - 二層構造: building-block 関数群 + atomic applyTurnAction。reducer は演出フェーズ
+//     (CONFIRM/COMMIT) を維持しつつ同一 building-block を呼ぶ (関数レベル single-authority)。
+//   - DP-1: drawProgress は turn 終了時に +1、AUTO_DRAW_INTERVAL 到達∧deck非空で 0 reset + 自動ドロー
+//     (非再帰・1回)。AI 旧 immediate+1 近似は S1b でカーネル委譲時に解消。
+//   - DP-2: double_move はマルチ ply。1手目は flip 戻し turnEnded=false、2手目は applyMove で
+//     flip 済のため再 flip せず turnEnded=true + finalize 遅延消費。
+//   - DP-3: setTrap は hand→trap (graveyard 不変)、通常カードは hand→graveyard。
+//   - currentPlayer flip: move は applyMove (makeMoveWithEffects 内) が flip。draw/playCard は
+//     盤を applyMove で動かさないため kernel が明示 flip。
+
+import type { GameState, Move, Player } from "@/lib/shogi/types";
+import { isInCheck } from "@/lib/shogi/moves";
+import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import { unpromotePieceType } from "@/lib/shogi/variants/standard";
+import { CARD_DEFS, DRAW_COST, AUTO_DRAW_INTERVAL } from "@/lib/shogi/cards/definitions";
+import {
+  applyPawnReturn,
+  applyPieceReturn,
+  applyDoublePawn,
+  applyManaUp,
+  applyTrapSet,
+  consumeNormalCard,
+  removeNoPromoteMark,
+} from "@/lib/shogi/cards/effects";
+import { makeMoveWithEffects } from "@/hooks/card-shogi/reducer";
+import type {
+  CardGameState,
+  CardInstance,
+  GameEvent,
+} from "@/lib/shogi/cards/types";
+import type { TurnAction } from "@/lib/shogi/ai/turn/types";
+
+// ===== WorldState (L0) =====
+// kernel が扱う二手指し継続状態。reducer の doubleMove から UI/UNDO 専用フィールド
+// (mateInOneAvailable / preFirstMoveState / preCardState) を除いたロジック部分。
+export interface KernelDoubleMove {
+  active: Player;
+  movesLeft: 1 | 2;
+  cardInstance: CardInstance;
+  cardCost: number;
+}
+
+export interface WorldState {
+  gameState: GameState; // 盤 + 持ち駒 + currentPlayer + status
+  cardState: CardGameState; // mana/hand/deck/graveyard/trap/drawProgress/noPromoteMarks
+  doubleMove: KernelDoubleMove | null;
+}
+
+export interface ApplyTurnActionResult {
+  world: WorldState;
+  events: GameEvent[];
+  turnEnded: boolean;
+}
+
+export interface ApplyTurnActionOptions {
+  spectatorMode?: boolean; // DP-4: 早指しボーナス無効化 (決定論化)
+}
+
+const opponentOf = (p: Player): Player => (p === "sente" ? "gote" : "sente");
+
+// ===== building-block: advanceDrawProgress (DP-1) =====
+// applyTurnEndEffects (reducer.ts:447-494) の cardState 変換部を抽出。
+// turn 終了側 player の drawProgress を +1、AUTO_DRAW_INTERVAL 到達∧deck非空で 0 reset +
+// 自動ドロー (deck先頭→hand)。**非再帰・1回のみ**。UI flag (isDrawing 等) は呼出側 (reducer)
+// が返り値 events の auto drawEvent を読んで event-driven にセットする (S1c)。
+export function advanceDrawProgress(
+  cardState: CardGameState,
+  gameState: GameState,
+  player: Player,
+): { cardState: CardGameState; events: GameEvent[] } {
+  // 終局後はドロー進捗加算・自動ドロー発火をスキップ (reducer.ts:454、Issue #170)
+  if (gameState.status !== "active") return { cardState, events: [] };
+
+  const current = cardState.drawProgress[player];
+  const next = current + 1;
+  const deck = cardState.deck[player];
+
+  if (next < AUTO_DRAW_INTERVAL || deck.length === 0) {
+    return {
+      cardState: {
+        ...cardState,
+        drawProgress: { ...cardState.drawProgress, [player]: next },
+      },
+      events: [],
+    };
+  }
+
+  const [top, ...rest] = deck;
+  return {
+    cardState: {
+      ...cardState,
+      drawProgress: { ...cardState.drawProgress, [player]: 0 },
+      deck: { ...cardState.deck, [player]: rest },
+      hand: { ...cardState.hand, [player]: [...cardState.hand[player], top] },
+    },
+    events: [{ kind: "drawEvent", player, instance: top, source: "auto", at: Date.now() }],
+  };
+}
+
+// ===== building-block: finalizeDoubleMoveLogic (DP-2) =====
+// finalizeDoubleMoveCardConsumption (reducer.ts:666-694) の cardState/event 部を抽出。
+// 二手指し 2手目完了 (or 1手目詰み) 時にカード本体を遅延消費 (consumeNormalCard) + cardPlayEvent。
+export function finalizeDoubleMoveLogic(
+  cardState: CardGameState,
+  dm: KernelDoubleMove,
+): { cardState: CardGameState; events: GameEvent[] } {
+  const consumed = consumeNormalCard(
+    cardState,
+    dm.active,
+    dm.cardInstance.instanceId,
+    dm.cardCost,
+  );
+  // 異常系: 手札からカードが消えている (reducer.ts:676-679 と同じ防御)。消費せず継続。
+  if (!consumed) return { cardState, events: [] };
+  return {
+    cardState: consumed,
+    events: [
+      { kind: "cardPlayEvent", player: dm.active, instance: dm.cardInstance, at: Date.now() },
+    ],
+  };
+}
+
+// ===== building-block: applyCardEffectLogic (DP-3/DP-7) =====
+// CONFIRM_PLAY_CARD (reducer.ts:1226-1342) の効果適用部を抽出 (確定済 playCard を 1 ステップ適用)。
+// modifyBoard 系は direct-apply (simulateCardEffect は returnedPiece / removeNoPromoteMark を
+// 落とすため使わない、計画 §4 訂正)。double_move は本関数の対象外 (applyTurnAction で別扱い)。
+// 返り値: 効果適用後の {gameState, cardState, event}。不正 (王手未解除等) は null。
+function applyCardEffectLogic(
+  world: WorldState,
+  action: Extract<TurnAction, { kind: "playCard" }>,
+  player: Player,
+): { gameState: GameState; cardState: CardGameState; event: GameEvent } | null {
+  const def = CARD_DEFS[action.defId];
+  let nextGameState = world.gameState;
+  let nextCardState = world.cardState;
+  let returnedPieceInfo: { row: number; col: number; pieceType: string } | undefined;
+
+  if (def.kind === "trap") {
+    // トラップ: consumeNormalCard を使わず mana 直接減算 + applyTrapSet (graveyard 不変 DP-3)
+    if (world.cardState.mana[player] < def.cost) return null;
+    const afterMana: CardGameState = {
+      ...world.cardState,
+      mana: { ...world.cardState.mana, [player]: world.cardState.mana[player] - def.cost },
+    };
+    const afterSet = applyTrapSet(afterMana, player, action.cardInstanceId);
+    if (!afterSet) return null;
+    nextCardState = afterSet;
+  } else if (def.effectId === "mana_up") {
+    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
+    if (!consumed) return null;
+    nextCardState = applyManaUp(consumed, player);
+  } else if (def.effectId === "pawn_return" || def.effectId === "piece_return") {
+    if (!action.target || action.target.kind !== "square") return null;
+    const targetPos = { row: action.target.row, col: action.target.col };
+    const returnedPiece = world.gameState.board[targetPos.row]?.[targetPos.col];
+    const ng =
+      def.effectId === "pawn_return"
+        ? applyPawnReturn(world.gameState, player, targetPos)
+        : applyPieceReturn(world.gameState, player, targetPos);
+    if (!ng) return null;
+    nextGameState = ng;
+    if (returnedPiece) {
+      returnedPieceInfo = {
+        row: targetPos.row,
+        col: targetPos.col,
+        pieceType: unpromotePieceType(returnedPiece.type),
+      };
+    }
+    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
+    if (!consumed) return null;
+    // 持ち駒に戻った駒は no_promote マークを失う (案A 仕様、reducer.ts:1266/1284)
+    nextCardState = removeNoPromoteMark(consumed, player, targetPos);
+  } else if (def.effectId === "double_pawn") {
+    if (!action.target || action.target.kind !== "square") return null;
+    const targetPos = { row: action.target.row, col: action.target.col };
+    const ng = applyDoublePawn(world.gameState, player, targetPos);
+    if (!ng) return null;
+    nextGameState = ng;
+    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
+    if (!consumed) return null;
+    nextCardState = consumed;
+  } else {
+    return null;
+  }
+
+  // 王手中の最終ガード (reducer.ts:1338-1342): 王手中だった場合、適用後も王手なら不正 (no-op)。
+  // 合法 action では発生しないが reducer 等価のため再現。
+  if (
+    isInCheck(world.gameState, player, CARD_SHOGI_VARIANT) &&
+    isInCheck(nextGameState, player, CARD_SHOGI_VARIANT)
+  ) {
+    return null;
+  }
+
+  const event: GameEvent =
+    def.kind === "trap"
+      ? {
+          kind: "trapSetEvent",
+          player,
+          instance: { instanceId: action.cardInstanceId, defId: action.defId, owner: player },
+          at: Date.now(),
+        }
+      : {
+          kind: "cardPlayEvent",
+          player,
+          instance: { instanceId: action.cardInstanceId, defId: action.defId },
+          target: action.target,
+          returnedPiece: returnedPieceInfo,
+          at: Date.now(),
+        };
+
+  return { gameState: nextGameState, cardState: nextCardState, event };
+}
+
+// ===== atomic applyTurnAction =====
+// 確定済 TurnAction を WorldState に 1 遷移で適用。AI / property test / headless から呼ぶ。
+// reducer は演出フェーズで同一 building-block を呼ぶため、本関数と等価な結果になる
+// (property-based 等価テストで担保)。
+export function applyTurnAction(
+  world: WorldState,
+  action: TurnAction,
+  opts: ApplyTurnActionOptions = {},
+): ApplyTurnActionResult {
+  if (action.kind === "move") {
+    return applyMoveAction(world, action.move, opts);
+  }
+  if (action.kind === "draw") {
+    return applyDrawAction(world);
+  }
+  return applyPlayCardAction(world, action, opts);
+}
+
+function applyMoveAction(
+  world: WorldState,
+  move: Move,
+  opts: ApplyTurnActionOptions,
+): ApplyTurnActionResult {
+  const dm = world.doubleMove;
+  const spectatorMode = opts.spectatorMode;
+
+  // 二手指し 1手目 (movesLeft === 2)
+  if (dm && dm.movesLeft === 2) {
+    const r = makeMoveWithEffects(world.gameState, world.cardState, move, {
+      mode: "double_move_first",
+      spectatorMode,
+    });
+    const gameOver = r.gameState.status !== "active";
+    if (gameOver) {
+      // 1手目で詰み成立 → 即 finalize (reducer.ts:800-816)。status≠active なので
+      // advanceDrawProgress は no-op (reducer の COMMIT_PLAY_CARD→applyTurnEndEffects と等価)。
+      const fin = finalizeDoubleMoveLogic(r.cardState, dm);
+      const adv = advanceDrawProgress(fin.cardState, r.gameState, dm.active);
+      return {
+        world: { gameState: r.gameState, cardState: adv.cardState, doubleMove: null },
+        events: [...r.events, ...fin.events, ...adv.events],
+        turnEnded: true,
+      };
+    }
+    // 継続: currentPlayer を dm.active (自分) に戻し movesLeft 2→1 (reducer.ts:819-832)
+    return {
+      world: {
+        gameState: { ...r.gameState, currentPlayer: dm.active },
+        cardState: r.cardState,
+        doubleMove: { ...dm, movesLeft: 1 },
+      },
+      events: r.events,
+      turnEnded: false,
+    };
+  }
+
+  // 二手指し 2手目 (movesLeft === 1) → finalize 遅延消費 (reducer.ts:836-855 + COMMIT_PLAY_CARD)
+  if (dm && dm.movesLeft === 1) {
+    const r = makeMoveWithEffects(world.gameState, world.cardState, move, {
+      mode: "double_move_second",
+      spectatorMode,
+    });
+    // currentPlayer は applyMove で既に opponent へ flip 済 → 再 flip しない (DP-2)
+    const fin = finalizeDoubleMoveLogic(r.cardState, dm);
+    const adv = advanceDrawProgress(fin.cardState, r.gameState, dm.active);
+    return {
+      world: { gameState: r.gameState, cardState: adv.cardState, doubleMove: null },
+      events: [...r.events, ...fin.events, ...adv.events],
+      turnEnded: true,
+    };
+  }
+
+  // 通常 move (reducer.ts:857-875)。applyMove が currentPlayer を flip。
+  const r = makeMoveWithEffects(world.gameState, world.cardState, move, { spectatorMode });
+  const adv = advanceDrawProgress(r.cardState, r.gameState, move.player);
+  return {
+    world: { gameState: r.gameState, cardState: adv.cardState, doubleMove: null },
+    events: [...r.events, ...adv.events],
+    turnEnded: true,
+  };
+}
+
+function applyDrawAction(world: WorldState): ApplyTurnActionResult {
+  const player = world.gameState.currentPlayer;
+  // 合法 draw 前提 (deck非空・mana≥DRAW_COST・非王手・dm なし) は getLegalActions で保証。
+  const deck = world.cardState.deck[player];
+  const [top, ...rest] = deck;
+  const afterDraw: CardGameState = {
+    ...world.cardState,
+    mana: { ...world.cardState.mana, [player]: world.cardState.mana[player] - DRAW_COST },
+    deck: { ...world.cardState.deck, [player]: rest },
+    hand: { ...world.cardState.hand, [player]: [...world.cardState.hand[player], top] },
+  };
+  const drawEvent: GameEvent = {
+    kind: "drawEvent",
+    player,
+    instance: top,
+    source: "manual",
+    at: Date.now(),
+  };
+  // flip (reducer.ts:1133-1135) + turn 終了処理 (drawProgress)
+  const flippedGame: GameState = { ...world.gameState, currentPlayer: opponentOf(player) };
+  const adv = advanceDrawProgress(afterDraw, flippedGame, player);
+  return {
+    world: { gameState: flippedGame, cardState: adv.cardState, doubleMove: null },
+    events: [drawEvent, ...adv.events],
+    turnEnded: true,
+  };
+}
+
+function applyPlayCardAction(
+  world: WorldState,
+  action: Extract<TurnAction, { kind: "playCard" }>,
+  opts: ApplyTurnActionOptions,
+): ApplyTurnActionResult {
+  void opts;
+  const player = world.gameState.currentPlayer;
+  const def = CARD_DEFS[action.defId];
+
+  // double_move: doubleMove フラグ set のみ (mana/hand/graveyard 不変 = 遅延消費 DP-2、reducer.ts:1294-1331)
+  if (action.defId === "double_move") {
+    return {
+      world: {
+        ...world,
+        doubleMove: {
+          active: player,
+          movesLeft: 2,
+          cardInstance: { instanceId: action.cardInstanceId, defId: action.defId },
+          cardCost: def.cost,
+        },
+      },
+      events: [],
+      turnEnded: false,
+    };
+  }
+
+  const applied = applyCardEffectLogic(world, action, player);
+  if (!applied) {
+    // 不正 (合法 action では発生しない)。状態不変・turnEnded=false で返す。
+    return { world, events: [], turnEnded: false };
+  }
+
+  // flip (reducer.ts COMMIT_PLAY_CARD:1405) + turn 終了処理
+  const flippedGame: GameState = { ...applied.gameState, currentPlayer: opponentOf(player) };
+  const adv = advanceDrawProgress(applied.cardState, flippedGame, player);
+  return {
+    world: { gameState: flippedGame, cardState: adv.cardState, doubleMove: null },
+    events: [applied.event, ...adv.events],
+    turnEnded: true,
+  };
+}

--- a/src/lib/shogi/kernel/world-kernel.ts
+++ b/src/lib/shogi/kernel/world-kernel.ts
@@ -5,10 +5,12 @@
 //   同一ロジックを呼ぶ構造の土台を作る (P4 二重実装の解消)。
 //
 // 戦略 (再実装せず抽出して委譲、計画 §1):
-//   - move の純粋ロジックは reducer の makeMoveWithEffects を **reuse** (export して import)。
-//     ※ S1a では reducer 側は makeMoveWithEffects に export を付与するのみで振る舞い不変。
-//       makeMoveWithEffects の kernel への物理移設と reducer 薄ラッパ化は S1c (clean な層構造化)。
-//       それまで lib/kernel → hooks/reducer の暫定依存が残る (循環なし、reducer は React 非依存)。
+//   - move のロジックは `makeMoveWithEffects` を **reuse** (lib/kernel/move-effects.ts から import)。
+//     ※ S1a では reducer.ts に置いたまま export して import 再利用していたが、これは
+//       lib(kernel) → hooks(reducer) の暫定逆依存 (層違反) を生んでいた。
+//       S1c でこの関数 (+ MakeMoveMode 型) を lib 層の move-effects.ts へ物理移設し、逆依存を解消済。
+//       reducer も move-effects.ts から import して呼ぶ (挙動不変)。reducer 本体の各演出フェーズを
+//       kernel building-block へ委譲 (薄ラッパ化) するのは S1d cutover。
 //   - draw/playCard/turnEnd は UI state 結合の reducer ロジックから cardState 変換部のみを抽出して
 //     kernel に新規実装 (advanceDrawProgress / applyCardEffectLogic / finalizeDoubleMoveLogic)。
 //     これらと reducer 経路の等価性は property-based 等価テスト (S1a part2) で担保する。
@@ -38,7 +40,7 @@ import {
   consumeNormalCard,
   removeNoPromoteMark,
 } from "@/lib/shogi/cards/effects";
-import { makeMoveWithEffects } from "@/hooks/card-shogi/reducer";
+import { makeMoveWithEffects } from "@/lib/shogi/kernel/move-effects";
 import type {
   CardGameState,
   CardInstance,


### PR DESCRIPTION
## Summary
Issue #235「カード将棋AI 土台再設計」epic の **S1(L0 カーネル統合)全段**を実装。通常将棋エンジンにカードを継ぎはぎした二重実装(P4)を解消し、L0 カーネル(`applyTurnAction` + building-block)を reducer(UI)と AI 探索の**単一権威**に統一した。

### 段階
- **S1a** (29d1e1e/668cb78): `world-kernel.ts` 新設(L0 カーネル + applyTurnAction)+ property-based 等価テスト(180 seed×40 ply + targeted 15)。additive・production 不変。
- **S1b** (b2d5fd6): AI 探索を `useKernelSearch` フラグ裏で applyTurnAction 経由に切替可能化(既定 OFF、production 不変)。
- **S1c** (f5464c0): `makeMoveWithEffects` を reducer→`lib/shogi/kernel/move-effects.ts` へ物理移設(lib→hooks 逆依存解消)。挙動完全不変・純粋リファクタ(関数本体 byte 一致を diff 実証)。
- **S1d** (a8b41ca): cutover。reducer 3箇所(applyTurnEndEffects/finalizeDoubleMoveCardConsumption/CONFIRM_PLAY_CARD)を kernel building-block へ委譲 + AI `useKernelSearch` 既定 ON(route.ts、案B)。探索 lookahead は spectatorMode=true 固定で決定論化。

### 挙動変化
- **UI**: 意図的に等価(reducer.test + 演出オーケストレーション統合テスト 3 件新設で担保)。
- **AI**: DP-1 lazy drawProgress / move への base mana charge の**意図的既知差分のみ**(root 兄弟 move は同一オフセットで move 間順位不変、move vs card/draw 選好のみ作用。係数再校正は S3 予定・ユーザー承認済)。

### rollback
S1d は単一コミット隔離 → `git revert` で旧経路復帰。AI は route.ts の `useKernelSearch: true` 削除で OFF。engine 既定は OFF 維持のため test/bench baseline 不変。

## Test plan
- lint 0err / typecheck / **test:ci 542 passed** / build green
- bench (RUN_PERF_BENCH=true): advanced/expert で cardRate OFF=4/4→ON=4/4、全 8 シナリオで action 選択 **OFF==ON 一致**、depthCompleted **d4==d4**(棋力退化なし)
- 各段で M1(計画直後)/ M2(実装後)の adversarial レビューを実施(S1d は M2 でコード欠陥ゼロ)

詳細・S1 完了定義・S2 引き継ぎ: `docs/plans/issue-235-s1-kernel.md` §16

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)