### PR TITLE
feat: #235 S2a L1 CardSpec registry 新設 (additive)

### DIFF
--- a/docs/plans/issue-235-s2-cardspec.md
+++ b/docs/plans/issue-235-s2-cardspec.md
@@ -1,0 +1,127 @@
+# Issue #235 S2: L1 カードフレームワーク化 (CardSpec registry) — 実装計画
+
+> 親 doc (epic SSOT): `docs/plans/issue-235-card-shogi-ai-redesign.md` (§3 L1 / §4 CardSpec/EffectSpec 詳細 / §7 S2 行 / §11 D-D)。
+> 前段: S1 (L0 カーネル統合) 完了・PR #236 マージ済 (main `cad859c`)。S1 完了定義: `issue-235-s1-kernel.md §16`。
+> ブランチ `refactor/#235-s2` (origin/main 起点)。本 doc は AGENTS.md ルール8 マイルストーン1 (実装着手前レビュー) の対象。
+
+## 0. 位置づけ・ゴール / 非ゴール
+S2 = L1 カードフレームワーク化。現状 1 カードが 6+ ファイルに分散 (definitions CARD_DEFS + CARD_USE_CONDITIONS +
+effects applyXxx + digest/heuristics 係数 + action-generator 候補 + undo-policy isCardOpEvent + reducer/kernel 効果分岐)
+している構造を、単一 `CardSpec` registry に集約する (P2/P5 解消)。
+
+**ゴール**:
+1. `CardSpec` 型 + `EffectSpec` 判別共用体 (modifyBoard/setTrap/multiPly/modifyResource) を定義し、**7 カード全てを CardSpec で表現**する registry を新設。
+2. **効果適用を registry 駆動に統一**: kernel `applyCardEffectLogic` の effectId switch (S1d で集約済) を `spec.effect.apply` 一本へ置換 (P5 解消)。
+3. **横断制約を registry から自動導出**: undo-policy `isCardOpEvent` / action-generator 候補生成 / checkUsage を CardSpec から導出し、族別 switch を排除。
+4. CardId は **branded string + ランタイム registry** (§11 D-D 既定。型安全不足なら codegen を後続検討)。
+5. serialize 境界維持: 関数を持つ registry はサーバ専用、Client へは `meta` のみ (現 CARD_USE_CONDITIONS 分離を踏襲)。
+
+**非ゴール (S2 では触らない)**:
+- **valueModel の内容依存値付け = S3** (S2 では valueModel フィールドを CardSpec に置くが、中身は現行 digest/heuristics の固定係数を呼ぶ薄いブリッジに留める。局面・コスト依存化は S3)。
+- L2 TurnAction 単一探索 / TT 拡張 = S4。L3 相手モデル = S5。
+- 新カード追加・カード仕様変更・マナ/レアリティ定数の値変更 (CardSystemConfig 集約は構造のみ、値は不変)。
+- standard variant (カード非関与)。
+
+## 1. 等価性の大前提 (挙動完全不変)
+S2 は**振る舞いを変えない純粋リファクタ** (registry 経由でも現行と同一の効果・event・候補・undo 判定)。
+- 既存テスト (reducer.test/undo-policy.test/effects.test/world-kernel-equivalence/kernel-search-equivalence/card-digest/action-generator) 全 green を**全コミットで維持**。
+- bench で棋力退化なし (action 選択 / depthCompleted / cardRate)。
+- 等価ゲート = 上記テスト群 + registry 出力 ≡ 現行関数出力の特性化テスト。
+
+## 2. CardSpec スキーマ (epic §4 準拠、**M1 確定版**)
+```ts
+interface CardSpec {
+  meta: CardMeta;                            // 関数なし = Client 送信可 (§9 A5)
+  targeting: "none" | "ownPiece" | "enemyPiece" | "square";
+  effect: EffectSpec;                        // 判別共用体 (CONFIRM 時の効果適用、下記)
+  multiPly?: number;                         // M1: double_move 専用。effect 外の独立フィールド。
+                                             //   遅延消費/flip 抑止/preFirstMoveState は reducer+kernel の
+                                             //   既存 orchestration (KernelDoubleMove/finalizeDoubleMoveLogic)
+                                             //   が担い、registry はメタデータ (plies) のみ保持。
+  useCondition?: (world, player) => boolean; // = CARD_USE_CONDITIONS 内包 (サーバ専用)
+  checkUsage: "forbidden" | "conditional" | "unconditional";
+  valueModel: (gameState, player) => number; // S2 は現行 digest/heuristics 係数を呼ぶ薄い wrapper、S3 で局面依存化
+  eventKind: GameEventKind;                  // undo-policy.isCardOpEvent を registry から導出 (§9 A6 派生規則)
+}
+// CardMeta = { id: CardId; kind: "normal"|"trap"; name; icon; cost; rarity; phase; status; relatedIssues? }
+//   (description/detailDescription/useConditionDescription/addedAt は meta から除外 = §9 A6)
+type EffectSpec =
+  // modifyBoard: 盤面のみ変更 (持ち駒消費 consumeNormalCard と event 構築は dispatcher が汎用処理)。
+  //   pawn_return/piece_return の removeNoPromoteMark 等の sideEffect は dispatcher の post-apply で処理 (§9 B3)。
+  | { type: "modifyBoard"; apply: (gameState, player, target) => GameState | null } // pawn_return/piece_return/double_pawn
+  // setTrap: set は registry 駆動 (applyTrapSet)。onTrigger は **S2 では未配線 stub** (型枠のみ、@deferred)。
+  //   trap trigger (no_promote 成り抑止 / check_break 王手崩し) は move-effects.ts インライン温存 = Route B (§9 R-1)。
+  | { type: "setTrap"; trigger: "promotion_declared" | "check_declared"; onTrigger?: (world) => WorldState }
+  // modifyResource: mana_up 等。mana/draw のリソース変更を宣言的に。
+  | { type: "modifyResource"; mana?: number; draw?: number }; // mana_up
+```
+- `meta` (関数なし) は Client 送信可。`effect.apply`/`useCondition`/`valueModel`/`onTrigger` (関数) は**サーバ専用モジュール `card-spec-server.ts` に物理分離** (§9 A5)。
+- **multiPly は effect 共用体から除外** (M1 A1/A2)。double_move は applyCardEffectLogic 対象外でフラグセットのみ、遅延消費は finalizeDoubleMoveLogic という S1d 既存構造を維持し、registry はメタデータのみ持つ。
+- **EffectSpec.type 別テンプレ**で新カードは type 選択 + パラメータ埋め (ビジョン⑥)。
+
+## 3. 段階分割案 (S2a〜S2e、各段で等価ゲート green) — **M1 で妥当性検証**
+S1 の a/b/c/d 同様、低リスクな additive → cutover の順で段階化:
+- **S2a (additive、型 + registry skeleton)**: `card-spec.ts` 新設 = CardSpec/EffectSpec 型 + 7 カードの CardSpec データ (meta は CARD_DEFS から、effect は既存 applyXxx を包む薄い wrapper、valueModel は現行係数ブリッジ、eventKind/useCondition/checkUsage を移植)。**production 未配線**。registry 出力 ≡ 現行の特性化テスト新設。
+- **S2b (effect 統一)**: kernel `applyCardEffectLogic` の effectId switch を `spec.effect.apply` 駆動へ置換 (modifyBoard/setTrap/multiPly/modifyResource)。reducer は S1d で既に applyCardEffectLogic 委譲済のため kernel 1 箇所の置換で UI/AI 両方に波及。等価ゲート green。
+- **S2c (横断制約 registry 化)**: undo-policy `isCardOpEvent` を `spec.eventKind` 導出へ / action-generator 候補生成を registry クエリへ / checkUsage を spec 参照へ。族別 switch 排除。
+- **S2d (cleanup)**: 旧 CARD_DEFS / CARD_USE_CONDITIONS / effects applyXxq の重複を registry へ一本化 (legacy 経路を撤去 or 薄い re-export 化)。デッドコード除去。CardId branded string 化。
+- **S2e (config 集約)**: RARITY_MAX_PER_DECK / マナ定数を `CardSystemConfig` として registry 近傍に集約 (値は不変)。
+- 注: §4 移行方針の「legacy wrapper で段階移行」は **7 カードを一括で CardSpec data 化 (S2a) しつつ、production 配線を S2b 以降で段階切替**することで工数とデグレリスクを分散する解釈。一括 data 化 vs カード単位 wrapper の是非は M1 で検討。
+
+## 4. 現行構造の棚卸し (移植元マップ)
+- `definitions.ts`: CardDefinition (id/kind/name/icon/cost/rarity/phase/status/effectId/targeting/relatedIssues/useConditionDescription/checkUsage) + CARD_DEFS (7枚) + CARD_USE_CONDITIONS (関数) + 定数 (MANA_CAP/DRAW_COST/AUTO_DRAW_INTERVAL/MANA_PER_TURN/MANA_FAST_BONUS) + RARITY 系。
+- `effects.ts`: applyManaUp/applyPawnReturn/applyPieceReturn/applyDoublePawn/applyTrapSet/applyCheckBreak/applyTrapClear/consumeNormalCard/hasNoPromoteMark/addNoPromoteMark/removeNoPromoteMark/moveNoPromoteMark/getCheckEscapingSquares/hasSameKindTrapPlaced/simulateCardEffect/isValidCardTargetSquare。
+- `kernel/world-kernel.ts`: `applyCardEffectLogic` (effectId switch、S1d で UI/AI 共通の効果適用権威) ← **S2b の主置換点**。
+- `kernel/move-effects.ts`: makeMoveWithEffects (trap 発動 no_promote/check_break をインライン処理) ← setTrap.onTrigger との関係を S2b で整理。
+- `undo-policy.ts`: isCardOpEvent ← S2c で eventKind 導出。
+- `ai/turn/action-generator.ts` (or current-rules.ts): playCard 候補生成 ← S2c で registry クエリ。
+- `ai/cards/digest.ts` / `heuristics.ts`: 固定係数 ← S2 は valueModel ブリッジで温存、S3 で置換。
+- `types.ts`: CardId 手書きユニオン ← S2d で branded string + registry 導出。
+- seed (`prisma`): ALL_CARD_DEFS 経由 ← registry から ALL_CARD_DEFS を導出して互換維持。
+
+## 5. リスク (M1 確定方針を併記)
+- **R-1 trap 発動の二系統 → Route B 確定 (M1)**: `setTrap` の **set のみ registry 化** (applyTrapSet)、**trigger (no_promote 成り抑止 / check_break 王手崩し) は move-effects.ts インライン温存**。理由: trigger は post-move 状態 (promote flag / isInCheck / double_move 遅延) と密結合で、`onTrigger:(world)=>WorldState` では applyCheckBreak の `capturedPieces` (effects.ts:369) を caller に返せず trapTriggerEvent を構築不能。完全 registry 化 (Route A) は move-effects 数百 LOC 改修 + DP-7 再検証を S2b に持ち込みリスク過大。`setTrap.onTrigger` は型枠のみ S2a で確保 (`@deferred`)、実配線は S3 新サブタスクへ。→ **P5 は 5/7 カードで解消、trap 2 枚は S3 へ正当に先送り**。
+- **R-2 serialize 境界 → 現状の漏れを S2d で是正 (M1 訂正)**: 「現 CARD_USE_CONDITIONS 分離を踏襲」は**誤り**。現状 Client (card-view 等) / use-card-shogi-game が `isValidCardTargetSquare` 等の関数を直接 import しており分離は崩れている。S2 で `card-spec.ts` (meta-only / client-safe) と `card-spec-server.ts` (関数入り) を物理分離し、ESLint で `src/components/**`・`src/hooks/**` からの server import を禁止。registry の関数バンドルを Client に出さないことを厳格化 (是正は S2d)。
+- **R-3 CardId → 手書きユニオン維持 (M1 から安全側に確定)**: M1 既定は「branded string + property-test safeguard」だが、**S2 では CardId 手書きユニオンを維持** (`Record<CardId, CardSpec>` で網羅検査を保持) を採用。理由: registry の価値 (効果/undo/候補の単一源) は CardId の型表現変更を要さず、branded string 化は compile-time 網羅検査を失う実害がある一方 S2 の機能的便益はゼロ。branded string / codegen は registry-derived ID が必要になった時点 (新カード運用 S6 等) で再検討 (park)。加えて registry 定義漏れ検出の property test (全7枚 `CARD_DEFS[id]!==undefined`) を CI 必須化。
+- **R-4 valueModel ブリッジ → 採用 (M1、箱だけ作るは妥当)**: S3 で局面依存値付けを入れる interface 固定先として S2 で枠を置くのは合理的 (CardSpec を 2 度書き換え回避)。S2 の中身は現行 digest/heuristics 固定係数を呼ぶ薄い wrapper に厳格限定、シグネチャ `(gameState, player)=>number` を固定。
+- **R-5 一括 data 化のデグレ → 一括採用 (M1)**: カード単位 wrapper は不採用。7 カード一括 CardSpec data 化 (S2a) + production 段階配線 (S2b〜) が工数コンパクト・rollback を S2b 単一に隔離・wrapper lifecycle 管理不要。特性化テスト (§6/§9 A6) で move-only 等価を担保。
+
+## 6. 検証ゲート
+各段で lint → typecheck → test:ci (全 green 維持) → build。S2b/S2c (production 配線変更) は bench (棋力退化なし) 追加。
+registry 出力 ≡ 現行の特性化テストを S2a で新設し全段で維持。
+
+## 7. rollback
+各段 additive or 単一 cutover コミット隔離。S2b (effect 統一) が主たる production 配線変更 = `git revert` 対象。
+registry は新規ファイルのため S2a は revert 安全。
+
+## 8. S2 DoD (M1 確定反映)
+- [ ] **S2a**: CardSpec/EffectSpec 型 (multiPly は effect 外 / onTrigger optional stub) + 7 カード registry data (`card-spec.ts` = meta-only client-safe / `card-spec-server.ts` = 関数)。registry SSOT helper (`getActiveCards`/`getPlayableCards`/`getValidCardIds`) 定義。`ALL_CARD_DEFS = registry 由来` の re-export で seed bit-identical 互換。CardId 手書きユニオン維持 + 全7枚 exhaustiveness property test。CARD_USE_CONDITIONS の `(world,player)` シグネチャ統一 (現3引数の cardState 未使用) を同梱。
+- [ ] **S2a 特性化テスト** (§9 A6): meta subset 一致 / effect.apply を各 modifyBoard カードで複数 board×player×target fixture で現 applyXxx と構造一致 / eventKind 派生規則 / useCondition・checkUsage・valueModel を複数 snapshot で現行一致。
+- [ ] **S2b**: applyCardEffectLogic の effectId switch → spec.effect.apply dispatch へ置換 (consumeNormalCard・event 構築・sideEffect removeNoPromoteMark は dispatcher 汎用処理)。**trap trigger (move-effects インライン) には触れない (Route B、DP-7 保全)**。bench 棋力退化なし。
+- [ ] **S2c**: isCardOpEvent を spec.eventKind 導出 / action-generator 候補生成を registry クエリ / checkUsage を spec 参照。族別 switch 排除。
+- [ ] **S2d**: 旧 CARD_DEFS/CARD_USE_CONDITIONS 重複の一本化・デッドコード除去。serialize 境界是正 (ESLint で Client→server import 禁止)。
+- [ ] **S2e**: CardSystemConfig 集約 (値は不変)。
+- [ ] valueModel は現行係数ブリッジ (中身は S3、構造のみ)。trap onTrigger は @deferred stub (実配線 S3)。
+- [ ] 各段 lint/typecheck/test:ci/build green。段階順序 S2a→S2b→(S2c)→S2d→S2e (S2c/S2d は S2b 前提=revert 単独不可を §7 明記)。
+
+## 9. M1 マイルストーン1レビュー反映 (計画直後、2026-06-07、AGENTS.md ルール8)
+5観点 adversarial workflow (schema-coverage/staging-risk/trap-integration/serialize-cardid/scope-equivalence-doc、41 agents、26 confirmed) でレビュー。**総合判定: 計画は妥当・条件付き着手可**(アーキ不備の指摘ゼロ、全て「doc の明示不足/段階分割の詳細化」に収束)。本節で 6 決定を確定 = 反映済で S2a 着手可。
+
+### 確定した主要設計判断 (c)
+- **A1/A2 CardSpec スキーマ訂正** (§2 反映): (1) `multiPly` を effect 共用体から外し CardSpec 直下 `multiPly?: number` へ (double_move の遅延消費/preFirstMoveState は reducer+kernel の既存 orchestration が担い registry はメタのみ)。(2) `modifyBoard.apply` 返り値を `GameState|null` に (consumeNormalCard/event は dispatcher 汎用)。(3) `setTrap.onTrigger` は optional stub (@deferred)。(4) `modifyResource` 明示シグネチャ。
+- **R-1 trap = Route B 確定**: set のみ registry 化、trigger はインライン温存。P5 は 5/7 解消、trap 2 枚は S3 へ先送り (capturedPieces を onTrigger で返せない構造的理由)。
+- **R-5 一括 data 化採用**: 7 カード一括 (S2a) + 段階配線 (S2b〜)。カード単位 wrapper 不採用。rollback を S2b 単一隔離。
+- **R-3 CardId 手書きユニオン維持** (M1 から安全側へ): branded string 化は網羅検査喪失の実害があり S2 便益ゼロのため見送り。registry は `Record<CardId,CardSpec>`。exhaustiveness property test を CI 必須化。branded/codegen は park。
+- **R-4 valueModel ブリッジ採用**: S3 interface 固定先として枠を置く (中身は現行係数 wrapper)。
+
+### 着手前に反映すべき必須事項 (a) — 本節で対応済
+- **A5 serialize 漏れの訂正**: 「現状踏襲」は誤り (Client が関数を直 import = 分離崩れ)。`card-spec.ts`(meta) / `card-spec-server.ts`(関数) 物理分離 + ESLint 禁止ルール (是正は S2d)。§5 R-2 訂正済。
+- **A6 特性化テスト仕様 + eventKind 派生規則を DoD 明記**: §8 反映。**eventKind 派生規則**: `mana_up/pawn_return/piece_return/double_pawn/double_move → "cardPlayEvent"` (double_move は finalize 時)、`no_promote/check_break(set) → "trapSetEvent"`、trigger は `"trapTriggerEvent"` (別ライフサイクル)。mana_up の発行 event は現 reducer を実測して合わせる。
+
+### 実装時の注意 (b)
+- **B1 S2b の trigger スコープ侵食防止**: S2b は applyCardEffectLogic 置換に限定、move-effects の trap trigger に触れない (DP-7 デグレ防止)。
+- **B2 段階順序・revert 隔離**: S2a→S2b→(S2c)→S2d→S2e。S2c/S2d は S2b 前提で単独 revert 不可 (§7 明記)。CARD_USE_CONDITIONS の `(world,player)` 化は S2a 同梱可。
+- **B3 sideEffect**: pawn_return/piece_return の removeNoPromoteMark は dispatcher の post-apply 条件呼び出し (registry に sideEffects 枠は足さない)。
+- **B4 registry SSOT helper**: seed/orphan-guard/Client が ALL_CARD_DEFS を直読 → helper 経由へ S2c/S2d で切替、seed bit-identical test を S2d DoD。
+- **B5 Client 防御レンダリング (派生軽微、同居可)**: card-view の `CARD_DEFS[id]` raw lookup は deprecate 時 NPE 懸念 → `if(!def) return <UnknownCard/>` を S2a/S2b で同居 (rule 2)。
+- **B6 deferCheckBreak は外部維持**: double_move_first の trap defer は将来 onTrigger registry 化しても call site 外に残す (S3 申し送り)。

--- a/docs/plans/issue-235-s2-cardspec.md
+++ b/docs/plans/issue-235-s2-cardspec.md
@@ -95,11 +95,15 @@ registry 出力 ≡ 現行の特性化テストを S2a で新設し全段で維�
 registry は新規ファイルのため S2a は revert 安全。
 
 ## 8. S2 DoD (M1 確定反映)
-- [ ] **S2a**: CardSpec/EffectSpec 型 (multiPly は effect 外 / onTrigger optional stub) + 7 カード registry data (`card-spec.ts` = meta-only client-safe / `card-spec-server.ts` = 関数)。registry SSOT helper (`getActiveCards`/`getPlayableCards`/`getValidCardIds`) 定義。`ALL_CARD_DEFS = registry 由来` の re-export で seed bit-identical 互換。CardId 手書きユニオン維持 + 全7枚 exhaustiveness property test。CARD_USE_CONDITIONS の `(world,player)` シグネチャ統一 (現3引数の cardState 未使用) を同梱。
-- [ ] **S2a 特性化テスト** (§9 A6): meta subset 一致 / effect.apply を各 modifyBoard カードで複数 board×player×target fixture で現 applyXxx と構造一致 / eventKind 派生規則 / useCondition・checkUsage・valueModel を複数 snapshot で現行一致。
+- [x] **S2a** (完了・commit 予定): CardSpec/EffectSpec 型 (multiPly は effect 外 / onTrigger optional stub) + 7 カード registry data (`card-spec.ts` = meta-only client-safe / `card-spec-server.ts` = 関数)。registry SSOT helper (`getActiveCards`/`getPlayableCards`/`getValidCardIds`) 定義。CardId 手書きユニオン維持 + 全7枚 exhaustiveness property test。CARD_USE_CONDITIONS の `(world,player)` シグネチャ統一 (現3引数の cardState 未使用) を同梱。
+  - **S2a 実装時の確定 (M2 反映、§10)**: 「`ALL_CARD_DEFS = registry 由来` re-export で seed bit-identical」は **S2d へ先送り** (seed.ts が CardMeta 非包含の `description`/`effectId` を必要とし、CardMeta subset から再構成不可)。S2a は **definitions.ts を SSOT 維持** + registry の meta を CARD_DEFS から射影 (`toCardMeta`)。helper は additive 提供のみ (consumer 切替は S2c/S2d)。
+- [x] **S2a 特性化テスト** (§9 A6、完了 29件): meta subset 一致 / effect.apply を各 modifyBoard カードで複数 board×player×target fixture で現 applyXxx と構造一致 / eventKind 派生規則 / useCondition・checkUsage を複数 snapshot で現行一致 / valueModel は静的 stub の snapshot (現行に per-card valueModel は無く、本 stub の出力を pin)。
 - [ ] **S2b**: applyCardEffectLogic の effectId switch → spec.effect.apply dispatch へ置換 (consumeNormalCard・event 構築・sideEffect removeNoPromoteMark は dispatcher 汎用処理)。**trap trigger (move-effects インライン) には触れない (Route B、DP-7 保全)**。bench 棋力退化なし。
+  - **M2 申し送り (§10 D1-1)**: world-kernel が card-spec-server を **value import** する際、world-kernel ↔ card-spec-server の **型レベル相互参照** が成立する (runtime 循環は無害=検証済。card-spec-server の runtime 依存は card-spec/definitions/effects のみで kernel に到達しない)。L1(cards/) が L0(kernel/) から `WorldState` を借りる型従属は目標アーキ (ai→L1 正方向) と逆向きのため、(a) `WorldState` を下位共有型モジュールへ移す、または (b) `UseCondition`/`ValueModel`/`onTrigger` を cards/ ローカル最小型 `{ gameState; cardState }` に縮約 (KernelDoubleMove 不要) して kernel 依存を外す、のいずれかで型循環を解消することを **S2b の PR レビュー観点に含める**。
 - [ ] **S2c**: isCardOpEvent を spec.eventKind 導出 / action-generator 候補生成を registry クエリ / checkUsage を spec 参照。族別 switch 排除。
+  - **M2 申し送り**: `CardEventKind` (card-spec.ts) は card 自身の使用/設置 event (`cardPlayEvent`/`trapSetEvent`) のみ。`isCardOpEvent` 導出時は **トラップ発動 `trapTriggerEvent` を別途合算** すること (別ライフサイクル=相手手番で発火するため card の eventKind には含めていない)。
 - [ ] **S2d**: 旧 CARD_DEFS/CARD_USE_CONDITIONS 重複の一本化・デッドコード除去。serialize 境界是正 (ESLint で Client→server import 禁止)。
+  - **M2 申し送り (§10 D1-2)**: 境界強制方式の候補。repo には既に `server-only` パッケージが導入済 (`package.json` deps + `src/lib/auth/{current-user,config,merge,user-bootstrap}.ts` で実使用 + `vitest.config.ts` で no-op shim alias 済) のため、`card-spec-server.ts` 冒頭へ `import "server-only"` を付すのが最小コスト。eslint `no-restricted-paths` との二者択一を S2d で確定する。
 - [ ] **S2e**: CardSystemConfig 集約 (値は不変)。
 - [ ] valueModel は現行係数ブリッジ (中身は S3、構造のみ)。trap onTrigger は @deferred stub (実配線 S3)。
 - [ ] 各段 lint/typecheck/test:ci/build green。段階順序 S2a→S2b→(S2c)→S2d→S2e (S2c/S2d は S2b 前提=revert 単独不可を §7 明記)。
@@ -125,3 +129,24 @@ registry は新規ファイルのため S2a は revert 安全。
 - **B4 registry SSOT helper**: seed/orphan-guard/Client が ALL_CARD_DEFS を直読 → helper 経由へ S2c/S2d で切替、seed bit-identical test を S2d DoD。
 - **B5 Client 防御レンダリング (派生軽微、同居可)**: card-view の `CARD_DEFS[id]` raw lookup は deprecate 時 NPE 懸念 → `if(!def) return <UnknownCard/>` を S2a/S2b で同居 (rule 2)。
 - **B6 deferCheckBreak は外部維持**: double_move_first の trap defer は将来 onTrigger registry 化しても call site 外に残す (S3 申し送り)。
+
+## 10. M2 マイルストーンレビュー (実装後、2026-06-07、AGENTS.md ルール8)
+
+S2a 実装完了時点のレビュー。adversarial multi-agent workflow (6観点: equivalence / architecture / plan-conformance / additive-regression / test-quality / code-quality、各 finding を懐疑的に検証) を起動したが、**セッション上限により途中で打ち切り** (architecture 観点の検証のみ完走=確定2件、equivalence/additive-regression 観点と他観点の verifier・synthesis は未完)。打ち切り分は **main-loop セルフレビュー** で補完した (ルール8 のセルフレビュー軸)。検証実測: lint 0err / typecheck 緑 / test:ci **571 passed** (S1d 542 + 新規 29) / build 緑。production への registry import は **0件** (grep 確認 = 真に additive・未配線)。
+
+### 総合判定
+**S2a は commit/push 可 (high かつ S2a スコープ内の指摘ゼロ)**。確定 findings は 2 件で、いずれも **S2a スコープ外 (S2b/S2d 後段送り)** = S2a コード変更不要。doc への申し送りのみ実施 (§8 の各段 DoD に追記)。
+
+### 確定 findings (adversarial 検証通過、両方とも後段送り)
+- **D1-1 (architecture, medium → S2b)**: card-spec-server の `import type { WorldState }` は S2a では inert stub として最小・正当 (runtime 循環なし、`isolatedModules` で完全 erase)。ただし S2b で world-kernel が card-spec-server を value import すると **型レベル相互参照** が成立し、L1→L0 への型従属が目標アーキと逆向きになる。→ §8 S2b DoD に解消方針 (WorldState 下位移設 or ローカル最小型縮約) を S2b PR レビュー観点として追記済。
+- **D1-2 (architecture, low → S2d)**: S2d 前提の ESLint 境界 (components/hooks → server import 禁止) が現 eslint.config に未整備。現状は `-server` 命名規約 + 物理分離のみで境界担保 (S2a は未配線のため挙動・安全性に影響なし)。→ §8 S2d DoD に「`server-only` パッケージは repo 既使用のため `import "server-only"` が最小コスト」を追記済 (検証者が原 finding の「server-only 未使用」の事実誤りを訂正)。
+
+### セルフレビューで確認した未完観点 (問題なし)
+- **等価性**: effect.apply は applyXxx の薄い wrapper (15 fixture deepEqual 緑) / eventKind 派生 (`deriveEventKind`) は world-kernel.ts:215-230 の発行 event と一致 (mana_up=cardPlayEvent / trap=trapSetEvent) / useCondition は現行3条件が cardState 未使用のため (world,player) wrap で等価 / meta・targeting・checkUsage は CARD_DEFS 射影。
+- **additive/非デグレ**: production の registry import 0件 / card-view B5 ガード `faceDown || !def` は def 常時定義済のため挙動不変 / definitions.ts・ALL_CARD_DEFS・seed/deck/auth 経路は不変。
+- **テスト品質**: 29件で成功/null/ピン/と金 unpromote/gote 対称/非square target/exhaustiveness/入力非依存を網羅。`trapTriggerEvent` の S2c 申し送りをコメント明記。
+- **コード品質**: CARD_VALUE_BRIDGE は named const + 文書化 (ai/heuristics 同値だが上向き依存回避のため非 import、S3 で valueModel を SSOT 化し依存反転)。void パターンは world-kernel:350 前例と整合。未使用 export は特性化テストが exercise (デッドコードなし)。
+- **計画適合**: M1 6決定すべて反映。逸脱 (ALL_CARD_DEFS re-export 先送り / meta を CARD_DEFS から派生 / valueModel ローカルブリッジ) は本 §10 / §8 で文書化・正当化済。
+
+### 残課題 (S2a 後)
+- セッション上限が解消した後 (任意)、打ち切った adversarial workflow を fresh 再実行して equivalence/additive 観点の独立検証を補強してもよい (現状はセルフレビュー + 29特性化テスト + grep で代替済)。

--- a/src/components/game/card-shogi/card-view.tsx
+++ b/src/components/game/card-shogi/card-view.tsx
@@ -197,7 +197,10 @@ export const CardView = memo(function CardView({
 }: CardViewProps) {
   const def = CARD_DEFS[card.defId];
 
-  if (faceDown) {
+  // Issue #235 S2 (B5): CARD_DEFS の raw lookup 防御。S2d で CARD_DEFS を registry へ
+  // 一本化・deprecate する過程で未知 defId が渡された場合に def.rarity 等で NPE するのを防ぐ。
+  // 現状 def は常に定義済のため挙動不変 (本ガードは到達しない)。未知時は裏向き表示でフォールバック。
+  if (faceDown || !def) {
     return <CardBack size={size} fullWidth={fullWidth} />;
   }
 

--- a/src/lib/shogi/cards/__tests__/card-spec.test.ts
+++ b/src/lib/shogi/cards/__tests__/card-spec.test.ts
@@ -1,0 +1,542 @@
+// Issue #235 S2a: CardSpec registry の特性化テスト (S2 計画 §8 / §9 A6)。
+//
+// 位置づけ: S2a で新設した registry (card-spec.ts / card-spec-server.ts) は production 未配線 (additive)。
+// 本テストが「registry 出力 ≡ 現行 (CARD_DEFS / CARD_USE_CONDITIONS / applyXxx)」を pin する唯一の
+// 正当性検証であり、S2b 以降 (registry を実 dispatch へ繋ぐ cutover) の等価ゲートの土台になる。
+//
+// 検証項目:
+//   1. exhaustiveness (全 7 枚が registry に存在、CARD_DEFS と過不足なし — R-3 安全網)
+//   2. CARD_META ≡ CARD_DEFS の subset 射影 (除外フィールドを含まない、§9 A6)
+//   3. CardSpec の targeting / checkUsage ≡ CARD_DEFS
+//   4. eventKind 派生規則 (trap → trapSetEvent / 他 → cardPlayEvent、§9 A6)
+//   5. effect.type / multiPly / setTrap.trigger / onTrigger stub の構造
+//   6. effect.apply ≡ 現行 applyXxx (複数 board × player × target fixture で構造一致)
+//   7. useCondition ≡ CARD_USE_CONDITIONS (複数 snapshot)
+//   8. valueModel snapshot (静的 stub、入力非依存)
+//   9. registry SSOT helper ≡ ALL_CARD_DEFS ベースの抽出
+
+import { describe, expect, it } from "vitest";
+
+import type { Board, GameState, Piece, Player, Position } from "@/lib/shogi/types";
+import type { CardGameState, CardId, CardInstance } from "../types";
+import { ALL_CARD_DEFS, CARD_DEFS, CARD_USE_CONDITIONS } from "../definitions";
+import { applyDoublePawn, applyPawnReturn, applyPieceReturn } from "../effects";
+import {
+  CARD_META,
+  getActiveCards,
+  getPlayableCards,
+  getValidCardIds,
+} from "../card-spec";
+import {
+  CARD_SPECS,
+  getAllCardSpecs,
+  getCardSpec,
+  type EffectSpec,
+} from "../card-spec-server";
+import type { WorldState } from "@/lib/shogi/kernel/world-kernel";
+
+// ===== fixtures (effects.test.ts と同方式) =====
+
+const ROWS = 9;
+const COLS = 9;
+
+// 手書きユニオン CardId の全件 (R-3: registry 定義漏れ検出の property test 用。
+// CardId を追加して registry/本配列に追記し忘れると、型 (Record<CardId, CardSpec>) と本テストの
+// 双方で検出される)。
+const ALL_CARD_IDS: CardId[] = [
+  "mana_up",
+  "pawn_return",
+  "double_pawn",
+  "piece_return",
+  "check_break",
+  "double_move",
+  "no_promote",
+];
+
+// CardMeta が持つべきキー / 持ってはならないキー (§9 A6)。
+const META_KEYS: (keyof (typeof CARD_META)[CardId])[] = [
+  "id",
+  "kind",
+  "name",
+  "icon",
+  "cost",
+  "rarity",
+  "phase",
+  "status",
+  "relatedIssues",
+];
+const META_EXCLUDED_KEYS = [
+  "description",
+  "detailDescription",
+  "useConditionDescription",
+  "addedAt",
+  "effectId",
+  "targeting",
+  "checkUsage",
+];
+
+function emptyBoard(): Board {
+  return Array.from({ length: ROWS }, () => Array<Piece | null>(COLS).fill(null));
+}
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    board: emptyBoard(),
+    hand: { sente: {}, gote: {} },
+    currentPlayer: "sente",
+    moveHistory: [],
+    positionHistory: [],
+    status: "active",
+    moveCount: 0,
+    ...overrides,
+  };
+}
+
+function makeCardState(overrides: Partial<CardGameState> = {}): CardGameState {
+  return {
+    mana: { sente: 0, gote: 0 },
+    manaCap: 20,
+    hand: { sente: [], gote: [] },
+    deck: { sente: [], gote: [] },
+    graveyard: { sente: [], gote: [] },
+    trap: { sente: null, gote: null },
+    pendingCard: null,
+    lastTurnStartedAt: { sente: null, gote: null },
+    noPromoteMarks: { sente: [], gote: [] },
+    drawProgress: { sente: 0, gote: 0 },
+    ...overrides,
+  };
+}
+
+function makeWorld(gameState: GameState, cardState: CardGameState = makeCardState()): WorldState {
+  return { gameState, cardState, doubleMove: null };
+}
+
+function place(state: GameState, pos: Position, piece: Piece): void {
+  state.board[pos.row][pos.col] = piece;
+}
+
+// modifyBoard effect の apply を取り出す (型ナローイング)。
+function boardApply(id: CardId): Extract<EffectSpec, { type: "modifyBoard" }>["apply"] {
+  const effect = CARD_SPECS[id].effect;
+  if (!effect || effect.type !== "modifyBoard") {
+    throw new Error(`${id} は modifyBoard effect ではない`);
+  }
+  return effect.apply;
+}
+
+// ===== 1. exhaustiveness =====
+
+describe("CardSpec registry exhaustiveness (R-3)", () => {
+  it("全 7 枚が CARD_SPECS / CARD_META に存在する", () => {
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_SPECS[id], `CARD_SPECS[${id}] が未定義`).toBeDefined();
+      expect(CARD_META[id], `CARD_META[${id}] が未定義`).toBeDefined();
+    }
+  });
+
+  it("CARD_SPECS のキー集合は CARD_DEFS と完全一致 (過不足なし)", () => {
+    expect(new Set(Object.keys(CARD_SPECS))).toEqual(new Set(Object.keys(CARD_DEFS)));
+    expect(new Set(Object.keys(CARD_META))).toEqual(new Set(Object.keys(CARD_DEFS)));
+  });
+
+  it("ALL_CARD_IDS が CARD_DEFS の全件と一致 (手書きユニオン網羅)", () => {
+    expect(new Set(ALL_CARD_IDS)).toEqual(new Set(Object.keys(CARD_DEFS)));
+  });
+
+  it("getAllCardSpecs() は 7 件・挿入順が CARD_SPECS と一致", () => {
+    const specs = getAllCardSpecs();
+    expect(specs).toHaveLength(7);
+    expect(specs.map((s) => s.meta.id)).toEqual(Object.keys(CARD_SPECS));
+  });
+
+  it("getCardSpec(id) は CARD_SPECS[id] と同一参照", () => {
+    for (const id of ALL_CARD_IDS) {
+      expect(getCardSpec(id)).toBe(CARD_SPECS[id]);
+    }
+  });
+});
+
+// ===== 2. CARD_META ≡ CARD_DEFS subset 射影 =====
+
+describe("CARD_META ≡ CARD_DEFS subset (§9 A6)", () => {
+  it("各カードの meta フィールドが CARD_DEFS と一致", () => {
+    for (const id of ALL_CARD_IDS) {
+      const def = CARD_DEFS[id];
+      const meta = CARD_META[id];
+      expect(meta.id).toBe(def.id);
+      expect(meta.kind).toBe(def.kind);
+      expect(meta.name).toBe(def.name);
+      expect(meta.icon).toBe(def.icon);
+      expect(meta.cost).toBe(def.cost);
+      expect(meta.rarity).toBe(def.rarity);
+      expect(meta.phase).toBe(def.phase);
+      expect(meta.status).toBe(def.status);
+      expect(meta.relatedIssues).toEqual(def.relatedIssues);
+    }
+  });
+
+  it("meta は許可キーのみを持ち、除外フィールドを含まない", () => {
+    for (const id of ALL_CARD_IDS) {
+      const keys = Object.keys(CARD_META[id]);
+      // 許可キーの部分集合であること (phase/relatedIssues は optional のため undefined 時は欠落しうる)
+      for (const k of keys) {
+        expect(META_KEYS as string[]).toContain(k);
+      }
+      // 除外キーは一切持たない
+      for (const excluded of META_EXCLUDED_KEYS) {
+        expect(keys).not.toContain(excluded);
+      }
+    }
+  });
+});
+
+// ===== 3. targeting / checkUsage ≡ CARD_DEFS =====
+
+describe("CardSpec targeting / checkUsage ≡ CARD_DEFS", () => {
+  it("targeting が CARD_DEFS と一致", () => {
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_SPECS[id].targeting).toBe(CARD_DEFS[id].targeting);
+    }
+  });
+
+  it("checkUsage が CARD_DEFS と一致", () => {
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_SPECS[id].checkUsage).toBe(CARD_DEFS[id].checkUsage);
+    }
+  });
+});
+
+// ===== 4. eventKind 派生規則 =====
+
+describe("eventKind 派生規則 (§9 A6)", () => {
+  it("trap → trapSetEvent / 他 → cardPlayEvent (CARD_DEFS.kind から導出)", () => {
+    for (const id of ALL_CARD_IDS) {
+      const expected = CARD_DEFS[id].kind === "trap" ? "trapSetEvent" : "cardPlayEvent";
+      expect(CARD_SPECS[id].eventKind).toBe(expected);
+    }
+  });
+
+  it("明示 pin: 通常/multiPly カードは cardPlayEvent", () => {
+    for (const id of ["mana_up", "pawn_return", "piece_return", "double_pawn", "double_move"] as CardId[]) {
+      expect(CARD_SPECS[id].eventKind).toBe("cardPlayEvent");
+    }
+  });
+
+  it("明示 pin: トラップ設置は trapSetEvent", () => {
+    for (const id of ["no_promote", "check_break"] as CardId[]) {
+      expect(CARD_SPECS[id].eventKind).toBe("trapSetEvent");
+    }
+  });
+});
+
+// ===== 5. effect 構造 / multiPly / setTrap =====
+
+describe("effect 構造 / multiPly (M1 A1/A2 / R-1)", () => {
+  it("modifyBoard カード (pawn_return / piece_return / double_pawn)", () => {
+    for (const id of ["pawn_return", "piece_return", "double_pawn"] as CardId[]) {
+      expect(CARD_SPECS[id].effect?.type).toBe("modifyBoard");
+      expect(CARD_SPECS[id].multiPly).toBeUndefined();
+    }
+  });
+
+  it("modifyResource カード (mana_up) は mana: 3", () => {
+    const effect = CARD_SPECS.mana_up.effect;
+    expect(effect?.type).toBe("modifyResource");
+    if (effect?.type === "modifyResource") {
+      expect(effect.mana).toBe(3);
+      expect(effect.draw).toBeUndefined();
+    }
+  });
+
+  it("setTrap カード: trigger 正・onTrigger は未配線 stub (@deferred S3)", () => {
+    const noPromote = CARD_SPECS.no_promote.effect;
+    expect(noPromote?.type).toBe("setTrap");
+    if (noPromote?.type === "setTrap") {
+      expect(noPromote.trigger).toBe("promotion_declared");
+      expect(noPromote.onTrigger).toBeUndefined();
+    }
+    const checkBreak = CARD_SPECS.check_break.effect;
+    expect(checkBreak?.type).toBe("setTrap");
+    if (checkBreak?.type === "setTrap") {
+      expect(checkBreak.trigger).toBe("check_declared");
+      expect(checkBreak.onTrigger).toBeUndefined();
+    }
+  });
+
+  it("double_move は effect なし・multiPly: 2 (effect 共用体外)", () => {
+    expect(CARD_SPECS.double_move.effect).toBeUndefined();
+    expect(CARD_SPECS.double_move.multiPly).toBe(2);
+  });
+});
+
+// ===== 6. effect.apply ≡ applyXxx =====
+
+describe("effect.apply ≡ applyXxx (modifyBoard 構造一致)", () => {
+  // pawn_return: 自盤上の歩 / と金を持ち駒へ。ピン駒・空マス・敵駒は null。
+  it("pawn_return ≡ applyPawnReturn (複数 fixture)", () => {
+    const apply = boardApply("pawn_return");
+
+    const cases: { state: GameState; player: Player; sq: Position }[] = [];
+
+    // (a) 自歩を戻す (sente、玉あり・ピンなし)
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 6, col: 4 }, { type: "pawn", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 4 } });
+    }
+    // (b) と金を戻す (unpromote)
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 3, col: 5 }, { type: "promoted_pawn", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 3, col: 5 } });
+    }
+    // (c) 空マス → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 5, col: 5 } });
+    }
+    // (d) 敵の歩 → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 2, col: 4 }, { type: "pawn", owner: "gote" });
+      cases.push({ state: s, player: "sente", sq: { row: 2, col: 4 } });
+    }
+    // (e) ピン駒 (gote 飛車が sente 玉を狙う筋の自歩) → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 5, col: 4 }, { type: "pawn", owner: "sente" });
+      place(s, { row: 0, col: 4 }, { type: "rook", owner: "gote" });
+      cases.push({ state: s, player: "sente", sq: { row: 5, col: 4 } });
+    }
+    // (f) gote 対称
+    {
+      const s = makeState({ currentPlayer: "gote" });
+      place(s, { row: 0, col: 4 }, { type: "king", owner: "gote" });
+      place(s, { row: 2, col: 3 }, { type: "pawn", owner: "gote" });
+      cases.push({ state: s, player: "gote", sq: { row: 2, col: 3 } });
+    }
+
+    for (const { state, player, sq } of cases) {
+      const viaSpec = apply(state, player, { kind: "square", row: sq.row, col: sq.col });
+      const viaDirect = applyPawnReturn(state, player, sq);
+      expect(viaSpec).toEqual(viaDirect);
+    }
+  });
+
+  it("piece_return ≡ applyPieceReturn (複数 fixture)", () => {
+    const apply = boardApply("piece_return");
+    const cases: { state: GameState; player: Player; sq: Position }[] = [];
+
+    // (a) 金を戻す
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 6, col: 4 }, { type: "gold", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 4 } });
+    }
+    // (b) 成銀を戻す (unpromote → silver)
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 3, col: 2 }, { type: "promoted_silver", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 3, col: 2 } });
+    }
+    // (c) 玉 → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 8, col: 4 } });
+    }
+    // (d) ピン駒 → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 5, col: 4 }, { type: "gold", owner: "sente" });
+      place(s, { row: 0, col: 4 }, { type: "rook", owner: "gote" });
+      cases.push({ state: s, player: "sente", sq: { row: 5, col: 4 } });
+    }
+    // (e) 空マス → null
+    {
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 4, col: 4 } });
+    }
+
+    for (const { state, player, sq } of cases) {
+      const viaSpec = apply(state, player, { kind: "square", row: sq.row, col: sq.col });
+      const viaDirect = applyPieceReturn(state, player, sq);
+      expect(viaSpec).toEqual(viaDirect);
+    }
+  });
+
+  it("double_pawn ≡ applyDoublePawn (複数 fixture)", () => {
+    const apply = boardApply("double_pawn");
+    const cases: { state: GameState; player: Player; sq: Position }[] = [];
+
+    // (a) 同列に自歩あり・空マス・持ち駒歩あり → 配置可
+    {
+      const s = makeState({ hand: { sente: { pawn: 1 }, gote: {} } });
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 0, col: 0 }, { type: "king", owner: "gote" });
+      place(s, { row: 5, col: 3 }, { type: "pawn", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 3 } });
+    }
+    // (b) 配置先が埋まっている → null
+    {
+      const s = makeState({ hand: { sente: { pawn: 1 }, gote: {} } });
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 0, col: 0 }, { type: "king", owner: "gote" });
+      place(s, { row: 5, col: 3 }, { type: "pawn", owner: "sente" });
+      place(s, { row: 6, col: 3 }, { type: "silver", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 3 } });
+    }
+    // (c) 同列に自歩なし → null
+    {
+      const s = makeState({ hand: { sente: { pawn: 1 }, gote: {} } });
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 0, col: 0 }, { type: "king", owner: "gote" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 7 } });
+    }
+    // (d) 持ち駒に歩なし → null
+    {
+      const s = makeState({ hand: { sente: {}, gote: {} } });
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      place(s, { row: 0, col: 0 }, { type: "king", owner: "gote" });
+      place(s, { row: 5, col: 3 }, { type: "pawn", owner: "sente" });
+      cases.push({ state: s, player: "sente", sq: { row: 6, col: 3 } });
+    }
+
+    for (const { state, player, sq } of cases) {
+      const viaSpec = apply(state, player, { kind: "square", row: sq.row, col: sq.col });
+      const viaDirect = applyDoublePawn(state, player, sq);
+      expect(viaSpec).toEqual(viaDirect);
+    }
+  });
+
+  it("modifyBoard.apply は非 square target で null", () => {
+    for (const id of ["pawn_return", "piece_return", "double_pawn"] as CardId[]) {
+      const apply = boardApply(id);
+      const s = makeState();
+      place(s, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+      expect(apply(s, "sente", { kind: "handPiece", pieceType: "pawn" })).toBeNull();
+    }
+  });
+});
+
+// ===== 7. useCondition ≡ CARD_USE_CONDITIONS =====
+
+describe("useCondition ≡ CARD_USE_CONDITIONS (§8)", () => {
+  it("条件未登録カードは useCondition undefined", () => {
+    for (const id of ["mana_up", "check_break", "double_move", "no_promote"] as CardId[]) {
+      expect(CARD_SPECS[id].useCondition).toBeUndefined();
+      expect(CARD_USE_CONDITIONS[id]).toBeUndefined();
+    }
+  });
+
+  it("pawn_return: 盤上に自歩/と金がある時のみ true (現行と一致)", () => {
+    const condFn = CARD_SPECS.pawn_return.useCondition!;
+    const raw = CARD_USE_CONDITIONS.pawn_return!;
+
+    const withPawn = makeState();
+    place(withPawn, { row: 6, col: 4 }, { type: "pawn", owner: "sente" });
+    const withTokin = makeState();
+    place(withTokin, { row: 3, col: 4 }, { type: "promoted_pawn", owner: "sente" });
+    const without = makeState();
+    place(without, { row: 6, col: 4 }, { type: "silver", owner: "sente" });
+
+    for (const gs of [withPawn, withTokin, without]) {
+      const world = makeWorld(gs);
+      expect(condFn(world, "sente")).toBe(raw(gs, "sente", world.cardState));
+    }
+  });
+
+  it("piece_return: 盤上に玉以外の駒がある時のみ true (現行と一致)", () => {
+    const condFn = CARD_SPECS.piece_return.useCondition!;
+    const raw = CARD_USE_CONDITIONS.piece_return!;
+
+    const withPiece = makeState();
+    place(withPiece, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+    place(withPiece, { row: 6, col: 4 }, { type: "gold", owner: "sente" });
+    const onlyKing = makeState();
+    place(onlyKing, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+
+    for (const gs of [withPiece, onlyKing]) {
+      const world = makeWorld(gs);
+      expect(condFn(world, "sente")).toBe(raw(gs, "sente", world.cardState));
+    }
+  });
+
+  it("double_pawn: 持ち駒に歩あり & 盤上に自未成り歩がある時のみ true (現行と一致)", () => {
+    const condFn = CARD_SPECS.double_pawn.useCondition!;
+    const raw = CARD_USE_CONDITIONS.double_pawn!;
+
+    const ok = makeState({ hand: { sente: { pawn: 1 }, gote: {} } });
+    place(ok, { row: 5, col: 3 }, { type: "pawn", owner: "sente" });
+    const noHand = makeState({ hand: { sente: {}, gote: {} } });
+    place(noHand, { row: 5, col: 3 }, { type: "pawn", owner: "sente" });
+    const noBoardPawn = makeState({ hand: { sente: { pawn: 1 }, gote: {} } });
+    place(noBoardPawn, { row: 3, col: 3 }, { type: "promoted_pawn", owner: "sente" });
+
+    for (const gs of [ok, noHand, noBoardPawn]) {
+      const world = makeWorld(gs);
+      expect(condFn(world, "sente")).toBe(raw(gs, "sente", world.cardState));
+    }
+  });
+});
+
+// ===== 8. valueModel snapshot =====
+
+describe("valueModel snapshot (S2 stub、入力非依存)", () => {
+  const EXPECTED: Record<CardId, number> = {
+    no_promote: 50,
+    check_break: 80,
+    mana_up: 30,
+    pawn_return: 0,
+    piece_return: 0,
+    double_pawn: 0,
+    double_move: 0,
+  };
+
+  it("各カードの valueModel が期待静的値を返す", () => {
+    const gs = makeState();
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_SPECS[id].valueModel(gs, "sente")).toBe(EXPECTED[id]);
+    }
+  });
+
+  it("valueModel は gameState / player に依存しない (S2 stub)", () => {
+    const gsA = makeState();
+    const gsB = makeState({ currentPlayer: "gote", moveCount: 50 });
+    place(gsB, { row: 4, col: 4 }, { type: "rook", owner: "gote" });
+    for (const id of ALL_CARD_IDS) {
+      const vm = CARD_SPECS[id].valueModel;
+      expect(vm(gsA, "sente")).toBe(vm(gsB, "gote"));
+    }
+  });
+});
+
+// ===== 9. registry SSOT helper =====
+
+describe("registry SSOT helper ≡ ALL_CARD_DEFS ベース抽出", () => {
+  it("getValidCardIds() ≡ ALL_CARD_DEFS の id 集合", () => {
+    expect(new Set(getValidCardIds())).toEqual(new Set(ALL_CARD_DEFS.map((d) => d.id)));
+  });
+
+  it("getActiveCards() ≡ status === active", () => {
+    expect(new Set(getActiveCards().map((m) => m.id))).toEqual(
+      new Set(ALL_CARD_DEFS.filter((d) => d.status === "active").map((d) => d.id)),
+    );
+  });
+
+  it("getPlayableCards() ≡ status !== deprecated", () => {
+    expect(new Set(getPlayableCards().map((m) => m.id))).toEqual(
+      new Set(ALL_CARD_DEFS.filter((d) => d.status !== "deprecated").map((d) => d.id)),
+    );
+  });
+});

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -1,0 +1,205 @@
+// Issue #235 S2a: L1 カードフレームワーク (CardSpec registry) の **サーバ専用 / 関数** 層。
+//
+// 目的 (S2 計画 docs/plans/issue-235-s2-cardspec.md §2/§5): card-spec.ts (meta-only) に対し、
+//   関数 (effect.apply / useCondition / valueModel / onTrigger) を持つ `CardSpec` 本体 + registry
+//   `CARD_SPECS` を定義する。effects.ts / world-kernel(WorldState 型) / heuristics 相当の
+//   値付けを内包するため Client へ出してはならない (§5 R-2。S2d で ESLint により
+//   `src/components/**`・`src/hooks/**` からの import を禁止する)。
+//
+// S2a の大前提 (§1): **production 未配線 (additive)**。挙動完全不変。
+//   - effect.apply は既存 applyXxx を包む薄い wrapper (再実装しない → 構造的に等価)。
+//   - 効果適用の dispatch (consumeNormalCard / mana 減算 / event 構築 / removeNoPromoteMark 等の
+//     sideEffect) は kernel `applyCardEffectLogic` 側の汎用処理であり、本 registry は **盤面変更のみ**
+//     を表現する (§2 / §9 B3)。registry を実際に dispatch へ繋ぐのは S2b。
+//
+// 設計判断 (M1 確定、§9):
+//   - **multiPly は EffectSpec 共用体外** (CardSpec.multiPly?: number)。double_move は applyCardEffectLogic
+//     対象外でフラグセットのみ、遅延消費は finalizeDoubleMoveLogic という S1d 既存 orchestration が担う。
+//     registry は plies 数のメタのみ保持し effect は持たない (A1/A2)。
+//   - **trap = Route B** (R-1): `setTrap` は **set のみ** registry 化。trigger (no_promote 成り抑止 /
+//     check_break 王手崩し) は move-effects.ts インライン温存。`onTrigger` は型枠のみ (@deferred、実配線 S3)。
+//   - **valueModel は枠のみ** (R-4): S3 値付けの interface 固定先。中身は静的 per-card 値を返す薄い stub。
+
+import type { GameState, Player, Position } from "@/lib/shogi/types";
+import type { CardCheckUsage, CardId, CardTarget, CardTargeting, TrapTrigger } from "./types";
+import type { CardEventKind, CardMeta } from "./card-spec";
+import type { WorldState } from "@/lib/shogi/kernel/world-kernel";
+import { CARD_META } from "./card-spec";
+import { CARD_DEFS, CARD_USE_CONDITIONS } from "./definitions";
+import { applyDoublePawn, applyPawnReturn, applyPieceReturn } from "./effects";
+
+// ===== EffectSpec 判別共用体 (M1 §2) =====
+// CONFIRM 時の効果適用を type 別テンプレで宣言する。新カードは type 選択 + パラメータ埋め (ビジョン⑥)。
+export type EffectSpec =
+  // modifyBoard: 盤面のみ変更し GameState | null を返す (pawn_return / piece_return / double_pawn)。
+  //   持ち駒消費 (consumeNormalCard)・event 構築・removeNoPromoteMark 等の sideEffect は
+  //   dispatcher (S2b の applyCardEffectLogic) が汎用処理する (§9 B3)。apply は applyXxx を包む薄い wrapper。
+  | {
+      type: "modifyBoard";
+      apply: (gameState: GameState, player: Player, target: CardTarget) => GameState | null;
+    }
+  // setTrap: set のみ registry 化 (Route B、R-1)。trigger は「いつ発火するか」のメタ。
+  //   onTrigger は **S2a では未配線 stub** (型枠のみ、@deferred)。実 trigger は move-effects.ts インライン。
+  | {
+      type: "setTrap";
+      trigger: TrapTrigger;
+      onTrigger?: (world: WorldState) => WorldState;
+    }
+  // modifyResource: mana/draw のリソース変更を宣言的に (mana_up)。
+  | { type: "modifyResource"; mana?: number; draw?: number };
+
+// 使用条件 (マナ以外の独自条件)。CARD_USE_CONDITIONS を (world, player) シグネチャに統一して内包する
+// (§8 / §B2。現行 CardUseCondition の 3 引数目 cardState は未使用)。
+export type UseCondition = (world: WorldState, player: Player) => boolean;
+
+// カード価値モデル (cp)。S2 は静的 stub、S3 で局面・コスト依存値付け (R-4)。シグネチャを固定する。
+export type ValueModel = (gameState: GameState, player: Player) => number;
+
+// 単一カード仕様 (epic §4 / M1 §2)。registry の値オブジェクト。
+export interface CardSpec {
+  meta: CardMeta; // client-safe (card-spec.ts)
+  targeting: CardTargeting;
+  // CONFIRM 時の効果。double_move は multiPly のみで本フィールドを持たない (effect 共用体外、A1/A2)。
+  effect?: EffectSpec;
+  // double_move 専用: 1 ターンに消費する ply 数 (= 2)。遅延消費/flip 抑止は既存 orchestration が担う。
+  multiPly?: number;
+  useCondition?: UseCondition;
+  checkUsage: CardCheckUsage;
+  valueModel: ValueModel;
+  eventKind: CardEventKind;
+}
+
+// ===== valueModel ブリッジ (S2 stub、R-4) =====
+// **本ブリッジが card 価値の将来 SSOT (L1)**。現状 ai/cards/heuristics の TRAP_VALUE_NO_PROMOTE=50 /
+// TRAP_VALUE_CHECK_BREAK=80 / (MANA_DELTA_COEFFICIENT=10 × +3 mana = 30) と同値だが、`cards/ → ai/` の
+// 上向き依存を新規導入しないため import せず併記する。S3 で valueModel を card 価値の単一源とし、ai 側を
+// 本 valueModel 参照へ切替えて依存を正方向 (ai → L1) に統一する。それまで両者は同値を保つ
+// (valueModel は S2 では未配線 = inert のため、仮に drift しても探索挙動には影響しない)。
+// 盤面系 (pawn_return/piece_return/double_pawn) と double_move は現行で静的 per-card 値を持たず
+// (局面評価 digest / super-action 探索が間接捕捉)、S3 で局面依存値付けするまで 0。
+const CARD_VALUE_BRIDGE: Record<CardId, number> = {
+  no_promote: 50,
+  check_break: 80,
+  mana_up: 30,
+  pawn_return: 0,
+  piece_return: 0,
+  double_pawn: 0,
+  double_move: 0,
+};
+
+// 静的値を返す valueModel stub (gameState/player は S3 まで未使用)。
+function staticValueModel(value: number): ValueModel {
+  return (gameState, player) => {
+    void gameState;
+    void player;
+    return value;
+  };
+}
+
+// modifyBoard effect: applyXxx (Position 受け) を CardTarget (square) 受けに包む薄い wrapper。
+function boardEffect(
+  apply: (state: GameState, player: Player, target: Position) => GameState | null,
+): EffectSpec {
+  return {
+    type: "modifyBoard",
+    apply: (gameState, player, target) =>
+      target.kind === "square"
+        ? apply(gameState, player, { row: target.row, col: target.col })
+        : null,
+  };
+}
+
+// CARD_USE_CONDITIONS を (world, player) シグネチャに統一して内包 (§8)。
+// 現行条件は gameState のみ参照 (cardState 未使用) のため、world.gameState への委譲で等価。
+// 条件が未登録のカードは undefined (= 常に使用可)。
+// 命名: `use` 始まりにすると react-hooks/rules-of-hooks が Hook と誤検知するため `resolve...` とする。
+function resolveUseCondition(id: CardId): UseCondition | undefined {
+  const fn = CARD_USE_CONDITIONS[id];
+  return fn ? (world, player) => fn(world.gameState, player, world.cardState) : undefined;
+}
+
+// eventKind 派生規則 (§9 A6): trap → "trapSetEvent"、それ以外 (normal/multiPly) → "cardPlayEvent"。
+// 単一規則として encode し、各カードで個別ハードコードしない。
+function deriveEventKind(meta: CardMeta): CardEventKind {
+  return meta.kind === "trap" ? "trapSetEvent" : "cardPlayEvent";
+}
+
+// CardSpec 組み立て共通処理。targeting / checkUsage / eventKind / useCondition は CARD_DEFS・CARD_META
+// から派生し (S2a additive = definitions.ts を SSOT 維持)、effect / valueModel / multiPly のみ registry が付与する。
+function buildSpec(
+  id: CardId,
+  effect: EffectSpec | undefined,
+  valueModel: ValueModel,
+  opts: { multiPly?: number } = {},
+): CardSpec {
+  const def = CARD_DEFS[id];
+  const meta = CARD_META[id];
+  return {
+    meta,
+    targeting: def.targeting,
+    effect,
+    multiPly: opts.multiPly,
+    useCondition: resolveUseCondition(id),
+    checkUsage: def.checkUsage,
+    valueModel,
+    eventKind: deriveEventKind(meta),
+  };
+}
+
+// ===== 7 カード registry (SSOT) =====
+// 挿入順は CARD_DEFS / CARD_META と一致させる。
+export const CARD_SPECS: Record<CardId, CardSpec> = {
+  // 廃止 (status: "deprecated")。即時マナ +3 (上限 manaCap でクランプ)。
+  mana_up: buildSpec(
+    "mana_up",
+    { type: "modifyResource", mana: 3 },
+    staticValueModel(CARD_VALUE_BRIDGE.mana_up),
+  ),
+  // 自盤上の歩 / と金 1 枚を持ち駒へ (unpromote)。
+  pawn_return: buildSpec(
+    "pawn_return",
+    boardEffect(applyPawnReturn),
+    staticValueModel(CARD_VALUE_BRIDGE.pawn_return),
+  ),
+  // 持ち駒の歩 1 枚を自分の歩がいる列の空マスへ (二歩禁則の一時解除)。
+  double_pawn: buildSpec(
+    "double_pawn",
+    boardEffect(applyDoublePawn),
+    staticValueModel(CARD_VALUE_BRIDGE.double_pawn),
+  ),
+  // 自盤上の駒 (玉以外) 1 枚を持ち駒へ (unpromote)。歩戻しの上位互換。
+  piece_return: buildSpec(
+    "piece_return",
+    boardEffect(applyPieceReturn),
+    staticValueModel(CARD_VALUE_BRIDGE.piece_return),
+  ),
+  // トラップ: 相手の王手宣言時に王手駒を全て持ち駒化 (発火は move-effects インライン = Route B)。
+  check_break: buildSpec(
+    "check_break",
+    { type: "setTrap", trigger: "check_declared" },
+    staticValueModel(CARD_VALUE_BRIDGE.check_break),
+  ),
+  // 二手指し: 1 ターンに続けて 2 手指す。effect なし・multiPly: 2 のみ (A1/A2)。
+  double_move: buildSpec(
+    "double_move",
+    undefined,
+    staticValueModel(CARD_VALUE_BRIDGE.double_move),
+    { multiPly: 2 },
+  ),
+  // トラップ: 相手の成り宣言を無効化し「成り不可」を永続付与 (発火は move-effects インライン = Route B)。
+  no_promote: buildSpec(
+    "no_promote",
+    { type: "setTrap", trigger: "promotion_declared" },
+    staticValueModel(CARD_VALUE_BRIDGE.no_promote),
+  ),
+};
+
+// 単一カード仕様を取得。
+export function getCardSpec(id: CardId): CardSpec {
+  return CARD_SPECS[id];
+}
+
+// 全カード仕様 (挿入順)。
+export function getAllCardSpecs(): CardSpec[] {
+  return Object.values(CARD_SPECS);
+}

--- a/src/lib/shogi/cards/card-spec.ts
+++ b/src/lib/shogi/cards/card-spec.ts
@@ -1,0 +1,86 @@
+// Issue #235 S2a: L1 カードフレームワーク (CardSpec registry) の **client-safe / meta-only** 層。
+//
+// 目的 (epic doc §3 L1 / §4 / S2 計画 docs/plans/issue-235-s2-cardspec.md §2):
+//   1 カードが 6+ ファイルに分散している現状 (definitions CARD_DEFS + CARD_USE_CONDITIONS +
+//   effects applyXxx + digest/heuristics 係数 + action-generator 候補 + undo-policy isCardOpEvent +
+//   reducer/kernel 効果分岐) を、単一 `CardSpec` registry に集約する (P2/P5 解消)。
+//
+// 本ファイルの責務 = **関数を持たない meta データのみ** (Server→Client 境界を serialize 可能):
+//   - `CardMeta` 型 + `CARD_META` レコード (CARD_DEFS から派生する client-safe な subset、§9 A6)
+//   - registry SSOT helper (`getValidCardIds` / `getActiveCards` / `getPlayableCards`)
+//   関数 (effect.apply / useCondition / valueModel / onTrigger) を持つ `CardSpec` 本体は
+//   サーバ専用モジュール `card-spec-server.ts` に物理分離する (§5 R-2 / §9 A5。S2d で ESLint により
+//   `src/components/**`・`src/hooks/**` からの server import を禁止する)。
+//
+// S2a の大前提 (§1): 本 registry は **production 未配線 (additive)**。挙動完全不変。
+//   meta は CARD_DEFS から派生し (§3 S2a「meta は CARD_DEFS から」)、definitions.ts を SSOT のまま
+//   維持する。旧 CARD_DEFS / ALL_CARD_DEFS の一本化 (registry 由来 re-export) は S2d で扱う
+//   (seed が CardMeta 非包含の description/effectId を必要とするため、本段では re-export しない)。
+
+import type { CardDefinition, CardId, CardKind, CardPhase, CardRarity, CardStatus, GameEvent } from "./types";
+import { CARD_DEFS } from "./definitions";
+
+// カードの client-safe メタデータ (§9 A6)。CardDefinition の subset。
+// **除外フィールド** (= meta に含めない): description / detailDescription / useConditionDescription /
+//   addedAt (表示文字列・履歴。catalog UI は引き続き CardDefinition から取得) / effectId / targeting /
+//   checkUsage (targeting・checkUsage は CardSpec の top-level フィールドとして card-spec-server が保持)。
+export interface CardMeta {
+  id: CardId;
+  kind: CardKind;
+  name: string;
+  icon: string;
+  cost: number;
+  rarity: CardRarity;
+  phase?: CardPhase;
+  status: CardStatus;
+  relatedIssues?: number[];
+}
+
+// カードの「使用/設置」イベント種別 (= undo-policy.isCardOpEvent を registry から導出する元、§9 A6)。
+// 通常/マルチ ply カード → "cardPlayEvent"、トラップ設置 → "trapSetEvent"。
+// トラップ発動 ("trapTriggerEvent") は別ライフサイクル (相手手番で発火) のため card 自身の
+// eventKind には含めない (S2c の isCardOpEvent 導出時に trapTriggerEvent を別途合算する)。
+export type CardEventKind = Extract<GameEvent["kind"], "cardPlayEvent" | "trapSetEvent">;
+
+// CardDefinition → CardMeta 射影 (§3 S2a「meta は CARD_DEFS から」)。
+// 除外フィールドを落とし client-safe subset に縮約する。
+function toCardMeta(def: CardDefinition): CardMeta {
+  return {
+    id: def.id,
+    kind: def.kind,
+    name: def.name,
+    icon: def.icon,
+    cost: def.cost,
+    rarity: def.rarity,
+    phase: def.phase,
+    status: def.status,
+    relatedIssues: def.relatedIssues,
+  };
+}
+
+// 全カードの client-safe meta レコード。CARD_DEFS と同一の挿入順を保持する
+// (Object.keys/values の列挙順 = mana_up, pawn_return, double_pawn, piece_return,
+//  check_break, double_move, no_promote)。
+export const CARD_META: Record<CardId, CardMeta> = Object.fromEntries(
+  (Object.keys(CARD_DEFS) as CardId[]).map((id) => [id, toCardMeta(CARD_DEFS[id])]),
+) as Record<CardId, CardMeta>;
+
+// ===== registry SSOT helper (§8 / §9 B4) =====
+// seed orphan-guard / deck.ts VALID_CARD_IDS / user-bootstrap・merge の playable 抽出などが
+// 現状 ALL_CARD_DEFS を直読している。S2c/S2d でこれら helper 経由へ移行する (本段では additive に提供のみ)。
+
+// registry に登録された全 CardId (= seed orphan-guard の validCardIds 相当)。
+export function getValidCardIds(): CardId[] {
+  return Object.keys(CARD_META) as CardId[];
+}
+
+// 公開中 (status === "active") のカード meta。
+export function getActiveCards(): CardMeta[] {
+  return Object.values(CARD_META).filter((m) => m.status === "active");
+}
+
+// プレイアブル (status !== "deprecated") のカード meta。
+// = deck.ts / user-bootstrap / merge の `ALL_CARD_DEFS.filter(d => d.status !== "deprecated")` 相当。
+export function getPlayableCards(): CardMeta[] {
+  return Object.values(CARD_META).filter((m) => m.status !== "deprecated");
+}


### PR DESCRIPTION
## Summary
カード将棋 CPU 土台再設計 (epic #235) の **L1 カードフレームワーク化 S2a**。1 カードが 6+ ファイルに分散 (definitions/effects/digest/action-generator/undo-policy/reducer) する構造を、単一 `CardSpec` registry へ集約する第一段。

**本 PR は additive のみ (production 未配線・挙動完全不変)**。registry を実 dispatch へ繋ぐ cutover は S2b 以降。

### 変更
- **新規** `card-spec.ts` (client-safe/meta-only): `CardMeta` 型 + `CARD_META` (CARD_DEFS から射影) + SSOT helper (`getValidCardIds`/`getActiveCards`/`getPlayableCards`)
- **新規** `card-spec-server.ts` (server-only): `CardSpec`/`EffectSpec` 型 + 7カード `CARD_SPECS`。effect.apply=既存 applyXxx 薄wrapper / useCondition=`CARD_USE_CONDITIONS` を `(world,player)` 統一内包 / valueModel=S3 値付けの枠 (静的 stub) / eventKind=kind 派生 / trap onTrigger=@deferred stub (Route B) / double_move=multiPly:2
- **新規** 特性化テスト 29件: registry 出力 ≡ 現行 (applyXxx/CARD_DEFS/CARD_USE_CONDITIONS) + eventKind 派生規則 + 全7枚 exhaustiveness
- **変更** `card-view.tsx`: CARD_DEFS raw lookup の NPE 防御ガード (B5、挙動不変)
- **変更** `docs/plans/issue-235-s2-cardspec.md`: 実装計画 + M1/M2 レビュー記録

### 設計判断 (M2 反映、計画 doc §10)
- definitions.ts は SSOT 維持。`ALL_CARD_DEFS` の registry 由来 re-export は seed が CardMeta 非包含の `description`/`effectId` を要するため **S2d 先送り**。meta は CARD_DEFS 射影で additive 性を担保
- valueModel は `cards/→ai/` の上向き依存を避けローカル定義 (ai/heuristics と同値、S3 で valueModel を SSOT 化し依存反転)
- CardId 手書きユニオン維持 (`Record<CardId,CardSpec>` で網羅検査)

## Test plan
- `npm run lint` → 0 error (22 warning は既存ベースライン)
- `npm run typecheck` → 緑
- `npm run test:ci` → **571 passed** / 12 skipped (S1d 542 + 新規 29、デグレなし)
- `npm run build` → 緑
- M2 adversarial レビュー (6観点) + main-loop セルフレビュー: S2a スコープ内の要修正指摘ゼロ。確定2件 (型レベル循環=S2b / ESLint境界=S2d) はいずれも後段送り

Refs #235