### PR TITLE
refactor: #235 S2b applyCardEffectLogic を CardSpec registry 駆動へ cutover

### DIFF
--- a/docs/plans/issue-235-s2-cardspec.md
+++ b/docs/plans/issue-235-s2-cardspec.md
@@ -98,8 +98,9 @@ registry は新規ファイルのため S2a は revert 安全。
 - [x] **S2a** (完了・commit 予定): CardSpec/EffectSpec 型 (multiPly は effect 外 / onTrigger optional stub) + 7 カード registry data (`card-spec.ts` = meta-only client-safe / `card-spec-server.ts` = 関数)。registry SSOT helper (`getActiveCards`/`getPlayableCards`/`getValidCardIds`) 定義。CardId 手書きユニオン維持 + 全7枚 exhaustiveness property test。CARD_USE_CONDITIONS の `(world,player)` シグネチャ統一 (現3引数の cardState 未使用) を同梱。
   - **S2a 実装時の確定 (M2 反映、§10)**: 「`ALL_CARD_DEFS = registry 由来` re-export で seed bit-identical」は **S2d へ先送り** (seed.ts が CardMeta 非包含の `description`/`effectId` を必要とし、CardMeta subset から再構成不可)。S2a は **definitions.ts を SSOT 維持** + registry の meta を CARD_DEFS から射影 (`toCardMeta`)。helper は additive 提供のみ (consumer 切替は S2c/S2d)。
 - [x] **S2a 特性化テスト** (§9 A6、完了 29件): meta subset 一致 / effect.apply を各 modifyBoard カードで複数 board×player×target fixture で現 applyXxx と構造一致 / eventKind 派生規則 / useCondition・checkUsage を複数 snapshot で現行一致 / valueModel は静的 stub の snapshot (現行に per-card valueModel は無く、本 stub の出力を pin)。
-- [ ] **S2b**: applyCardEffectLogic の effectId switch → spec.effect.apply dispatch へ置換 (consumeNormalCard・event 構築・sideEffect removeNoPromoteMark は dispatcher 汎用処理)。**trap trigger (move-effects インライン) には触れない (Route B、DP-7 保全)**。bench 棋力退化なし。
-  - **M2 申し送り (§10 D1-1)**: world-kernel が card-spec-server を **value import** する際、world-kernel ↔ card-spec-server の **型レベル相互参照** が成立する (runtime 循環は無害=検証済。card-spec-server の runtime 依存は card-spec/definitions/effects のみで kernel に到達しない)。L1(cards/) が L0(kernel/) から `WorldState` を借りる型従属は目標アーキ (ai→L1 正方向) と逆向きのため、(a) `WorldState` を下位共有型モジュールへ移す、または (b) `UseCondition`/`ValueModel`/`onTrigger` を cards/ ローカル最小型 `{ gameState; cardState }` に縮約 (KernelDoubleMove 不要) して kernel 依存を外す、のいずれかで型循環を解消することを **S2b の PR レビュー観点に含める**。
+- [x] **S2b** (完了・commit 予定): applyCardEffectLogic の effectId switch → spec.effect.apply dispatch へ置換 (consumeNormalCard・event 構築・sideEffect removeNoPromoteMark は dispatcher 汎用処理)。**trap trigger (move-effects インライン) には触れない (Route B、DP-7 保全)**。bench 棋力退化なし (kernel-search OFF==ON 4/4・depth d4 同値、card-usage baseline 同値)。
+  - **M2 (§11) で D1-1 解消済**: 当初案 (b) を採用し、`UseCondition`/`onTrigger` を card-spec-server の `import type { WorldState }` から **cards/ ローカル最小型 `CardWorldView` ({gameState, cardState})** に縮約。world-kernel が CARD_SPECS を value import する一方 card-spec-server は world-kernel を import しない = **型/runtime 循環なし**。WorldState/AiTurnState は構造的に CardWorldView へ代入可 (caller 不変)。
+  - **汎用化の等価性 (§9 B3)**: modifyBoard は適用前の `pieceBefore = board[target]` 有無で returnedPiece + removeNoPromoteMark を条件発火。applyPawnReturn/applyPieceReturn は target に駒必須 (null時は早期 return) のため pieceBefore 常在 = 旧版の無条件呼び出しと一致。double_pawn は target 常に空 = 不発で旧版と一致 (M2 adversarial 検証で6カード全件確認)。
 - [ ] **S2c**: isCardOpEvent を spec.eventKind 導出 / action-generator 候補生成を registry クエリ / checkUsage を spec 参照。族別 switch 排除。
   - **M2 申し送り**: `CardEventKind` (card-spec.ts) は card 自身の使用/設置 event (`cardPlayEvent`/`trapSetEvent`) のみ。`isCardOpEvent` 導出時は **トラップ発動 `trapTriggerEvent` を別途合算** すること (別ライフサイクル=相手手番で発火するため card の eventKind には含めていない)。
 - [ ] **S2d**: 旧 CARD_DEFS/CARD_USE_CONDITIONS 重複の一本化・デッドコード除去。serialize 境界是正 (ESLint で Client→server import 禁止)。
@@ -150,3 +151,25 @@ S2a 実装完了時点のレビュー。adversarial multi-agent workflow (6観�
 
 ### 残課題 (S2a 後)
 - セッション上限が解消した後 (任意)、打ち切った adversarial workflow を fresh 再実行して equivalence/additive 観点の独立検証を補強してもよい (現状はセルフレビュー + 29特性化テスト + grep で代替済)。
+
+## 11. S2b M2 マイルストーンレビュー (cutover 実装後、2026-06-07、AGENTS.md ルール8)
+
+S2b = `applyCardEffectLogic` を旧 effectId-switch から CardSpec registry の EffectSpec 駆動 dispatch へ置換する cutover (P5 解消、production 効果適用経路を registry 化)。reducer (S1d 委譲済) と AI (applyTurnAction) の単一権威を 1 箇所置換。
+
+### 検証実測
+- lint 0err / typecheck 緑 / test:ci **571 passed** (S2a と同数=デグレなし。等価ゲート world-kernel-equivalence / reducer / effects / kernel-search-equivalence / card-spec すべて緑) / build 緑。
+- bench (RUN_PERF_BENCH): kernel-search advanced/expert **cardRate OFF=4/4 ON=4/4・action 選択 OFF==ON 一致 (piece_return/double_move/pawn_return)・depthCompleted d4==d4**。card-usage beginner 100%/intermediate 86%/advanced・expert 57% (baseline 同値)、registry 駆動の選択 (`playCard:board`/`playCard:trap`) 正常。**棋力退化なし**。
+
+### 総合判定
+**S2b は commit/push 可 (指摘ゼロ)**。独立 adversarial agent (general-purpose、27 tool uses) による等価性検証 = **cutover は旧版と byte 等価・発散点ゼロ (high/medium/low すべて 0)**。
+
+### adversarial 検証で確認した等価性 (6カード全件)
+- **dispatch マッピング**: effectId→effect.type / kind→eventKind が旧版と一致 (deriveEventKind = trap→trapSetEvent / 他→cardPlayEvent、trap は check_break/no_promote の 2 枚のみ)。
+- **汎用化 (pieceBefore 方式)**: pawn_return/piece_return は applyXxx が target に駒必須 (null時早期 return) のため `ng` 非 null 時 pieceBefore 常在 → 旧版の無条件 returnedPiece + removeNoPromoteMark と一致。double_pawn は isDoublePawnLegalSquare で target 必ず空 → pieceBefore falsy で不発 (旧版一致)。不正 target は `apply` が null → pieceBefore 使用前に早期 return (旧版一致)。
+- **mana_up modifyResource**: `Math.min(consumed.manaCap, consumed.mana+effect.mana=3)` = 旧 applyManaUp。**trap setTrap**: cost = spec.meta.cost = CARD_DEFS[id].cost、mana 直接減算 + applyTrapSet 経路同一、event instance owner 付与一致。**王手中ガード**: 完全一致。**double_move**: `!spec.effect` 防御 null (applyTurnAction が事前分岐で未到達、旧 `else return null` 等価)。
+
+### D1-1 解消 (S2a M2 申し送りを本段で対応)
+card-spec-server の `WorldState` 型依存を `CardWorldView` ({gameState, cardState}) に縮約 (案 b)。world-kernel→card-spec-server の value import 一方向のみ = 型/runtime 循環なし (grep 確認)。
+
+### dead code 申し送り
+`applyManaUp` (effects.ts) は本 cutover で production から未参照になるが、effects.test/reducer.test/equivalence (OBS5-3) のカバレッジ維持のため **除去は S2d**。

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -21,12 +21,22 @@
 //   - **valueModel は枠のみ** (R-4): S3 値付けの interface 固定先。中身は静的 per-card 値を返す薄い stub。
 
 import type { GameState, Player, Position } from "@/lib/shogi/types";
-import type { CardCheckUsage, CardId, CardTarget, CardTargeting, TrapTrigger } from "./types";
+import type { CardCheckUsage, CardGameState, CardId, CardTarget, CardTargeting, TrapTrigger } from "./types";
 import type { CardEventKind, CardMeta } from "./card-spec";
-import type { WorldState } from "@/lib/shogi/kernel/world-kernel";
 import { CARD_META } from "./card-spec";
 import { CARD_DEFS, CARD_USE_CONDITIONS } from "./definitions";
 import { applyDoublePawn, applyPawnReturn, applyPieceReturn } from "./effects";
+
+// L1 が参照するカード文脈の最小ビュー (gameState + cardState)。
+// useCondition / onTrigger は二手指し継続状態 (doubleMove) を要さないため、kernel の WorldState 全体
+// ではなく本最小型に縮約する。これにより cards/ → kernel/ の型依存を断つ (M2 D1-1: S2b で world-kernel が
+// CARD_SPECS を value import するため、card-spec-server が WorldState を type import すると型レベル循環が
+// 生じる)。world-kernel.WorldState ({gameState, cardState, doubleMove}) と ai の AiTurnState はいずれも
+// 本型へ構造的に代入可能 (caller 側は従来どおり渡せる)。
+export interface CardWorldView {
+  gameState: GameState;
+  cardState: CardGameState;
+}
 
 // ===== EffectSpec 判別共用体 (M1 §2) =====
 // CONFIRM 時の効果適用を type 別テンプレで宣言する。新カードは type 選択 + パラメータ埋め (ビジョン⑥)。
@@ -39,18 +49,18 @@ export type EffectSpec =
       apply: (gameState: GameState, player: Player, target: CardTarget) => GameState | null;
     }
   // setTrap: set のみ registry 化 (Route B、R-1)。trigger は「いつ発火するか」のメタ。
-  //   onTrigger は **S2a では未配線 stub** (型枠のみ、@deferred)。実 trigger は move-effects.ts インライン。
+  //   onTrigger は **未配線 stub** (型枠のみ、@deferred、実配線 S3)。実 trigger は move-effects.ts インライン。
   | {
       type: "setTrap";
       trigger: TrapTrigger;
-      onTrigger?: (world: WorldState) => WorldState;
+      onTrigger?: (world: CardWorldView) => CardWorldView;
     }
   // modifyResource: mana/draw のリソース変更を宣言的に (mana_up)。
   | { type: "modifyResource"; mana?: number; draw?: number };
 
 // 使用条件 (マナ以外の独自条件)。CARD_USE_CONDITIONS を (world, player) シグネチャに統一して内包する
 // (§8 / §B2。現行 CardUseCondition の 3 引数目 cardState は未使用)。
-export type UseCondition = (world: WorldState, player: Player) => boolean;
+export type UseCondition = (world: CardWorldView, player: Player) => boolean;
 
 // カード価値モデル (cp)。S2 は静的 stub、S3 で局面・コスト依存値付け (R-4)。シグネチャを固定する。
 export type ValueModel = (gameState: GameState, player: Player) => number;

--- a/src/lib/shogi/kernel/world-kernel.ts
+++ b/src/lib/shogi/kernel/world-kernel.ts
@@ -32,14 +32,14 @@ import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
 import { unpromotePieceType } from "@/lib/shogi/variants/standard";
 import { CARD_DEFS, DRAW_COST, AUTO_DRAW_INTERVAL } from "@/lib/shogi/cards/definitions";
 import {
-  applyPawnReturn,
-  applyPieceReturn,
-  applyDoublePawn,
-  applyManaUp,
   applyTrapSet,
   consumeNormalCard,
   removeNoPromoteMark,
 } from "@/lib/shogi/cards/effects";
+// Issue #235 S2b: 効果適用を CardSpec registry の effect 駆動へ統一 (P5 解消)。
+// 各 applyXxx は CARD_SPECS[id].effect.apply (= 薄い wrapper) 経由で呼ばれるため、world-kernel が
+// applyPawnReturn/applyPieceReturn/applyDoublePawn/applyManaUp を直接 import する必要はなくなった。
+import { CARD_SPECS } from "@/lib/shogi/cards/card-spec-server";
 import { makeMoveWithEffects } from "@/lib/shogi/kernel/move-effects";
 import type {
   CardGameState,
@@ -139,71 +139,83 @@ export function finalizeDoubleMoveLogic(
 }
 
 // ===== building-block: applyCardEffectLogic (DP-3/DP-7) =====
-// CONFIRM_PLAY_CARD (reducer.ts:1226-1342) の効果適用部を抽出 (確定済 playCard を 1 ステップ適用)。
-// modifyBoard 系は direct-apply (simulateCardEffect は returnedPiece / removeNoPromoteMark を
-// 落とすため使わない、計画 §4 訂正)。double_move は本関数の対象外 (applyTurnAction で別扱い)。
+// CONFIRM_PLAY_CARD (reducer.ts) の効果適用部を抽出 (確定済 playCard を 1 ステップ適用)。
 // 返り値: 効果適用後の {gameState, cardState, event}。不正 (王手未解除等) は null。
-// Issue #235 S1d: reducer の CONFIRM_PLAY_CARD が効果適用を本関数へ委譲するため export
-// (double_move/selectTarget は reducer に残し、trap/mana_up/pawn_return/piece_return/double_pawn を委譲)。
+// reducer の CONFIRM_PLAY_CARD (S1d) と AI 探索 (applyTurnAction) が本関数へ委譲する単一権威。
+//
+// Issue #235 S2b cutover: 旧 effectId switch (trap / mana_up / pawn_return / piece_return / double_pawn)
+// を **CardSpec registry の EffectSpec 駆動 dispatch** へ統一 (P5 解消)。盤面変更は spec.effect.apply
+// (= 既存 applyXxx の薄い wrapper) に委譲し、汎用処理 (consumeNormalCard / mana 減算 / event 構築 /
+// returnedPiece / removeNoPromoteMark sideEffect) は本 dispatcher が担う (§9 B3)。挙動は旧実装と等価
+// (world-kernel-equivalence / reducer / effects / kernel-search-equivalence / card-spec テストで担保)。
+// double_move は effect を持たない (multiPly のみ) ため本関数の対象外 = applyTurnAction で別扱い。
+// trap trigger (no_promote 成り抑止 / check_break 王手崩し) の発火は move-effects.ts インライン (Route B、不変)。
 export function applyCardEffectLogic(
   world: WorldState,
   action: Extract<TurnAction, { kind: "playCard" }>,
   player: Player,
 ): { gameState: GameState; cardState: CardGameState; event: GameEvent } | null {
-  const def = CARD_DEFS[action.defId];
+  const spec = CARD_SPECS[action.defId];
+  const effect = spec.effect;
+  // effect 無 (double_move 等 multiPly カード) は本関数の対象外。applyTurnAction の playCard 分岐が
+  // 事前に処理するため通常到達しないが、防御的に null (旧実装の `else return null` と等価)。
+  if (!effect) return null;
+
+  const cost = spec.meta.cost;
   let nextGameState = world.gameState;
   let nextCardState = world.cardState;
   let returnedPieceInfo: { row: number; col: number; pieceType: string } | undefined;
 
-  if (def.kind === "trap") {
-    // トラップ: consumeNormalCard を使わず mana 直接減算 + applyTrapSet (graveyard 不変 DP-3)
-    if (world.cardState.mana[player] < def.cost) return null;
+  if (effect.type === "setTrap") {
+    // トラップ: consumeNormalCard を使わず mana 直接減算 + applyTrapSet (graveyard 不変 DP-3)。
+    if (world.cardState.mana[player] < cost) return null;
     const afterMana: CardGameState = {
       ...world.cardState,
-      mana: { ...world.cardState.mana, [player]: world.cardState.mana[player] - def.cost },
+      mana: { ...world.cardState.mana, [player]: world.cardState.mana[player] - cost },
     };
     const afterSet = applyTrapSet(afterMana, player, action.cardInstanceId);
     if (!afterSet) return null;
     nextCardState = afterSet;
-  } else if (def.effectId === "mana_up") {
-    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
-    if (!consumed) return null;
-    nextCardState = applyManaUp(consumed, player);
-  } else if (def.effectId === "pawn_return" || def.effectId === "piece_return") {
+  } else if (effect.type === "modifyBoard") {
     if (!action.target || action.target.kind !== "square") return null;
     const targetPos = { row: action.target.row, col: action.target.col };
-    const returnedPiece = world.gameState.board[targetPos.row]?.[targetPos.col];
-    const ng =
-      def.effectId === "pawn_return"
-        ? applyPawnReturn(world.gameState, player, targetPos)
-        : applyPieceReturn(world.gameState, player, targetPos);
+    // 盤面適用前に target マスの駒を控える。駒があれば「持ち駒へ戻す」効果 (pawn_return / piece_return):
+    //   returnedPiece (cardPlayEvent の駒フライト演出用) + removeNoPromoteMark (案A: 戻した駒はマーク喪失)。
+    // double_pawn は空マスへの打ちで pieceBefore 無 → どちらも発生しない (旧実装と等価、§9 B3)。
+    const pieceBefore = world.gameState.board[targetPos.row]?.[targetPos.col];
+    const ng = effect.apply(world.gameState, player, action.target);
     if (!ng) return null;
     nextGameState = ng;
-    if (returnedPiece) {
+    if (pieceBefore) {
       returnedPieceInfo = {
         row: targetPos.row,
         col: targetPos.col,
-        pieceType: unpromotePieceType(returnedPiece.type),
+        pieceType: unpromotePieceType(pieceBefore.type),
       };
     }
-    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
+    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, cost);
     if (!consumed) return null;
-    // 持ち駒に戻った駒は no_promote マークを失う (案A 仕様、reducer.ts:1266/1284)
-    nextCardState = removeNoPromoteMark(consumed, player, targetPos);
-  } else if (def.effectId === "double_pawn") {
-    if (!action.target || action.target.kind !== "square") return null;
-    const targetPos = { row: action.target.row, col: action.target.col };
-    const ng = applyDoublePawn(world.gameState, player, targetPos);
-    if (!ng) return null;
-    nextGameState = ng;
-    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, def.cost);
+    nextCardState = pieceBefore ? removeNoPromoteMark(consumed, player, targetPos) : consumed;
+  } else if (effect.type === "modifyResource") {
+    const consumed = consumeNormalCard(world.cardState, player, action.cardInstanceId, cost);
     if (!consumed) return null;
-    nextCardState = consumed;
+    // mana リソース変更 (mana_up: +effect.mana、manaCap でクランプ = 旧 applyManaUp と等価)。
+    nextCardState =
+      effect.mana !== undefined
+        ? {
+            ...consumed,
+            mana: {
+              ...consumed.mana,
+              [player]: Math.min(consumed.manaCap, consumed.mana[player] + effect.mana),
+            },
+          }
+        : consumed;
+    // effect.draw は S2a registry では未使用 (将来カード用)。
   } else {
     return null;
   }
 
-  // 王手中の最終ガード (reducer.ts:1338-1342): 王手中だった場合、適用後も王手なら不正 (no-op)。
+  // 王手中の最終ガード (reducer 等価): 王手中だった場合、適用後も王手なら不正 (no-op)。
   // 合法 action では発生しないが reducer 等価のため再現。
   if (
     isInCheck(world.gameState, player, CARD_SHOGI_VARIANT) &&
@@ -213,7 +225,7 @@ export function applyCardEffectLogic(
   }
 
   const event: GameEvent =
-    def.kind === "trap"
+    spec.eventKind === "trapSetEvent"
       ? {
           kind: "trapSetEvent",
           player,


### PR DESCRIPTION
## Summary
カード将棋 CPU 土台再設計 (epic #235) L1 フレームワーク化 **S2b**。S2a (PR #237) で additive 新設した CardSpec registry を **production の効果適用経路へ配線する cutover** (P5 解消)。

これまで効果適用は `applyCardEffectLogic` 内の effectId switch (trap/mana_up/pawn_return/piece_return/double_pawn) に分散していた。これを `CardSpec` の `EffectSpec` 駆動 dispatch へ統一し、新カードは registry にデータを足すだけで効果適用が通る土台にする。reducer (S1d 委譲済) と AI (`applyTurnAction`) の単一権威 `applyCardEffectLogic` を 1 箇所置換するだけで UI/AI 両経路へ波及。

### 変更
- **`world-kernel.ts`**: `applyCardEffectLogic` の effectId switch → `CARD_SPECS[id].effect` 駆動 dispatch へ置換。盤面変更は `spec.effect.apply` (既存 applyXxx の薄い wrapper) に委譲、汎用処理 (consumeNormalCard / mana 減算 / event 構築 / returnedPiece / removeNoPromoteMark) は dispatcher が担う。modifyBoard は適用前の `pieceBefore` 有無で returnedPiece + removeNoPromoteMark を条件発火 (旧版と等価)。未使用化した applyPawnReturn/applyPieceReturn/applyDoublePawn/applyManaUp の import を除去。
- **`card-spec-server.ts`** (M2 D1-1 解消): `UseCondition`/`onTrigger` を `WorldState` 依存から cards/ ローカル最小型 `CardWorldView` ({gameState, cardState}) へ縮約。world-kernel が CARD_SPECS を value import する一方 card-spec-server は world-kernel を import しない = **型/runtime 循環なし**。
- **計画 doc**: §11 S2b M2 レビュー記録。

### 挙動
**意図的に等価** (refactor、観測挙動不変)。effectId switch → registry dispatch の内部置換のみ。trap trigger (no_promote 成り抑止 / check_break 王手崩し) の発火は move-effects.ts インライン温存 (Route B、不変)。

## Test plan
- `npm run lint` → 0 error / `npm run typecheck` → 緑
- `npm run test:ci` → **571 passed** / 12 skipped (S2a 同数=デグレなし。等価ゲート world-kernel-equivalence / reducer / effects / kernel-search-equivalence / card-spec すべて緑)
- `npm run build` → 緑
- bench (`RUN_PERF_BENCH=true`): kernel-search advanced/expert **cardRate OFF=4/4 ON=4/4・action 選択 OFF==ON 一致・depthCompleted d4==d4**、card-usage baseline 同値 = **棋力退化なし**
- M2 独立 adversarial agent 検証: cutover は旧版と **byte 等価・発散点ゼロ** (6カード全件、pieceBefore 汎用化 / mana_up modifyResource / trap setTrap / eventKind 派生 / 王手ガード / double_move 防御を確認)

Refs #235