### PR TITLE
refactor: #235 S2c 横断制約 (待った可否/AI候補生成) を CardSpec registry 導出へ

### DIFF
--- a/docs/plans/issue-235-s2-cardspec.md
+++ b/docs/plans/issue-235-s2-cardspec.md
@@ -101,8 +101,8 @@ registry は新規ファイルのため S2a は revert 安全。
 - [x] **S2b** (完了・commit 予定): applyCardEffectLogic の effectId switch → spec.effect.apply dispatch へ置換 (consumeNormalCard・event 構築・sideEffect removeNoPromoteMark は dispatcher 汎用処理)。**trap trigger (move-effects インライン) には触れない (Route B、DP-7 保全)**。bench 棋力退化なし (kernel-search OFF==ON 4/4・depth d4 同値、card-usage baseline 同値)。
   - **M2 (§11) で D1-1 解消済**: 当初案 (b) を採用し、`UseCondition`/`onTrigger` を card-spec-server の `import type { WorldState }` から **cards/ ローカル最小型 `CardWorldView` ({gameState, cardState})** に縮約。world-kernel が CARD_SPECS を value import する一方 card-spec-server は world-kernel を import しない = **型/runtime 循環なし**。WorldState/AiTurnState は構造的に CardWorldView へ代入可 (caller 不変)。
   - **汎用化の等価性 (§9 B3)**: modifyBoard は適用前の `pieceBefore = board[target]` 有無で returnedPiece + removeNoPromoteMark を条件発火。applyPawnReturn/applyPieceReturn は target に駒必須 (null時は早期 return) のため pieceBefore 常在 = 旧版の無条件呼び出しと一致。double_pawn は target 常に空 = 不発で旧版と一致 (M2 adversarial 検証で6カード全件確認)。
-- [ ] **S2c**: isCardOpEvent を spec.eventKind 導出 / action-generator 候補生成を registry クエリ / checkUsage を spec 参照。族別 switch 排除。
-  - **M2 申し送り**: `CardEventKind` (card-spec.ts) は card 自身の使用/設置 event (`cardPlayEvent`/`trapSetEvent`) のみ。`isCardOpEvent` 導出時は **トラップ発動 `trapTriggerEvent` を別途合算** すること (別ライフサイクル=相手手番で発火するため card の eventKind には含めていない)。
+- [x] **S2c** (完了・commit 予定): isCardOpEvent を `CARD_OP_EVENT_KINDS` (registry 全カード eventKind の集合、client-safe) 導出へ / action-generator 候補生成を `CARD_SPECS` クエリ (cost/kind/useCondition/checkUsage/targeting) へ / checkUsage を spec 参照。族別ハードコード排除。reducer の checkUsage UI gate (client) は client/server 境界の論点があり **S2d 領域**として本段では CARD_DEFS のまま据置。
+  - **申し送り対応済**: `isCardOpEvent` 導出時に **トラップ発動 `trapTriggerEvent` を別途合算** (CARD_OP_EVENT_KINDS は card 自身の eventKind のみ=別ライフサイクル)。`deriveEventKind` を card-spec.ts (client-safe) へ移し card-spec-server が import (重複定義解消)。検証: lint0err/typecheck/test:ci **573**(+2)/build/bench。M2 独立 adversarial で旧版と等価 (isCardOpEvent 全6 kind 真偽一致・action-generator 候補集合/順序同一)、§12 記録。
 - [ ] **S2d**: 旧 CARD_DEFS/CARD_USE_CONDITIONS 重複の一本化・デッドコード除去。serialize 境界是正 (ESLint で Client→server import 禁止)。
   - **M2 申し送り (§10 D1-2)**: 境界強制方式の候補。repo には既に `server-only` パッケージが導入済 (`package.json` deps + `src/lib/auth/{current-user,config,merge,user-bootstrap}.ts` で実使用 + `vitest.config.ts` で no-op shim alias 済) のため、`card-spec-server.ts` 冒頭へ `import "server-only"` を付すのが最小コスト。eslint `no-restricted-paths` との二者択一を S2d で確定する。
 - [ ] **S2e**: CardSystemConfig 集約 (値は不変)。
@@ -173,3 +173,20 @@ card-spec-server の `WorldState` 型依存を `CardWorldView` ({gameState, card
 
 ### dead code 申し送り
 `applyManaUp` (effects.ts) は本 cutover で production から未参照になるが、effects.test/reducer.test/equivalence (OBS5-3) のカバレッジ維持のため **除去は S2d**。
+
+## 12. S2c M2 マイルストーンレビュー (横断制約 registry 化、実装後、2026-06-07、AGENTS.md ルール8)
+
+S2c = 横断制約 (待った可否 / AI 候補生成) を CardSpec registry から導出する behavior-preserving refactor。
+- **isCardOpEvent** (undo-policy.ts、client): 旧 4 条件ハードコードを `CARD_OP_EVENT_KINDS` (card-spec.ts で全カード eventKind を集約=client-safe Set) 導出 + manual drawEvent + trapTriggerEvent 別合算へ。
+- **action-generator** (ai): CARD_DEFS/CARD_USE_CONDITIONS 個別参照を `CARD_SPECS[id]` クエリ (meta.cost/meta.kind/useCondition/checkUsage/targeting) へ統一。族別 switch 排除。
+- **deriveEventKind**: server → card-spec.ts (client-safe) へ移設、card-spec-server は import (重複解消)。
+
+### 検証実測
+- lint 0err / typecheck 緑 / test:ci **573 passed** (S2b 571 + 新規 CARD_OP_EVENT_KINDS テスト 2) / build 緑。
+- bench: kernel-search advanced/expert **cardRate OFF==ON 4/4・depth d4 同値** (決定的 bench=ロジック不変の確証)。card-usage は `cardCount>=1` sanity passed。**rate ログ変動 (beginner 86%/intermediate 100% 等) は退化ではない**: 当該 bench は C-13 で意図的に非決定化 (beginner addNoise=0.50 + wall-clock 時間予算) され strict per-scenario assert は flaky のため削除済、決定的 calibration 検証は `evaluate-action.test.ts` (test:ci に含まれ緑) へ移管済。
+
+### 総合判定
+**S2c は commit/push/マージ可 (指摘ゼロ)**。独立 adversarial agent 検証 = **旧版と挙動等価・発散点ゼロ (high/medium/low すべて 0)**。
+- isCardOpEvent: 全 6 GameEvent kind で旧新真偽一致 (cardPlayEvent/trapSetEvent/trapTriggerEvent=true、manual drawEvent=true、**auto drawEvent=false**、moveEvent/manaChargeEvent=false)。CARD_OP_EVENT_KINDS = {cardPlayEvent, trapSetEvent} を全7カード deriveEventKind で確認。
+- action-generator: 候補集合・yield 順序同一。spec.meta.cost/kind/checkUsage/targeting は CARD_DEFS 直写、spec.useCondition は CARD_USE_CONDITIONS を world.gameState/world.cardState へ委譲 (AiTurnState→CardWorldView 構造代入成立)。target 列挙は spec.meta.id=def.id で同一マス。
+- 層/循環: undo-policy→card-spec (client-safe meta、関数非保持)、action-generator→card-spec-server (server) はいずれも正方向。新規循環なし。dead code (action-generator の CARD_DEFS/CARD_USE_CONDITIONS/CardDefinition) 除去済。

--- a/src/hooks/card-shogi/undo-policy.ts
+++ b/src/hooks/card-shogi/undo-policy.ts
@@ -15,12 +15,18 @@
 // - 1 ターンに複数 ply 消費するカード (double_move 系) は本ヘルパが自動対応する
 //   (プレイヤー切替検出により同色連続を 1 ターン扱い)。
 
+import { CARD_OP_EVENT_KINDS } from "@/lib/shogi/cards/card-spec";
 import type { GameEvent } from "@/lib/shogi/cards/types";
 import type { Player } from "@/lib/shogi/types";
 
 /**
  * イベントが「カード操作系」(待った可否判定でブロック対象) か。
- * 新たな card 系 event を追加するときはここを更新する。
+ *
+ * Issue #235 S2c: カード使用/設置 event (cardPlayEvent / trapSetEvent) の集合は CardSpec registry の
+ * eventKind から導出した `CARD_OP_EVENT_KINDS` (client-safe、card-spec.ts) を参照する。新カードの
+ * eventKind は registry が単一源として持つため、本関数の族別ハードコードは不要になった。
+ * トラップ発動 (trapTriggerEvent) は card 自身の eventKind ではない (別ライフサイクル=相手手番で発火)
+ * ため CARD_OP_EVENT_KINDS に含まれず、ここで別途合算する。
  *
  * Issue #130: auto drawEvent は手番終了時の副作用であり、ユーザーが任意に実行した
  * カード操作ではない。待った時に reducer 側で手札/山札へ巻き戻すため、ブロック対象外。
@@ -28,9 +34,8 @@ import type { Player } from "@/lib/shogi/types";
  */
 export function isCardOpEvent(ev: GameEvent): boolean {
   return (
-    ev.kind === "cardPlayEvent" ||
+    (CARD_OP_EVENT_KINDS as ReadonlySet<string>).has(ev.kind) ||
     (ev.kind === "drawEvent" && (ev.source ?? "manual") === "manual") ||
-    ev.kind === "trapSetEvent" ||
     ev.kind === "trapTriggerEvent"
   );
 }

--- a/src/lib/shogi/ai/turn/action-generator.ts
+++ b/src/lib/shogi/ai/turn/action-generator.ts
@@ -1,36 +1,33 @@
 // Issue #193 / PR1d-2: AI 探索側のカードアクション候補生成。
 //
 // 設計:
-// reducer.ts の BEGIN_PLAY_CARD (L1124) で集約された 7 項目のカード使用可否判定を、
-// AI 側で **同じ純粋関数** (`hasSameKindTrapPlaced` / `isInCheck` /
-// `getCheckEscapingSquares` / `CARD_USE_CONDITIONS`) を呼んで再現する。
+// reducer.ts の BEGIN_PLAY_CARD で集約されたカード使用可否判定を、AI 側で**同じ値**を参照して再現する。
 // 二重実装を避けて構造的に整合性を確保。
 //
-// PR1d-2 では通常 3 カード (pawn_return / piece_return / double_pawn) に対応。
-// double_move (PR1d-3 super-action 探索) とトラップ系 (PR1d-4 no_promote / check_break)
-// は別 sub PR で実装。
-//
-// 計画 md `docs/plans/issue-193-pr1d.md` PR1d-2 詳細 / 主な変更 1. action-generator.ts 新規 参照。
+// Issue #235 S2c: 使用可否判定を **CardSpec registry のクエリへ統一**。従来は CARD_DEFS (cost/kind/
+// checkUsage/targeting) と CARD_USE_CONDITIONS (関数) を個別参照していたが、`CARD_SPECS[id]` の
+// meta.cost / meta.kind / useCondition / checkUsage / targeting へ集約 (族別 switch 排除、単一源化)。
+// registry 由来値は CARD_DEFS/CARD_USE_CONDITIONS と等価 (card-spec.test で担保) のため挙動不変。
+// 盤面マスの空間妥当性 (isValidCardTargetSquare) と 同種トラップ重複 / 王手回避列挙
+// (hasSameKindTrapPlaced / getCheckEscapingSquares) は registry 非保持の純粋関数として effects.ts に残す。
 
-import { CARD_DEFS, CARD_USE_CONDITIONS } from "@/lib/shogi/cards/definitions";
 import {
   hasSameKindTrapPlaced,
   isValidCardTargetSquare,
   getCheckEscapingSquares,
 } from "@/lib/shogi/cards/effects";
+import { CARD_SPECS, type CardSpec } from "@/lib/shogi/cards/card-spec-server";
 import { isInCheck } from "@/lib/shogi/moves";
-import type {
-  CardDefinition,
-  CardTarget,
-} from "@/lib/shogi/cards/types";
+import type { CardId, CardTarget } from "@/lib/shogi/cards/types";
 import type { GameState, Player, RuleVariant } from "@/lib/shogi/types";
 import type { AiTurnState, TurnAction } from "./types";
 
 /**
- * BEGIN_PLAY_CARD (reducer.ts:1124) の 7 項目を AI 側で再現したカードアクション候補生成。
+ * BEGIN_PLAY_CARD の 7 項目を AI 側で再現したカードアクション候補生成。
  *
- * 既存純粋関数 (hasSameKindTrapPlaced / isInCheck / getCheckEscapingSquares /
- * CARD_USE_CONDITIONS) を共用するため、reducer の判定ロジックと不一致リスクが構造的に発生しない。
+ * CardSpec registry (`CARD_SPECS`) を単一窓口にクエリするため、reducer の判定ロジックと不一致リスクが
+ * 構造的に発生しない。useCondition は registry が `(world, player)` シグネチャで内包 (= CARD_USE_CONDITIONS
+ * を統一)。AiTurnState は CardWorldView ({gameState, cardState}) へ構造的に代入可能。
  *
  * variant は AiTurnState に持たないため引数で明示的に受け取る (CurrentRules.getLegalActions と
  * 同じ「this.variant 経由」のパターンと一貫)。calling 側は CurrentRules.getLegalActions 内で
@@ -50,35 +47,35 @@ export function* getCardActions(
   if (state.gameState.currentPlayer !== player) return;
 
   for (const card of state.cardState.hand[player]) {
-    const def = CARD_DEFS[card.defId];
+    const spec = CARD_SPECS[card.defId];
 
     // (3) 手札にないカードは for...of で自然にスキップ済 (state.cardState.hand[player] が手札全件)
 
     // (4) マナ不足は使用不可
-    if (state.cardState.mana[player] < def.cost) continue;
+    if (state.cardState.mana[player] < spec.meta.cost) continue;
 
     // (5) 同種トラップ重複は使用不可
-    if (def.kind === "trap" && hasSameKindTrapPlaced(state.cardState, player, card.defId)) {
+    if (spec.meta.kind === "trap" && hasSameKindTrapPlaced(state.cardState, player, card.defId)) {
       continue;
     }
 
-    // (6) CARD_USE_CONDITIONS 個別判定 (定義済は 3 枚: pawn_return / double_pawn / piece_return)
-    const conditionFn = CARD_USE_CONDITIONS[card.defId];
-    if (conditionFn && !conditionFn(state.gameState, player, state.cardState)) {
+    // (6) 個別使用条件 (registry の useCondition = CARD_USE_CONDITIONS 内包、定義済は
+    //     pawn_return / double_pawn / piece_return の 3 枚)
+    if (spec.useCondition && !spec.useCondition(state, player)) {
       continue;
     }
 
     // (7) 王手中: checkUsage フラグで二段ゲート
     if (isInCheck(state.gameState, player, variant)) {
-      if (def.checkUsage === "forbidden") continue;
-      if (def.checkUsage === "conditional" && def.targeting !== "none") {
+      if (spec.checkUsage === "forbidden") continue;
+      if (spec.checkUsage === "conditional" && spec.targeting !== "none") {
         const escapingSquares = getCheckEscapingSquares(state.gameState, player, card.defId);
         if (escapingSquares.length === 0) continue;
       }
     }
 
     // 7 項目通過後、target 列挙して PlayCardAction を yield
-    for (const target of enumerateTargets(state, def, player)) {
+    for (const target of enumerateTargets(state, spec, player)) {
       yield {
         kind: "playCard",
         cardInstanceId: card.instanceId,
@@ -90,7 +87,7 @@ export function* getCardActions(
 }
 
 /**
- * カード定義の targeting に応じて対象 target を列挙 (第 4 次レビュー C-5 反映)。
+ * CardSpec の targeting に応じて対象 target を列挙 (第 4 次レビュー C-5 反映)。
  *
  * - "none": ターゲット不要カード (mana_up / check_break / double_move / no_promote) → null を 1 回 yield
  * - "square": 盤面マス指定カード (double_pawn 等) → 有効マスを順次 yield
@@ -101,10 +98,10 @@ export function* getCardActions(
  */
 function* enumerateTargets(
   state: AiTurnState,
-  def: CardDefinition,
+  spec: CardSpec,
   player: Player,
 ): Iterable<CardTarget | null> {
-  switch (def.targeting) {
+  switch (spec.targeting) {
     case "none":
       yield null;
       return;
@@ -112,7 +109,7 @@ function* enumerateTargets(
     case "ownPiece": {
       // 「ownPiece」も実態は盤面マス指定 (isValidCardTargetSquare の defId 別 case で
       // 自駒種別を判定するため、CardTarget の kind は "square" 統一)
-      for (const pos of enumerateValidSquaresForCard(state.gameState, def, player)) {
+      for (const pos of enumerateValidSquaresForCard(state.gameState, spec.meta.id, player)) {
         yield { kind: "square", row: pos.row, col: pos.col };
       }
       return;
@@ -124,20 +121,20 @@ function* enumerateTargets(
 }
 
 /**
- * targeting: "square" カード (pawn_return / piece_return / double_pawn) の対象マス列挙。
+ * targeting: "square"/"ownPiece" カード (pawn_return / piece_return / double_pawn) の対象マス列挙。
  *
- * isValidCardTargetSquare (effects.ts:274) を 9×9 ループで呼ぶシン実装 (= reducer 側と同一判定)。
+ * isValidCardTargetSquare (effects.ts) を 9×9 ループで呼ぶシン実装 (= reducer 側と同一判定)。
  * isValidCardTargetSquare 内部で variant.id 固定 (CARD_SHOGI_VARIANT) で王手判定済のため、
- * 王手中の use condition は CARD_USE_CONDITIONS 経由で getCardActions の (6) 段階で既に枝刈り済。
+ * 王手中の use condition は getCardActions の (6) 段階で既に枝刈り済。
  */
 function* enumerateValidSquaresForCard(
   gameState: GameState,
-  def: CardDefinition,
+  defId: CardId,
   player: Player,
 ): Iterable<{ row: number; col: number }> {
   for (let row = 0; row < 9; row++) {
     for (let col = 0; col < 9; col++) {
-      if (isValidCardTargetSquare(gameState, player, def.id, { row, col })) {
+      if (isValidCardTargetSquare(gameState, player, defId, { row, col })) {
         yield { row, col };
       }
     }

--- a/src/lib/shogi/cards/__tests__/card-spec.test.ts
+++ b/src/lib/shogi/cards/__tests__/card-spec.test.ts
@@ -23,6 +23,8 @@ import { ALL_CARD_DEFS, CARD_DEFS, CARD_USE_CONDITIONS } from "../definitions";
 import { applyDoublePawn, applyPawnReturn, applyPieceReturn } from "../effects";
 import {
   CARD_META,
+  CARD_OP_EVENT_KINDS,
+  deriveEventKind,
   getActiveCards,
   getPlayableCards,
   getValidCardIds,
@@ -227,6 +229,23 @@ describe("eventKind 派生規則 (§9 A6)", () => {
     for (const id of ["no_promote", "check_break"] as CardId[]) {
       expect(CARD_SPECS[id].eventKind).toBe("trapSetEvent");
     }
+  });
+
+  it("deriveEventKind は CARD_SPECS[id].eventKind と一致 (単一規則)", () => {
+    for (const id of ALL_CARD_IDS) {
+      expect(deriveEventKind(CARD_META[id])).toBe(CARD_SPECS[id].eventKind);
+    }
+  });
+
+  // S2c: undo-policy.isCardOpEvent が参照する registry 導出集合。
+  it("CARD_OP_EVENT_KINDS = 全カード eventKind の集合 = {cardPlayEvent, trapSetEvent}", () => {
+    expect(CARD_OP_EVENT_KINDS).toEqual(new Set(["cardPlayEvent", "trapSetEvent"]));
+    // 全カードの eventKind が漏れなく含まれる
+    for (const id of ALL_CARD_IDS) {
+      expect(CARD_OP_EVENT_KINDS.has(CARD_SPECS[id].eventKind)).toBe(true);
+    }
+    // トラップ発動 (trapTriggerEvent) は card 自身の eventKind ではないため含まれない (別合算)
+    expect((CARD_OP_EVENT_KINDS as ReadonlySet<string>).has("trapTriggerEvent")).toBe(false);
   });
 });
 

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -23,7 +23,7 @@
 import type { GameState, Player, Position } from "@/lib/shogi/types";
 import type { CardCheckUsage, CardGameState, CardId, CardTarget, CardTargeting, TrapTrigger } from "./types";
 import type { CardEventKind, CardMeta } from "./card-spec";
-import { CARD_META } from "./card-spec";
+import { CARD_META, deriveEventKind } from "./card-spec";
 import { CARD_DEFS, CARD_USE_CONDITIONS } from "./definitions";
 import { applyDoublePawn, applyPawnReturn, applyPieceReturn } from "./effects";
 
@@ -126,12 +126,6 @@ function boardEffect(
 function resolveUseCondition(id: CardId): UseCondition | undefined {
   const fn = CARD_USE_CONDITIONS[id];
   return fn ? (world, player) => fn(world.gameState, player, world.cardState) : undefined;
-}
-
-// eventKind 派生規則 (§9 A6): trap → "trapSetEvent"、それ以外 (normal/multiPly) → "cardPlayEvent"。
-// 単一規則として encode し、各カードで個別ハードコードしない。
-function deriveEventKind(meta: CardMeta): CardEventKind {
-  return meta.kind === "trap" ? "trapSetEvent" : "cardPlayEvent";
 }
 
 // CardSpec 組み立て共通処理。targeting / checkUsage / eventKind / useCondition は CARD_DEFS・CARD_META

--- a/src/lib/shogi/cards/card-spec.ts
+++ b/src/lib/shogi/cards/card-spec.ts
@@ -65,6 +65,22 @@ export const CARD_META: Record<CardId, CardMeta> = Object.fromEntries(
   (Object.keys(CARD_DEFS) as CardId[]).map((id) => [id, toCardMeta(CARD_DEFS[id])]),
 ) as Record<CardId, CardMeta>;
 
+// eventKind 派生規則 (§9 A6): trap → "trapSetEvent"、それ以外 (normal/multiPly) → "cardPlayEvent"。
+// 単一規則として encode し各カードで個別ハードコードしない。CardSpec 構築 (card-spec-server) と
+// 本ファイルの CARD_OP_EVENT_KINDS が共有する。meta のみ参照 = client-safe。
+export function deriveEventKind(meta: CardMeta): CardEventKind {
+  return meta.kind === "trap" ? "trapSetEvent" : "cardPlayEvent";
+}
+
+// カードの使用/設置で発行されうる event 種別の集合 (= registry 全カードの eventKind を導出して集約)。
+// undo-policy.isCardOpEvent が「待った可否でブロックすべきカード操作 event」判定に使う (S2c で族別
+// ハードコードを本集合導出へ置換、§8)。現状は {cardPlayEvent, trapSetEvent} (全カードが normal/trap)。
+// 注: トラップ発動 "trapTriggerEvent" は card 自身の eventKind ではない (別ライフサイクル=相手手番で発火)
+// ため本集合に含まれない。isCardOpEvent 側で別途合算する (§9 A6 / S2c 申し送り)。
+export const CARD_OP_EVENT_KINDS: ReadonlySet<CardEventKind> = new Set(
+  Object.values(CARD_META).map(deriveEventKind),
+);
+
 // ===== registry SSOT helper (§8 / §9 B4) =====
 // seed orphan-guard / deck.ts VALID_CARD_IDS / user-bootstrap・merge の playable 抽出などが
 // 現状 ALL_CARD_DEFS を直読している。S2c/S2d でこれら helper 経由へ移行する (本段では additive に提供のみ)。


### PR DESCRIPTION
## Summary
カード将棋 CPU 土台再設計 (epic #235) L1 フレームワーク化 **S2c**。S2b (PR #238) で配線した CardSpec registry を、横断制約 (待った可否判定・AI カード候補生成) の**単一源**として活用する behavior-preserving refactor。

待った可否の `isCardOpEvent` (undo-policy) と AI 候補生成 (action-generator) が、カードメタ情報を `CARD_DEFS` / `CARD_USE_CONDITIONS` から族別に個別参照していた。新カード追加時の更新漏れ・判定分散の温床になるため、registry から自動導出する形へ統一。

### 変更 (観測挙動不変)
- **`card-spec.ts`**: `deriveEventKind` を server から移設 (client-safe) + `CARD_OP_EVENT_KINDS` (全カード eventKind の集合 = `{cardPlayEvent, trapSetEvent}`) を導出。
- **`undo-policy.ts`**: `isCardOpEvent` の族別ハードコードを `CARD_OP_EVENT_KINDS` 導出へ置換。トラップ発動 `trapTriggerEvent` は card 自身の eventKind でない (別ライフサイクル) ため別途合算。
- **`action-generator.ts`**: `getCardActions` の使用可否判定を `CARD_SPECS[id]` クエリ (meta.cost/meta.kind/useCondition/checkUsage/targeting) へ統一。`CARD_DEFS`/`CARD_USE_CONDITIONS` 個別参照を排除。`useCondition` は `AiTurnState` を `CardWorldView` として渡す。
- **`card-spec-server.ts`**: `deriveEventKind` を card-spec から import (重複定義解消)。
- **`card-spec.test.ts`**: `CARD_OP_EVENT_KINDS` / `deriveEventKind` 検証 2 件追加。
- 注: reducer の checkUsage UI gate (client) は client/server 境界の論点があり **S2d 領域**として据置。

## Test plan
- `npm run lint` → 0 error / `npm run typecheck` → 緑
- `npm run test:ci` → **573 passed** / 12 skipped (S2b 571 + 新規 2。undo-policy / action-generator / card-spec すべて緑)
- `npm run build` → 緑
- bench (`RUN_PERF_BENCH=true`): kernel-search (決定的) **cardRate OFF==ON 4/4・depth d4 同値** = ロジック不変の確証。card-usage は `cardCount>=1` sanity passed (rate ログ変動は C-13 で意図的非決定化=退化でなく、決定的 calibration は `evaluate-action.test.ts` に移管済・test:ci 緑)
- M2 独立 adversarial agent 検証: **旧版と挙動等価・発散点ゼロ** (isCardOpEvent 全6 GameEvent kind 真偽一致 / action-generator 候補集合・yield 順序同一 / 層・循環なし / dead code 除去)

Refs #235