### PR TITLE
refactor: #235 S2e カードシステム定数を CardSystemConfig に集約

### DIFF
--- a/docs/plans/issue-235-s2-cardspec.md
+++ b/docs/plans/issue-235-s2-cardspec.md
@@ -108,7 +108,7 @@ registry は新規ファイルのため S2a は revert 安全。
   - ② デッドコード除去 (`applyManaUp` 等) → **#80 の担当**: `definitions.ts:49` に「効果コード (applyManaUp) の最終撤去は #80」と明記。S2b で production 未参照化したが除去は #80 スコープ (effects.test のカバレッジ維持のため本段では残置)。
   - ③ serialize 境界 → **実施**: ESLint `no-restricted-imports` で `src/components/**` からの card-spec-server import を error 化 (probe で発火確認)。hooks (reducer 等) は world-kernel 経由で registry を必要とするため対象外 (Client 実行だが props serialize なし)。境界強制方式は `server-only` パッケージでなく eslint を採用 (reducer→world-kernel→card-spec-server の推移 import が成立しており `server-only` は Client build を壊すため不可)。
   - consumer 移行: deck.ts (VALID_CARD_IDS/playable/deprecated) と merge.ts (playable id) を `getValidCardIds`/`getPlayableCards` 経由へ (id/status のみ参照ゆえ移行可)。user-bootstrap/seed/cards-page は full CardDefinition 必要のため ALL_CARD_DEFS 維持。
-- [ ] **S2e**: CardSystemConfig 集約 (値は不変)。
+- [x] **S2e (完了・commit 予定)**: CardSystemConfig 集約 (値は不変)。新規 `card-system-config.ts` (client-safe = 値のみ) に `CardSystemConfig` 型 + `CARD_SYSTEM_CONFIG` + フラット名前付き定数 10 件 (マナ/ドロー 7 + デッキ構築 3) を集約。`definitions.ts` は純 re-export、`deck-rules.ts` は内部利用のため import + re-export。**DECK_TOTAL_MAX/MIN も凝集性のため同梱 (ユーザー承認、§14)**。挙動完全不変・値 byte 等価。検証: lint0err/typecheck/test:ci 573/build。M2=セルフ + 独立 adversarial agent (§14)。
 - [ ] valueModel は現行係数ブリッジ (中身は S3、構造のみ)。trap onTrigger は @deferred stub (実配線 S3)。
 - [ ] 各段 lint/typecheck/test:ci/build green。段階順序 S2a→S2b→(S2c)→S2d→S2e (S2c/S2d は S2b 前提=revert 単独不可を §7 明記)。
 
@@ -209,4 +209,30 @@ S2c = 横断制約 (待った可否 / AI 候補生成) を CardSpec registry か
 ### scope 外 (申し送り)
 - ① ALL_CARD_DEFS 全廃: CardMeta に説明文/effectId を含める設計変更が前提 (meta/spec 分離見直し)。必要になれば別途検討。
 - ② applyManaUp 等 dead code 除去: #80 (mana_up 効果コード最終撤去) のスコープ。
-- 次: S2e (CardSystemConfig 集約、値不変)。
+- 次: S2e (CardSystemConfig 集約、値不変)。 → **§14 で完了**。
+
+## 14. S2e レビュー (CardSystemConfig 集約、実装後、2026-06-08、AGENTS.md ルール8)
+
+S2e = カードシステムの散在定数を registry 近傍の `CardSystemConfig` に集約する **値不変の cosmetic refactor** (S2 最終段)。これで S2 (L1 フレームワーク化) の全段完了。
+
+### 変更
+- 新規 `src/lib/shogi/cards/card-system-config.ts` (client-safe = 関数を持たない値のみ): `CardSystemConfig` 型 (mana/draw/deck の 3 セクション) + SSOT オブジェクト `CARD_SYSTEM_CONFIG` + 後方互換のフラット名前付き定数 10 件を導出 export。確定経緯コメント (Issue #81/#130/#89、3→2 引き下げ理由、自動ドローのカウント規則等) を本ファイルへ集約保全。
+  - 集約定数: `INITIAL_MANA` / `MANA_CAP` / `DRAW_COST` / `AUTO_DRAW_INTERVAL` / `MANA_PER_TURN` / `MANA_FAST_BONUS` / `FAST_THRESHOLD_MS` (旧 definitions.ts) + `DECK_TOTAL_MAX` / `DECK_TOTAL_MIN` / `RARITY_MAX_PER_DECK` (旧 deck-rules.ts)。
+- `definitions.ts`: マナ/ドロー 7 定数を **純 re-export** (`export { ... } from "./card-system-config"`、ファイル内部で未使用ゆえ local binding 不要)。
+- `deck-rules.ts`: デッキ 3 定数を **import + re-export** (validateDeckEntries が内部で RARITY_MAX_PER_DECK/DECK_TOTAL_MIN/MAX を使うため local binding が必要)。
+- 派生修正 (同居、rule 2): 定数移設で stale 化した行番号参照コメント 3 件 (heuristics.ts:19-20 / digest.ts:37) を `card-system-config.ts` 参照へ更新 + 行番号ハードコードを除去 (今後のドリフト防止)。
+
+### 設計判断
+- **配置 = 別ファイル** (`card-spec.ts` への同居でなく): card-spec.ts は per-card meta、CardSystemConfig は system-wide config で別概念。関数を持たないため S2d の ESLint 境界 (components→card-spec-server 禁止) には抵触せず、Client から (definitions/deck-rules 経由で) 安全に参照可。
+- **move + re-export 方式** (全 consumer 一括書換でなく): 既存 import (definitions 経由 29 / deck-rules 経由 3 ファイル) を一切壊さず churn 最小。値の SSOT は CARD_SYSTEM_CONFIG。
+- **DECK_TOTAL_MAX/MIN 同梱** (ユーザー承認): 引き継ぎの明示スコープは RARITY_MAX_PER_DECK のみだが、同じデッキ構築上限で密接に関連するため deck セクションを完結させ凝集性を確保。値不変・追加リスクゼロ・phase 別バージョニングの目的に合致。
+- **型保全**: INITIAL_MANA は旧 `Record<"sente"|"gote", number>` → `Record<Player, number>` (Player="sente"|"gote" で同一)、RARITY は `Record<CardRarity, number|null>` 維持。プリミティブはリテラル型→number 幅広化 (config 値として適切、依存 consumer なし=typecheck pass で裏付け)。
+
+### 検証実測
+- lint 0err (22 warning は既存・変更ファイル指摘ゼロ) / typecheck 緑 / test:ci **573 passed** (S2d 同数=デグレなし。DRAW_COST===2 / INITIAL_MANA 差 -1 / MANA_CAP / AUTO_DRAW_INTERVAL 挙動を直接 assert するテスト群が全緑=値等価の実証) / build 緑。
+
+### 総合判定
+**S2e は commit/push 可 (high/medium 指摘ゼロ)**。独立 adversarial agent (general-purpose) 検証 = **値 byte 等価・re-export 正当・全 consumer 解決・循環なし・型互換・ESLint 境界抵触なし・mutation 無害の 6 観点すべて発散点ゼロ**。唯一の指摘 (low: 他ファイルの行番号参照コメント 3 件のドリフト) は本段で修正済。
+
+### S2 完了 → 次 = S3
+S2e マージで **S2 (L1 カードフレームワーク化) 全段完了**。次の主段は **S3 (ValueModel の内容依存値付け = AI のカード価値評価を局面・コスト依存へ。現 valueModel は静的 stub)**。棋力直結のため bench 実測必須。epic doc §3 L1 / §11 + #193 PR3 系校正資産を参照。

--- a/src/lib/shogi/ai/cards/digest.ts
+++ b/src/lib/shogi/ai/cards/digest.ts
@@ -34,7 +34,7 @@ import {
 export interface CardDigest {
   // mana.sente - mana.gote (W-2 反映: sente 絶対視点で、sente 有利なら正)
   manaDelta: number;
-  // 将来動的化想定 (現状静的だが枠は確保、definitions.ts:228 MANA_CAP = 20)
+  // 将来動的化想定 (現状静的だが枠は確保、card-system-config.ts MANA_CAP = 20)
   manaCap: number;
   // handValue(sente hand) - handValue(gote hand) (W-2: sente 絶対視点、単調減衰関数で算出)
   handValueDelta: number;

--- a/src/lib/shogi/ai/cards/heuristics.ts
+++ b/src/lib/shogi/ai/cards/heuristics.ts
@@ -16,8 +16,8 @@ import type { CardGameState } from "../../cards/types";
 //     現状 DRAW_COST = 2 + 1 = 3 が安全側だが、F-4 解釈 (drawProgress < AUTO_DRAW_INTERVAL - 1
 //     ガードと組み合わせて自然な絞り込みとなる) を踏まえて 2 で開始、bench で調整。
 //   ・(旧 DRAW_VALUE_BONUS=30 固定は PR3-1 で getDrawValue() に置換、退化原因 ① 解消)
-//   ・DRAW_COST は src/lib/shogi/cards/definitions.ts:233 で 2 と定義済 (本ファイルでは参照のみ)
-//   ・AUTO_DRAW_INTERVAL は src/lib/shogi/cards/definitions.ts:238 で 5 と定義済 (本ファイルでは参照のみ)
+//   ・DRAW_COST は src/lib/shogi/cards/card-system-config.ts で 2 と定義済 (本ファイルでは参照のみ)
+//   ・AUTO_DRAW_INTERVAL は src/lib/shogi/cards/card-system-config.ts で 5 と定義済 (本ファイルでは参照のみ)
 export const MIN_MANA_RESERVE = 2;
 
 // handValue 単調減衰関数 (PR1d-1 仮基準 → PR3-1 で 3.0→5.0 に変更、PR3-3 で再検証):

--- a/src/lib/shogi/cards/card-system-config.ts
+++ b/src/lib/shogi/cards/card-system-config.ts
@@ -1,0 +1,97 @@
+// Issue #235 S2e: カードシステム定数の集約層 (CardSystemConfig)。
+//
+// 目的 (epic doc §4 / S2 計画 docs/plans/issue-235-s2-cardspec.md §3 S2e / §8):
+//   従来 definitions.ts / deck-rules.ts に散在していたカードシステム定数 (マナ / ドロー /
+//   デッキ構築上限) を、registry 近傍の単一 `CardSystemConfig` に集約し、将来の phase 別
+//   バージョニングを可能にする。**値は一切変更しない (= 挙動完全不変)**。値の再校正・動的化は
+//   S3 以降の別段で扱う。
+//
+// 本ファイルの責務 = **関数を持たない値のみ** (Server→Client 境界を serialize 可能 = client-safe)。
+//   per-card meta を扱う card-spec.ts とは別概念 (system-wide config) のため別ファイルに分離する。
+//   関数を持たないため S2d の ESLint 境界 (src/components/** → card-spec-server import 禁止) には
+//   抵触せず、Client コンポーネントから (definitions/deck-rules 経由で) 安全に参照できる。
+//
+// 後方互換: 旧 definitions.ts / deck-rules.ts の名前付き定数 (MANA_CAP 等) は本ファイルから
+//   re-export することで既存 import を一切壊さない (churn 最小)。値の SSOT は CARD_SYSTEM_CONFIG。
+
+import type { Player } from "@/lib/shogi/types";
+import type { CardRarity } from "./types";
+
+// カードシステム全体の構成定数 (値のみ = client-safe)。将来 phase 別バージョニングの単位。
+export interface CardSystemConfig {
+  mana: {
+    // 先後別の初期マナ (Issue #81 / 2026-05-01 確定)。後手が +1 で先手番有利を緩和。
+    initial: Record<Player, number>;
+    // マナ上限。将来カード効果 (自分UP/相手DOWN) で動的化する想定 (現状は静的)。
+    cap: number;
+    // 1 手番消費するごとのマナ加算。
+    perTurn: number;
+    // 早指し (fastThresholdMs 以内) 時の追加マナ (合計 perTurn + fastBonus)。
+    fastBonus: number;
+    // 早指し判定のしきい値 (ms)。
+    fastThresholdMs: number;
+  };
+  draw: {
+    // 手動ドローのマナコスト (Issue #130 で 3 → 2 に引き下げ。自動ドローと併存させ、手動は
+    //   「自動を待たずに今すぐ引きたい」加速行動と位置づけ直してコストを下げた)。
+    cost: number;
+    // 経過手数による自動ドローの間隔 (Issue #130)。「自分の手番が終わるたびに +1」のカウントが
+    //   本値に到達すると、マナ消費なしで山札から 1 枚引く (駒移動・手動ドロー・カード使用・
+    //   トラップ設置のすべてが「手番終了」としてカウント対象)。
+    autoInterval: number;
+  };
+  deck: {
+    // デッキ合計枚数の上下限 (Issue #89)。
+    totalMax: number;
+    totalMin: number;
+    // レア度別の「デッキ内のそのレア度合計」上限。null は無制限 (合計 totalMax の範囲内)。
+    //   例: epic = 4 → 究極カード (同名/異名問わず合計) が 4 枚を超えてはいけない。
+    rarityMaxPerDeck: Record<CardRarity, number | null>;
+  };
+}
+
+// カードシステム定数の SSOT。**値は S2 着手前と完全一致 (S2e は集約のみ・値不変)**。
+export const CARD_SYSTEM_CONFIG: CardSystemConfig = {
+  mana: {
+    initial: { sente: 2, gote: 3 },
+    cap: 20,
+    perTurn: 1,
+    fastBonus: 1,
+    fastThresholdMs: 3000,
+  },
+  draw: {
+    cost: 2,
+    autoInterval: 5,
+  },
+  deck: {
+    totalMax: 30,
+    totalMin: 1,
+    rarityMaxPerDeck: {
+      common: null,
+      rare: null,
+      super_rare: 10,
+      epic: 4,
+    },
+  },
+};
+
+// ===== 後方互換のフラット名前付き定数 (CARD_SYSTEM_CONFIG からの導出ビュー) =====
+// 既存 consumer (definitions.ts / deck-rules.ts 経由 import) を壊さないため維持する。
+// 値の SSOT は CARD_SYSTEM_CONFIG。新規コードは CARD_SYSTEM_CONFIG を直接参照してよい。
+
+// マナ・早指しの確定値 (Issue #81 / 2026-05-01 確定)。
+export const INITIAL_MANA: Record<Player, number> = CARD_SYSTEM_CONFIG.mana.initial;
+export const MANA_CAP = CARD_SYSTEM_CONFIG.mana.cap;
+export const MANA_PER_TURN = CARD_SYSTEM_CONFIG.mana.perTurn;
+export const MANA_FAST_BONUS = CARD_SYSTEM_CONFIG.mana.fastBonus;
+export const FAST_THRESHOLD_MS = CARD_SYSTEM_CONFIG.mana.fastThresholdMs;
+
+// ドローの確定値 (Issue #130)。
+export const DRAW_COST = CARD_SYSTEM_CONFIG.draw.cost;
+export const AUTO_DRAW_INTERVAL = CARD_SYSTEM_CONFIG.draw.autoInterval;
+
+// デッキ編成上限 (Issue #89)。
+export const DECK_TOTAL_MAX = CARD_SYSTEM_CONFIG.deck.totalMax;
+export const DECK_TOTAL_MIN = CARD_SYSTEM_CONFIG.deck.totalMin;
+export const RARITY_MAX_PER_DECK: Record<CardRarity, number | null> =
+  CARD_SYSTEM_CONFIG.deck.rarityMaxPerDeck;

--- a/src/lib/shogi/cards/deck-rules.ts
+++ b/src/lib/shogi/cards/deck-rules.ts
@@ -5,18 +5,16 @@
 // 編成も不可とする。
 
 import type { CardId, CardRarity } from "./types";
+// デッキ編成上限 (枚数・レア度別) は CardSystemConfig (card-system-config.ts) に集約済 (Issue #235 S2e)。
+// 本ファイル内のバリデーションで使うため import し、既存 import を壊さないため re-export も行う
+// (値の SSOT は CARD_SYSTEM_CONFIG)。
+import {
+  DECK_TOTAL_MAX,
+  DECK_TOTAL_MIN,
+  RARITY_MAX_PER_DECK,
+} from "./card-system-config";
 
-export const DECK_TOTAL_MAX = 30;
-export const DECK_TOTAL_MIN = 1;
-
-// レア度別の「デッキ内のそのレア度合計」上限。null は無制限 (合計 30 枚の範囲内)。
-// 例: epic = 4 → 究極カード(同名/異名問わず合計)が 4 枚を超えてはいけない。
-export const RARITY_MAX_PER_DECK: Record<CardRarity, number | null> = {
-  common: null,
-  rare: null,
-  super_rare: 10,
-  epic: 4,
-};
+export { DECK_TOTAL_MAX, DECK_TOTAL_MIN, RARITY_MAX_PER_DECK };
 
 export interface DeckEntryInput {
   cardId: CardId;

--- a/src/lib/shogi/cards/definitions.ts
+++ b/src/lib/shogi/cards/definitions.ts
@@ -218,26 +218,14 @@ export const CARD_USE_CONDITIONS: Partial<Record<CardId, CardUseCondition>> = {
   // 2手以内回避は自明なので動的判定 (canEscapeCheckWithDoubleMove) は不要。
 };
 
-// マナ・ドローコストの確定値(Issue #81 / 2026-05-01 確定)
-export const INITIAL_MANA: Record<"sente" | "gote", number> = {
-  sente: 2,
-  gote: 3,
-};
-
-// 将来カード効果(自分UP/相手DOWN)で動的化する想定。state 側で保持する初期値として参照する。
-export const MANA_CAP = 20;
-
-// マナを消費して山札からドロー
-// Issue #130 で 3 → 2 に引き下げ。自動ドロー (AUTO_DRAW_INTERVAL) と併存させるため、
-// 手動ドローは「自動を待たずに今すぐ引きたい」加速行動と位置づけ直してコストを下げた。
-export const DRAW_COST = 2;
-
-// 経過手数による自動ドローの間隔 (Issue #130)。
-// 「自分の手番が終わるたびに +1」のカウントが本値に到達すると、マナ消費なしで山札から 1 枚引く。
-// 駒移動・手動ドロー・カード使用・トラップ設置のすべてが「手番終了」としてカウント対象。
-export const AUTO_DRAW_INTERVAL = 5;
-
-// 1ターン消費すると +1、早指し(FAST_THRESHOLD_MS 以内)で +2
-export const MANA_PER_TURN = 1;
-export const MANA_FAST_BONUS = 1; // 早指し時の追加分(合計+2)
-export const FAST_THRESHOLD_MS = 3000;
+// マナ・ドロー・早指しの確定値は CardSystemConfig (card-system-config.ts) に集約済 (Issue #235 S2e)。
+// 既存 import を壊さないため re-export する (値の SSOT・確定経緯は CARD_SYSTEM_CONFIG 側に記載)。
+export {
+  INITIAL_MANA,
+  MANA_CAP,
+  DRAW_COST,
+  AUTO_DRAW_INTERVAL,
+  MANA_PER_TURN,
+  MANA_FAST_BONUS,
+  FAST_THRESHOLD_MS,
+} from "./card-system-config";


### PR DESCRIPTION
## Summary
S2 (L1 カードフレームワーク化) 最終段。マナ/ドロー/デッキ構築上限の散在定数を registry 近傍の単一 `CardSystemConfig` (新規 `card-system-config.ts`) に集約し、将来の phase 別バージョニングを可能にする **値不変の cosmetic refactor**。

- `definitions.ts` はマナ/ドロー 7 定数を純 re-export、`deck-rules.ts` はデッキ 3 定数を import + re-export (既存 import 32 経路を壊さず churn 最小)。
- `DECK_TOTAL_MAX/MIN` も deck セクションへ同梱し凝集性確保 (ユーザー承認)。
- 確定経緯コメント (#81/#130/#89) は card-system-config.ts へ集約保全。
- 派生 (rule 2): 定数移設で stale 化した行番号参照コメント 3 件 (heuristics/digest) を card-system-config 参照へ更新 + 行番号除去。

S2e マージで **S2 (L1 フレームワーク化) 全段完了**。次は S3 (ValueModel 内容依存値付け)。

## Test plan
- [x] npm run lint (0 error / 22 warning は既存・変更ファイル指摘ゼロ)
- [x] npm run typecheck (緑)
- [x] npm run test:ci (**573 passed** = S2d 同数・デグレなし)
- [x] npm run build (緑)
- [x] M2: 独立 adversarial agent で値 byte 等価・re-export 正当・全 consumer 解決・循環なし・型互換・ESLint 境界・mutation 無害の **6 観点発散点ゼロ**

## 相手 CPU の動きへの影響
**なし** — 値 byte 等価のため棋力・カード選択・探索は一切不変 (土台整備の refactor)。

Refs #235