### PR TITLE
#235 S3 ValueModel局面依存化 (全段) + S4設計 + AI 504修正 + 思考表示UX

### DIFF
--- a/docs/plans/issue-235-card-shogi-ai-redesign.md
+++ b/docs/plans/issue-235-card-shogi-ai-redesign.md
@@ -66,7 +66,7 @@
 
 ### L2 — 不完全情報探索エンジン (TurnAction が一級市民)
 - move/draw/playCard を区別しない**単一の探索木**。negamax を `WorldState × TurnAction` に拡張し、αβ/TT/killer/history/LMR/quiescence をカード込みで効かせる (詳細 §6)。
-- leaf 評価 = 盤面評価 (既存 evaluators 7成分) + **ValueModel 集約** (内容・局面依存)。子ノードで digest 更新 (P1/P6/P7 解消)。
+- leaf 評価 = 盤面評価 (既存 evaluators 7成分) + **ValueModel 集約** (内容・局面依存) + **汎用評価拡張基盤 (EvalFeature registry) の拡張寄与** (状態異常 no_promote の per-piece 評価を最初の具体例に、将来要素を宣言的に差し込める。§6 item 7)。子ノードで digest 更新 (P1/P6/P7 解消)。
 - **ビジョン④** を満たす。
 
 ### L3 — 相手モデル/メタ認知 (不完全情報)
@@ -147,6 +147,41 @@ type EffectSpec =
 4. **TT**: zobrist を cardState 込みに拡張 (`hashLo ^ digestHash`、mana/手札カウント/trap/drawProgress を 32-bit ハッシュ化)。同一盤面・異 cardState の誤 hit 解消 (P6)。card-aware ノードは保守的 store。
 5. **爆発抑制** (最重要、critique F4/R5): ノード分岐を **move 上位 M (`scoreMoveForOrdering`) + カード候補 top-K + draw** に selector で絞る。難易度別 maxDepth/budget/M/K で棋力差。深さ予算超過は findBestMove 既定 move へフォールバック (既存 deadline 流用)。**S0 PoC で「±10% を実現する M/K/budget が存在するか」を先に確定** (C-2 実測 budget=3≈130万 evaluate を起点)。
 6. **相手カード**: 既定は相手 move-only (性能安全)。超上級のみ OpponentModel の確率分布で相手 playCard/draw を期待値展開 (S5)。
+7. **汎用評価拡張基盤 (EvalFeature registry、2026-06-10 ユーザー要件追加。3観点 adversarial 検証 (code-fit 事実検証 / 性能・レイヤリング / 将来拡張性ストレステスト) 反映済)**: カード将棋は今後のエンハンスで新要素 (状態異常・新資源・盤面持続効果等) が追加され続ける。**新たな評価基準が出るたびに探索/評価コードを場当たり改修するのではなく、ゲーム要素が触れる接面を標準化し宣言的に差し込める基盤を S4 で構築する**。最初の具体例 = 状態異常 `no_promote` (成り無効化マーク: 取られる/駒戻し系で手駒復帰しない限り**永久に成れない**) の移行。
+
+   **7.1 現状の確認済みギャップ (2026-06-10、全件実コード file:line で confirmed)**:
+   - 探索木 (negamax `search.ts:323` / quiescence `search.ts:236`) は `GameState` のみ伝播 (`applyMoveForSearch` は盤+持ち駒のみ)。cardDigest は root スカラー定数 (W-1) → **リーフに「この駒は成れない」情報が物理的に届かない**。
+   - リーフ評価が満額評価: マーク駒も `PIECE_VALUES` 満額 (`material.ts:39-49`)、自分が封じた相手大駒も満額の成り脅威 (`promotion-threat.ts:23-65` のファントム脅威、rook=150 等)。
+   - **符号逆バグ**: `move-effects.ts:127` はマークを**封じられた被害者本人**の配列に積む (`noPromoteMarks[p]` = p 自身の成れない駒) のに、`digest.ts:135-137` は「自マーク多=有利」と +30cp/個 加算 = **自駒が封じられるほど AI が有利と誤評価** (#193 PR1d-4 由来)。
+   - **幻の成り手 (事実確定)**: 着手生成3面 (`moves.ts` 幾何生成 / `legal-moves.ts:25-31` 透過 wrap / `captureGen.ts` 独自生成) + `applyMoveForSearch` の無条件成り適用 + 手順序付けの成り優遇 (`scoreMove` +50000 / `scoreMoveForOrdering` +200) が**全て mark-blind** → AI はマーク駒の幻の成り (と金 +500cp 級) を探索内で満額で読み、root 採用後に `move-effects.ts:88-90` の silent block (promote:false 矯正) で**読み筋と実盤面が乖離**する。
+   - 派生: **armed (未発動) no_promote トラップ越しの成り**も探索は無視 (成り矯正+マーク付与+トラップ消費が読みに入らない)。
+   - **UI/kernel のルール意味論分裂 (新発見)**: マーク駒の mustPromote マス (歩香の最奥段等) 進入は、UI (`reducer.ts:400` フィルタ) では選択不可・kernel (silent block) では不成進入 = 行き所のない駒、と挙動が割れている → **§11 D-I (ユーザー判断)**。
+
+   **7.2 基盤設計 = 5接面の標準化** (新ゲーム要素はこの5接面に触れる。各接面に宣言点を1つずつ用意し、漏れを型+テストで強制検出):
+   - **(i) 状態表現 (L0)**: 状態 slice を WorldState (`CardGameState`) に追加 (既存パターン、例 noPromoteMarks)。
+   - **(ii) 状態伝播 + TT fold (L0/L2)**: S4 の WorldState 搬送探索に乗せ、**TT fold ポリシーを slice ごとに型強制で宣言**: `Record<keyof CardGameState, "fold" | "evalIrrelevant">` — 新 slice を追加すると fold 方針を書くまでコンパイルが落ちる (宣言忘れ = silent TT 誤ヒット、を型レベルで排除。「全 slice が fold or 宣言済除外」unit test も DoD)。fold 実装 = **slice 参照変化検知 + slice fold 全量再計算** (updateCardDigest パターン流用、各 slice O(small)。純 XOR 差分宣言より堅牢)。mana/drawProgress は毎 ply 変化する path-length 関数のため明示 excluded 可 (fold すると異深度 transposition が全滅し正確性向上は僅少)。マーク/トラップ/doubleMove は合法手・評価を実際に変えるため fold 必須。hand fold は **defId 多重集合**で正規化 (instanceId 混入は等価局面の transpose を永久に殺す)。**check_break 発火等「move 以外の盤面変更」ノードは incremental updateHash でなく盤面 hash 全量再計算でゲート** (kernel 戻り値 `triggeredCheckBreak` 等で検知。カード/発火ノードは稀でコスト許容 — これを欠くと incremental hash が silent に狂い TT が汚染される)。
+   - **(iii) 行動生成 (二分 — 解決層を明確に分離)**:
+     - ① **合法性制約 (L0)**: 「指せない」を変える状態異常 (将来の凍結系等) は WorldState-aware な着手生成 (L0 単一 predicate) に実装し、**kernel 終局判定・reducer/UI・AI 探索の三者が同一関数を共有** (三重実装分裂の構造的防止。探索内詰み判定と実ルールの乖離も防ぐ)。no_promote の成り可否 predicate もここに置き、UI フィルタ (`reducer.ts:400`) と統一。
+     - ② **探索内 transform (L2)**: no_promote の幻成り対策。生成3面 (root `getLegalActions` / `getSearchLegalMoves` / `captureGen` 2関数) で「マーク駒の promote:true → **promote:false 置換** + 既存不成変種と重複時 drop」。**除去ではない** (mustPromote マスで「探索: 移動不可 / 実盤面: 不成で可能」の逆乖離が生じるため)。生成段置換なら手順序付けの幻成り優遇も自動是正される (後段フィルタ方式は順序付けに幻成りが残るため不採用)。
+     - **armed トラップ越しの成りは①②の対象外**: 違法ではなく「結果が異なる」手 (トラップを意図的に消費させる価値すらある) → (ii) の WorldState×`makeMoveWithEffects` 遷移が捕捉する。
+   - **(iv) 評価寄与 (L2 リーフ、3寄与型を単一 registry で合成)**:
+     1. **per-piece modifier (状態異常型)**: 駒単位の価値/脅威修正。no_promote = マーク駒の成り上昇分 (`value(promotesTo) − value(type)`) 減価 + 相手マーク駒の成り脅威割引 (ファントム脅威除去)。実装は `computeMaterial` / `evaluatePromotionThreats` への引数追加 (debug 用 `evaluateWithBreakdown` と構造共有し転記2箇所を作らない)。**リーフ毎 Set 構築は禁止**: マーク空なら fast path コストゼロ (現状ほぼ常時)、非空時のみ slice 参照変化で lookup 再構築しノード帯同、マーク≦2 は O(m) インライン比較で割当ゼロ。quiescence 内のマーク追従は from/to 一致時のみ O(m) 追従、または stale 許容を明文化+テスト pin (曖昧にしない)。
+     2. **global scalar (資源・経済型)**: mana/手札/drawProgress 等。**既存 CardDigest = この型のランタイムキャッシュとして一本化** (item 3「子ノードで digest 更新」は registry 駆動 `updateCardDigest` として実装、**二重機構を作らない**)。per-node 割当は per-ply 事前確保バッファで回避 (毎ノード新オブジェクトは ~100万割当/手で GC 負荷)。**`noPromoteMarkCountDelta` フィールド + `NO_PROMOTE_MARK_COEFFICIENT` は per-piece modifier 移行と同時に完全削除** (符号バグはフィールドごと消滅 = ユーザー決定の吸収方針。残すと二重計上)。
+     3. **option value (盤上持続オブジェクト型)**: トラップ option value (S3 valueModel = この型として接続済)。
+     - **リーフはデータ駆動** (新規関数呼び出しゼロ: digest スカラー加算 + nullable lookup 参照のみ)。registry の間接呼び出しは root セットアップ/slice 遷移時に限定 = JIT/inline 阻害を構造的に排除。
+   - **(v) lifecycle (L0)**: 状態の付与・追従・消滅・時限を宣言化: `{ attachedTo: "piece"|"square"|"player", onPieceMoved: "follow"|"stay", onPieceCaptured: "remove"|"stay", onTurnEnd?: "tick"|null }`。kernel は `makeMoveWithEffects`/`applyTurnAction` の固定点で全 slice の宣言を一括実行。**現行 no_promote のインライン (move-effects.ts:109-127 の follow/capture-cleanup) を最初の移行例**とする。時限効果 (Nターンで消滅)・マス付着効果 (駒に追従しない) はこの接面で吸収 (ECS から借りるのはこの宣言型 lifecycle のみ。フル ECS 化は immutable spread + JSON serialize + イベント駆動 undo の現アーキと相性が悪く不採用)。
+
+   **7.3 L1 接続 (CardSpec 宣言スロット)**: CardSpec に `statusEffect` (**意味論のみ**宣言、例 `{ kind: "no_promote", blocksPromotion: true }`) + `validTargets?: (world: CardWorldView, player) => CardTarget[]` (状態異常解除カード (#82 実在候補) 等「cardState を見るターゲット列挙」対応 — 現 `isValidCardTargetSquare` は GameState 止まりで宣言だけでは差し込めない) を追加。**cp 係数は ai 側 registry に置く** (L1 に cp を書くと cards→ai 逆流 or 駒価値テーブル4重化 [material/moves/ORDER_PIECE_VALUES に既に3つ]。S3 D-KS=C「cards は moves/variants プリミティブのみ」を維持)。シグネチャは `CardWorldView` ベース (型循環回避 D1-1 踏襲)、S2d ESLint client 境界の対象に新スロットも含める。
+
+   **7.4 基盤が買うもの (正直な2階層定義 — オーバープロミス防止)**:
+   - **(A) 既存 status 概念を再利用する新カード** = spec 宣言のみで (i)〜(v) 自動追従 (例: 別の駒/条件で no_promote を付与する新カード)。
+   - **(B) 新しい status 概念の導入** = slice/lifecycle/fold/eval/targeting/selector の **6点は実装が必要**。基盤の価値は「コードゼロ」ではなく「**接面の宣言漏れを型 (fold 強制 Record・exhaustive check) とテストで構造的にゼロにする**」こと。(B) の6点チェックリストは S4 完了時に AGENTS.md「新規カード追加時のチェックリスト」へ反映。
+   - **スコープ外 (v1 明示)**: 駒の利き/動きを変える movement 系 status は registry v1 対象外 (movement 前提が moves/captureGen/攻撃判定/評価に全域分散。`resolveEffectivePieceDef(piece, statusMarks)` 解決層の新設 = 別 epic 規模。導入時は §11 に新規判断事項として起票)。
+   - 将来要素ストレステスト済: 状態異常解除カード=(iv)1+7.3 validTargets / 凍結系=(iii)① / 駒強化バフ=価値は(iv)1・movement はスコープ外宣言 / マス付着オーラ=(v) attachedTo:"square" / 動的マナ上限=(iv)2+下記負債③④ / 時限効果=(v) onTurnEnd:"tick"。
+
+   **7.5 同時精算する既知負債 (S4 スコープ)**: ① `noPromoteMarkCountDelta` 符号逆バグ (フィールド削除で消滅) ② 幻の成り手 (7.1、(iii)②で解消) ③ `digest.manaCap` が cardState 非参照で定数 `MANA_CAP` 焼き込み (`digest.ts:82` — 動的マナ上限構想の前提是正。現行値では挙動不変) ④ `DEAD_MANA_THRESHOLD=16` の cap 比率化 (cap×0.8、cap 変動時の誤発火防止) ⑤ `world-kernel.ts:49` の TurnAction 型 ai/ import (L0→L2 型逆依存) を kernel/中立 types へ昇格 ⑥ top-K selector とセンチネル0価値カードの接続規約 (「探索で価値が創発する」解除カード等が候補選別で飢餓しない — per-piece modifier 定義から復元価値を O(marks) で機械算出し選別上界に使う)。
+
+   **7.6 性能ゲート**: depthCompleted ±10% (§12) に加え、S4 bench に **nodes/s・TT hit-rate カウンタ**を追加 (退行時に fold 起因か eval 起因かを切り分け可能にする)。
 
 ### 移行戦略 (critique R9, F6)
 一気に置換せず: (a) card-shogi 専用 TurnAction-negamax を既存 move-only negamax と**並走** (standard は触らない) → (b) bench で depthCompleted/棋力を旧経路と比較 → (c) 優位確認後に engine root 統合切替。standard は当面既存 negamax 温存 (二重保守期限は §11 D-B)。
@@ -163,7 +198,7 @@ type EffectSpec =
 | **S1** | refactor | L0 状態/ルールカーネル統合 | `WorldState`+`applyTurnAction` 新設、reducer/AI がカーネル委譲。reducer.test/undo-policy.test/effects.test 不変 (property-based 等価)。standard byte-level 不変 |
 | **S2** | refactor+feature | L1 カードフレームワーク化 | `CardSpec` registry + EffectSpec。既存7カード移植 (legacy wrapper 経由の段階移行可)。CardId codegen。effects/reducer分岐/undo を registry 駆動 |
 | **S3** | feature | L1 内容依存値付け | ValueModel でカードを局面・コスト依存に。固定係数 (TRAP_VALUE_* 等) 脱却。digest は集約キャッシュへ。bench で旧評価比較・校正 |
-| **S4** | feature | L2 TurnAction 単一探索 + TT 拡張 **(最重要)** | card-shogi 専用 TurnAction-negamax (standard 温存)。zobrist cardState 拡張・誤hit対策。selector(M/K/budget)。double_move 木統合。**S4a で実エンジンに selector を載せ M/K 再校正 → before-baseline 比 depthCompleted ±10%** (PoC-1 は same-engine 比で枝刈り余地を確認済、production 絶対比は S4a 実測) + カード使用率改善 |
+| **S4** | feature | L2 TurnAction 単一探索 + TT 拡張 + **汎用評価拡張基盤** **(最重要)** | card-shogi 専用 TurnAction-negamax (standard 温存)。zobrist cardState 拡張・誤hit対策 (fold 型強制)。selector(M/K/budget)。double_move 木統合。**EvalFeature registry (§6 item 7: 5接面標準化 + 状態異常 no_promote per-piece 評価を最初の具体例に + 符号バグ/幻成り/既知負債6件の同時精算、2026-06-10 ユーザー要件)**。**S4a で実エンジンに selector を載せ M/K 再校正 → before-baseline 比 depthCompleted ±10%** (PoC-1 は same-engine 比で枝刈り余地を確認済、production 絶対比は S4a 実測) + カード使用率改善 |
 | **S5** | feature | L3 相手モデル/期待値読み (超上級) | OpponentModel (ベイズ残り手札)。eventLog 伝播+永続化。相手ノード確率分岐+閾値枝刈り。超上級のみ。フェアネス (手札非透視) を test 固定。**依存 (blocking): eventLog 永続化は #193 PR1e の DB schema と協調が前提 → S5 着手条件に PR1e completion を明記** |
 | **S6** | chore+feature | 仕上げ・新カード運用確立 | テンプレ化された追加フロー (AGENTS.md 更新)。phase 別レアリティ上限 config 化。exhaustive fixture。Phase A カードを新フローで1枚追加し工数・品質実証 |
 
@@ -345,6 +380,7 @@ L0 統合 (reducer/AI が単一カーネル `applyTurnAction` に委譲) は最�
 | **D-F** | レアリティ上限バージョニング | `CardSystemConfig` の config で runtime 切替 (DB schema 不変) を既定。頻繁な試験変更に強い |
 | **D-G** | 移行のリスク許容度 | big-bang 不可。S0-S6 段階 + 各段 DoD (depthCompleted ±10%, カード使用率目標) を PoC 結果で確定 |
 | **D-H** | フェアネス是正の時期 | S1-S2 中間で「相手手札を探索入力から早期遮断」を推奨。移行設計: (1) `anonymizeOpponentHand()` で探索入力から相手手札中身を除去 + 「AI が相手手札中身を入力に使わない」を assert する test fixture を先に作成、(2) 現評価の `handValueDelta` 等が相手手札枚数に依存する箇所を「公開情報 (枚数は可視) のみ」に整理し透視前提を段階的に剥がす |
+| **D-I** | no_promote マーク駒の mustPromote マス進入のルール正解 (2026-06-10 発見、§6 item 7.1) | 現状 **UI と kernel で意味論が分裂**: UI (`reducer.ts:400` フィルタ) = 進入不可 (マーク歩の最奥段行きは唯一の生成手 promote:true がフィルタされ選択不能)、kernel (`move-effects.ts:88-90` silent block) = 不成進入 = **行き所のない駒**が成立。**推奨 = (a) 進入自体を非合法化** (本将棋の「行き所のない駒」原則と整合し UI 現挙動を正とする。kernel/着手生成も WorldState-aware predicate (§6 7.2 (iii)①) で統一)。代替 (b) = 不成進入許容 (kernel 現挙動を正とし UI フィルタを緩める)。S4 (iii) 実装前にユーザー確認 |
 
 ---
 

--- a/docs/plans/issue-235-s3-valuemodel.md
+++ b/docs/plans/issue-235-s3-valuemodel.md
@@ -89,15 +89,15 @@ S1/S2 同様、低リスクな additive → cutover の順:
 - S3c は係数調整 (値のみ) のため revert は値の差し戻し。
 
 ## 8. S3 DoD
-- [ ] D-NP 確定 (§9、check_break 1枚 or 両トラップ + 相手成り脅威指標)。
-- [ ] D-KS=C で card-spec-server が自前 king-exposure を持ち、`cards/ → ai/` 上向き依存を作らない。
-- [ ] 対象トラップの valueModel を局面依存実装 + 特性化テスト (局面で変動を pin、PoC-2 カーブ再現)。
-- [ ] `computeCardDigest`/`updateCardDigest` に gameState 供給 + トラップ項 `trapValueDelta` 化。`evaluateAction` 直接加算も valueModel 経由へ統一 (2系統解消)。`CARD_VALUE_BRIDGE` トラップ二重定義解消。
-- [ ] PoC-2 仮係数を bench 校正・確定。決定的 unit test で相対順序 + 安全玉↔露出玉ペアを pin。
-- [ ] 棋力退化なし (depthCompleted ±10% + phase別カード使用率) を bench 実証。
-- [ ] 未使用係数 (CHECK_BREAK_TRIGGER_THRESHOLD 等) が S3 完了時も未使用なら削除。盤面系 valueModel=0 のセンチネル意味をコメント明示。
-- [ ] 各段 lint / typecheck / test:ci / build green。段階順序 S3a → S3b → S3c (S3b が単一 revert 主点)。
-- [ ] 盤面系カード / digest 集約キャッシュ / trap onTrigger は S4 / 別サブタスクへ申し送り (非ゴール明記)。
+- [x] D-NP 確定 (§9、check_break 1枚 or 両トラップ + 相手成り脅威指標)。→ 両トラップ + 相手成り脅威指標 (選択肢 B、§9 D-NP)。
+- [x] D-KS=C で card-spec-server が自前 king-exposure を持ち、`cards/ → ai/` 上向き依存を作らない。→ S3a で `moves`/`variants` プリミティブ自前計算 (§10)。
+- [x] 対象トラップの valueModel を局面依存実装 + 特性化テスト (局面で変動を pin、PoC-2 カーブ再現)。→ S3a (§10)。
+- [x] `computeCardDigest`/`updateCardDigest` に gameState 供給 + トラップ項 `trapValueDelta` 化。`evaluateAction` 直接加算も valueModel 経由へ統一 (2系統解消)。`CARD_VALUE_BRIDGE` トラップ二重定義解消。→ S3b (§11)。
+- [x] PoC-2 仮係数を bench 校正・確定。決定的 unit test で相対順序 + 安全玉↔露出玉ペアを pin。→ S3c (§12、TRAP_P_MIN 0.05→0.10 確定、決定的テスト3件)。
+- [x] 棋力退化なし (depthCompleted ±10% + phase別カード使用率) を bench 実証。→ S3c (§12、全難易度 depthCompleted 0.0% 変化、card% beginner/intermediate 86%→100%)。
+- [x] 未使用係数 (CHECK_BREAK_TRIGGER_THRESHOLD 等) が S3 完了時も未使用なら削除。盤面系 valueModel=0 のセンチネル意味をコメント明示。→ S3c で `CHECK_BREAK_TRIGGER_THRESHOLD`/`MIN_MANA_RESERVE_FOR_TRAP` 削除 (§12)。盤面系=0 センチネルは S3a/S3b でコメント明示済。
+- [x] 各段 lint / typecheck / test:ci / build green。段階順序 S3a → S3b → S3c (S3b が単一 revert 主点)。→ 全段 green、順序遵守 (§10/§11/§12)。
+- [x] 盤面系カード / digest 集約キャッシュ / trap onTrigger は S4 / 別サブタスクへ申し送り (非ゴール明記)。→ §12 S4 申し送り。
 
 ## 9. M1 マイルストーン1レビュー反映 (策定直後、2026-06-10、AGENTS.md ルール8)
 独立 adversarial agent (general-purpose、実コード精読) でレビュー。**総合判定: 当初版は high 2件で要修正 → 本版で反映済**。骨子 (段階分割・rollback・非ゴール線引き・検証ゲート) は妥当と確認。
@@ -173,3 +173,56 @@ S3b = トラップ評価を固定係数 (TRAP_VALUE_*) から局面依存 valueM
 
 ### S3c への申し送り
 - PoC-2 仮係数 (TRAP_P_MIN/MAX / E_DAMAGE / KING_EXPOSURE_REF / PROMO_THREAT_REF 等) を bench 校正し本採用値を確定。安全玉↔露出玉ペアの決定的 unit test (§6 M-2) を追加。phase別カード使用率で 57% 非対称の改善傾向を測定。未使用係数の最終確認。
+
+## 12. S3c M2 マイルストーンレビュー (校正実装後、2026-06-10、AGENTS.md ルール8) — **S3 全段完了**
+
+S3c = PoC-2 仮係数を bench + 決定的 unit test で校正し**本採用値を確定**する段。S3b で局面依存化したトラップ valueModel の係数を実測ベースで仕上げ、未使用係数を整理する。**S3c 完了をもって S3 (L1 ValueModel 内容依存値付け) 全段完了**。
+
+### 変更 (4 ファイル、working-tree)
+- `card-spec-server.ts`: `TRAP_P_MIN` **0.05 → 0.10**。コメントブロックを「PoC-2 仮値 → S3c 本採用値」へ更新し校正根拠を明記。他係数 (TRAP_P_MAX=0.9 / CHECK_BREAK_E_DAMAGE=300 / NO_PROMOTE_E_DAMAGE=160 / KING_EXPOSURE_REF=6 / KING_IN_CHECK_WEIGHT=3 / PROMO_THREAT_REF=6 / PROMO_PROXIMITY_MAX=3) は PoC-2 + S3b ユーザー承認値のまま据置。
+- `card-spec.test.ts`: floor リテラル更新。check_break `P_MIN_VAL = 0.1×300 = 30`、no_promote `P_MIN_VAL = 0.1×160 = 16`。P_MAX 側 (0.9×) は不変。
+- `evaluate-action.test.ts`: 決定的テスト 3 件追加 (新 describe「evaluateAction calibration (S3c…)」)。noise なし `evaluateActionWithLookahead`/`evaluateAction` を直接呼び相対順序を pin (C-13 / §6 方式)。
+- `heuristics.ts`: デッドコード `MIN_MANA_RESERVE_FOR_TRAP` / `CHECK_BREAK_TRIGGER_THRESHOLD` を削除 (§5 L-2、しきい値方式トラップ候補生成は連続値 valueModel 採用で不採用に。実参照ゼロ)。`EARLY_GAME_THRESHOLD` は `computePhaseStage` で現用のため保持。
+
+### 校正の判断と根拠
+- **TRAP_P_MIN 0.05 → 0.10**: PoC-2 仮値 0.05 は「set 済の dormant トラップが**生涯で** trigger する確率」を過小評価していた。王手・成りは 1 局を通じて高頻度で発生するため、置いたトラップの将来発火確率は 5% より明らかに高い。0.10 への引き上げで:
+  - **floor**: check_break 15→30cp / no_promote 8→16cp。
+  - 「静かな盤面 + dead マナ (上限近接、overflow あり) → dormant トラップ set」が**正 EV** になる (浪費されるはずのマナを option value に変換する好手)。
+  - 「静かな盤面 + 通常マナ → move」は維持 (P_MIN<0.127 で過剰セットを抑止)。
+  - 危険局面 (露出玉 / 相手成り脅威) は ratio が P_MAX 側へ押し上げるため**挙動不変**。
+- **他係数据置の根拠**: PoC-2 実測カーブ (check_break 安全玉 -25 ↔ 露出玉 +230) + S3b 時点でユーザー承認済の正規化基準。bench で depthCompleted 退化なしを確認できたため再校正不要と判断。
+
+### 決定的テスト 3 件 (回帰ガード)
+1. **no_promote flip**: 相手成り脅威ありで trap > move、脅威なしで move > trap (局面依存が機能)。
+2. **check_break 露出 isolation** (ply=0): `(trap−draw)_露出玉 > (trap−draw)_安全玉`。getDrawValue が両局面同値で相殺され、valueModel 差 (270−30=240cp) が決定に伝播することを pin (盤面 eval は共通成分で打ち消し)。
+3. **check_break dead マナ dormant flip** (S3c 校正の核): dead マナ (19、overflow 3) → trap > move / 通常マナ (8) → move > trap。**P_MIN=0.05 では flip しない**ことをミューテーション検証で実証 (M2 で `TRAP_P_MIN=0.05` に戻すと `expected 10.03 to be greater than 21` で FAIL) = 本テストが校正の真の回帰ガード。
+- check_break は `checkUsage="forbidden"` (王手中使用不可) のため、本来の使い所は**予防的 dormant セット**。露出玉局面では「玉を安全マスへ逃がす能動防御 move」が trap に勝つのが正 (テストコメントに明記)。
+
+### bench 実測 (before P_MIN=0.05 → after 0.10、3-run median、全 4 難易度)
+| 難易度 | depthCompleted (B→A) | Δ% | card% (B→A) |
+|---|---|---|---|
+| beginner | 3 → 3 | **0.0%** | 86% → **100%** |
+| intermediate | 5.33 → 5.33 | **0.0%** | 86% → **100%** |
+| advanced | 5.78 → 5.78 | **0.0%** | 57% → 57% |
+| expert | 6 → 6 | **0.0%** | 57% → 57% |
+- **depthCompleted 全難易度 0.0% 変化 = 棋力退化なし** (DoD ±10% に余裕)。
+- **校正に測定可能な効果**: `calib-trap-only-no-draw` (no_promote, mana19) が beginner で before 全3run=move → after 全3run=**trap(no_promote)** に一貫 flip (floor 8→16cp + dead マナ回収で dormant トラップが競争力獲得=狙い通り)。intermediate も安定化。
+- **advanced/expert 57% 不変**: 深く読み best move > dormant trap となるため P1 深さ非対称が支配的 (S4 マター)。S3 単独では構造的に直らない (epic §8.4.5 caveat / §12 想定通り)。
+
+### 検証実測
+- lint **0 errors / 22 warnings** (S3b baseline 維持、純増ゼロ) / typecheck 緑 / test:ci **583 passed | 12 skipped** (S3b 580 + 新規3、既存不変=デグレなし) / build 緑。
+- bench (standalone tsx `measure-baseline-235.ts 3`、RUN_PERF_BENCH 経路): 上表のとおり。
+
+### 挙動変化 (意図的)
+- **dormant トラップの set 判断が局面適応的に**: dead マナ局面で予防的トラップセットを選好し、通常マナでは move を維持。advanced/expert の使い渋り (57%) は P1 深さ非対称が主因のため S3 単独では不変 (S4 で是正)。
+- UI / ゲームルール / standard variant = 不変。
+
+### 総合判定
+**S3c は commit/push 可 (high/medium 指摘ゼロ)**。独立 adversarial agent (general-purpose、約 39 tool uses、ミューテーションテスト + 手計算 × 実測突合 + grep 全消費者洗い出し併用) で以下を確認:
+- 符号正 (digest sente+/gote−、search ply=0 整合) / 二重計上なし (manaDelta でコスト 1 回・trapValueDelta で gross 1 回、P_MIN は会計に非干渉) / floor 算術正 (30 / 16、P_MAX 270 / 144 不変、clamp 健全) / 全 consumer 整合 (getCardValue 一本に集約、stale 旧 floor リテラル皆無) / デッドコード除去妥当 (削除2定数は参照ゼロ、EARLY_GAME_THRESHOLD は現用) / テスト非 vacuous (ミューテーションで test3 FAIL を実証) / 棋力退化なし (P_MIN は探索深度に非干渉な評価スカラー) / UI・UX 該当なし (変更は `src/lib/shogi/` のみ、components/hooks 非波及) / NaN・負値・異常値の発生経路なし (玉不在・手札ゼロ・マナ上限ちょうど等エッジ網羅)。
+- 指摘は low 1件 (test1/test2 は P_MIN を pin しない=S3a/S3b の局面依存性ガードであり、コメントで「2点で pin」と既に正確に説明済 → 修正不要)。
+
+### S4 (L2 TurnAction 単一探索 + TT 拡張) への申し送り
+- **57% 非対称の主因 P1 (深さ非対称)** は S3 では構造的に解消できない。S4 で TurnAction を単一探索木に統合し TT を拡張することが本丸 (epic §7、最大の山場)。
+- トラップ valueModel の係数は S3c で本採用確定。S4 で探索構造が変わっても valueModel は SSOT として再利用 (gross 値・root スカラー方式 W-1 を維持)。
+- 盤面系カード valueModel (現 0 センチネル) の精緻化 / digest 集約キャッシュ / trap onTrigger イベントモデルは引き続き非ゴール (S4 以降 / 別サブタスク)。

--- a/docs/plans/issue-235-s3-valuemodel.md
+++ b/docs/plans/issue-235-s3-valuemodel.md
@@ -1,0 +1,118 @@
+# Issue #235 S3: L1 ValueModel 内容依存値付け — 実装計画
+
+> 親 doc (epic SSOT): `docs/plans/issue-235-card-shogi-ai-redesign.md` (§3 L1/L2 / §4 ValueModel / §7 S3 / §8.4.5 PoC-2 caveat / §9 PR3 引き継ぎ / §12 棋力ゲート / §13 F-001 用語注意)。
+> 前段: S2 (L1 CardSpec registry) 完了・PR #237〜#241 マージ済 (main `e955d47`)。S2 完了定義: `issue-235-s2-cardspec.md §8/§14`。
+> ブランチ `feature/#235-s3` (origin/main 起点)。本 doc は AGENTS.md ルール8 マイルストーン1 (実装着手前レビュー) の対象。
+> スコープ: ユーザー承認の **「絞込型」** (2026-06-10)。**M1 adversarial レビュー反映済 (§9)**。
+
+## 0. 位置づけ・ゴール / 非ゴール
+S3 = L1 ValueModel の内容依存値付け。**S0〜S2 は全て挙動不変の土台整備だったが、S3 は CPU の棋力 (カード選択) を実際に変える最初の段**。現状トラップ2枚の価値が固定係数 (`TRAP_VALUE_CHECK_BREAK=80` / `TRAP_VALUE_NO_PROMOTE=50`) で局面非依存。これを局面依存の ValueModel へ置換する。
+
+**ゴール (絞込型、epic §7 S3 行)**:
+1. **トラップの ValueModel を局面依存化**: PoC-2 実証済の `P_trigger × E_damage` モデルを `card-spec-server.ts` の valueModel に実装し、固定係数 `TRAP_VALUE_*` を脱却する。**対象カードは §9 D-NP の決定に従う** (check_break は確定、no_promote は指標問題があり要決定)。
+2. **依存反転 (valueModel を SSOT 化)**: AI のトラップ評価を静的 `TRAP_VALUE_*` / `CARD_VALUE_BRIDGE` 参照から `spec.valueModel(...)` 経由へ cutover。`cards/ → ai/` 上向き二重定義 (S2 で温存) を解消。
+3. **bench 校正**: PoC-2 仮係数 (E_damage / P_min / P_max / SAFETY_*) を bench + 決定的 unit test で本採用値に確定。棋力退化なし (§12 多面指標) を実証する。
+
+**非ゴール (S3 では触らない、絞込型で確定)**:
+- **盤面系カード (pawn_return / piece_return / double_pawn / double_move) のコスト依存値付け**: 現状 `CARD_VALUE_BRIDGE` で 0 値、盤面 eval / super-action 探索が間接捕捉。S4 (L2 単一探索) で自然吸収するため S3 では現状維持 (valueModel=0 は「別経路で捕捉=ここでは加算しない」のセンチネル、§5 L-3)。
+- **digest 集約キャッシュ化** (epic §7): L2 探索木の子ノード digest 更新と密結合のため S4 へ。S3 は root per-action 経路 (`evaluateActionWithLookahead`) の現構造を維持。
+- **trap onTrigger の registry 配線** (S2 R-1 `@deferred` stub): 効果適用 (capturedPieces 返却) の話で valuation とは別概念。S3 valuation には不要。別サブタスク (effect 完成) として分離・申し送り。
+- **深い探索内のカード読み**: PR3-3-2 深掘りは逆効果 (advanced/expert 57%→0%) で **park 済 (epic §11 D-A)**。S3 は root 経路のみ、深掘り方向に進まない。
+- **ValueModel 第3引数 `opp?`** (epic §4): 相手モデル = S5。
+- L2 単一探索/TT = S4、L3 相手モデル = S5、新カード運用 = S6。
+
+## 1. 挙動変化の整理 (S3 は意図的に棋力を変える)
+S0〜S2 と異なり **S3b/c は意図的にカード価値評価を変える** (棋力向上狙い)。
+- **UI / ゲームルール = 不変**: valueModel は AI 探索専用。reducer / world-kernel / ルール判定には非関与 (これらは effect.apply / useCondition を使うが valueModel は読まない)。
+- **AI のカード選択 = 変わる**: トラップの価値が局面依存になり、安全玉では低く (使い渋り)、自玉露出時は高く (積極使用) 評価される。狙い = advanced/expert の構造的なカード使い渋り (57%) の一因である **P2 (価値スカラー圧縮)** を緩和する。
+- **棋力ゲート (§6)**: depthCompleted ±10% + phase別カード使用率 + 決定的 unit test の相対順序。**「局面依存になった ≠ 棋力向上」** (epic §8.4.5 caveat 3) を踏まえ bench で別途実証する。
+
+## 2. ValueModel スキーマ・呼び出し点 (S2 枠からの確定、M1 反映)
+- S2 現状: `valueModel: (gameState: GameState, player: Player) => number` (静的 stub = `staticValueModel`、引数 void)。
+- **S3 (絞込型): シグネチャ維持** `(gameState, player) => number`。
+  - 理由: トラップ king-exposure モデルは `gameState.board` のみ必要 (cardState / mana 不要)。cost は `spec.meta.cost` で別途扱い、AI 側 mana 会計 (`applyActionForLookahead`) が既に反映するため valueModel はコストを引かない (gross 値を返す、§5 R-1 で二重計上回避)。epic §4 の `opp?` は S5、cardState 拡張は必要時に後段。最小シグネチャ churn。
+  - valueModel は **gross なカード効果価値 (cp、player 視点の正値)** を返す。sente 絶対視点への符号付け (sente trap = +, gote trap = -) は **AI 呼び出し側 (digest 計算)** で行う。
+- **呼び出し点 (M1 H-1/H-2 反映、最重要)**: 現 production のトラップ価値は `digest.trapPresence` (defId) を `evaluateTrapPresence` が `TRAP_VALUE_*` 固定値へ変換する間接経路。**digest は GameState を保持しないため、局面依存 valueModel を効かせるには digest 計算へ GameState を供給する**。S3b では `computeCardDigest` / `updateCardDigest` に **gameState を引数追加** し、トラップ項を `trapPresence` (defId) → **valueModel で算出した cp 値 `trapValueDelta`** へ置換する (§3 S3b、approach (i))。これにより「**既設トラップの持続価値も局面依存で保たれる**」(approach (ii) の「set 時1回加算+digest除去」は持続価値を失うため不採用、§9 H-1)。
+
+## 3. 段階分割 (S3a〜S3c、additive→cutover、M1 反映)
+S1/S2 同様、低リスクな additive → cutover の順:
+- **S3a (additive、production 未配線)**:
+  - **D-KS = C 確定 (§9)**: card-spec-server が `lib/shogi/moves` プリミティブ (`findKing` / `isSquareAttackedByFast` 等) で **自前の軽量 king-exposure 指標**を計算する (ai/ への上向き依存を作らない。`cards/ → moves` は `cards/effects.ts` で既に確立済の正方向依存)。
+  - `card-spec-server.ts` の check_break valueModel を PoC-2 モデル (`P_trigger(自玉露出度) × E_damage`) で実装。no_promote は §9 D-NP の決定に従う (相手成り脅威指標を実装 or S4 送り)。mana_up (deprecated) / 盤面系4枚は現状値 (0 / 静的) 維持。
+  - 特性化テスト: valueModel が局面で変動すること (安全玉 → 低 / 露出玉 → 高、PoC-2 カーブ -25↔+230 を自前指標で再現) を pin。`card-spec.test.ts` の **静的 stub テスト 2 ブロック (現 514-537 の snapshot + 532-540 の入力非依存、§9 M-4)** を局面依存版へ更新。
+  - **AI は旧 `TRAP_VALUE_*` のまま = 挙動完全不変** (additive)。
+- **S3b (cutover + 依存反転、M1 H-1/H-2 反映で再設計)**:
+  - `computeCardDigest` / `updateCardDigest` に **gameState を供給**し、CardDigest のトラップ項を `trapPresence`→`trapValueDelta` (valueModel 算出 cp、sente 絶対視点) へ置換。`evaluateTrapPresence` (digest.ts) は `trapValueDelta` をそのまま返す薄い関数へ。
+  - **`evaluateAction` (lookaheadPly=0、`search.ts:784-791`) の直接 `TRAP_VALUE_*` 加算経路も同時に valueModel 経由へ統一** (§9 M-1 棚卸し補完。2系統ドリフト防止)。
+  - `CARD_VALUE_BRIDGE` のトラップ分の二重定義を解消 (valueModel が SSOT、`cards/ → ai/` 二重定義の片方除去)。
+  - **挙動変化**: トラップ価値が局面依存に。bench before/after (kernel-search OFF==ON depth 維持確認 + card-usage)。
+  - 単一 revert 隔離: 本段で digest 経路を valueModel へ切替え (revert = digest 経路を `TRAP_VALUE_*` へ差し戻し)。
+- **S3c (校正)**:
+  - PoC-2 仮係数 (E_damage / P_min / P_max / SAFETY_REF / SAFETY_SPAN) を bench + 決定的 unit test (`evaluate-action.test.ts` 方式) で校正・確定。
+  - phase別カード使用率で 57% 非対称の改善傾向を測定 (**S3 単独では P1 深さ非対称が残るため部分改善が想定**。完全是正は S4 と合わせて)。
+  - 棋力退化なし (depthCompleted ±10%) を確認。未使用化した係数 (§5 L-2) を整理。
+
+## 4. 現行構造の棚卸し (移植元マップ、M1 補完済)
+- `src/lib/shogi/cards/card-spec-server.ts`: `ValueModel` 型 (L66) + `CARD_VALUE_BRIDGE` (L90-98、静的) + `staticValueModel` stub (L100-107) ← S3a で実装、S3b で SSOT 化。
+- `src/lib/shogi/ai/cards/digest.ts`: `CardDigest.trapPresence` (defId 保持) + `evaluateCardDigest` の `evaluateTrapPresence` (`TRAP_VALUE_*` 加算、GameState 非受領) + `computeCardDigest` / `updateCardDigest` (GameState 非受領) ← S3b で gameState 供給 + `trapValueDelta` 化。
+- `src/lib/shogi/ai/search.ts`:
+  - `evaluateAction` (lookaheadPly=0) の **トラップ直接加算 `trapSigned + TRAP_VALUE_*` (`search.ts:784-791`)** ← S3b で valueModel 経由へ統一 (**M1 で棚卸し漏れ判明・補完**)。
+  - `evaluateActionWithLookahead` (lookaheadPly=1) = **実 production 経路** (`engine.ts:324-345` から呼ばれる)。PR3-3 C-6 でトラップ直接加算は削除済 (`search.ts:1347-1351` コメント)、digest.trapPresence 間接経由でのみ加算 ← S3b の digest 局面依存化が効く点。
+- `src/lib/shogi/ai/cards/heuristics.ts`: `TRAP_VALUE_NO_PROMOTE=50` / `TRAP_VALUE_CHECK_BREAK=80` + 未使用 `CHECK_BREAK_TRIGGER_THRESHOLD=-200` / `MIN_MANA_RESERVE_FOR_TRAP=6` ← S3b/c で valueModel へ移行、未使用係数は S3c で整理 (§5 L-2)。
+- `src/lib/shogi/ai/evaluators/king-safety.ts`: `evaluateKingSafety` (D-KS=C により**移設しない**。card-spec-server は自前 king-exposure を持つ。本ファイルは ai/ の盤面評価用に現状維持)。
+- `src/lib/shogi/moves.ts`: `findKing` / `isSquareAttackedByFast` ← card-spec-server の自前 king-exposure 計算が import (cards→moves 正方向、既存パターン)。
+- `docs/bench-results/issue-235-poc2.json`: PoC-2 仮係数・実測カーブ (check_break 安全玉 -25 ↔ 露出玉 +230) ← S3a 実装の数値根拠、S3c 校正の出発点。
+
+## 5. リスク (M1 確定反映)
+- **D-KS = C 確定 (§9、最重要)**: card-spec-server が `lib/shogi/moves` プリミティブで自前 king-exposure 指標を計算。`cards/ → moves` は `cards/effects.ts:7` で既に確立済の正方向依存ゆえ**新規層違反ゼロ**。B (king-safety 物理移設) は囲いボーナスが P_trigger に混入する意味的ノイズ + 新ディレクトリ新設コストがあり不採用。C の再校正コストは S3c の全係数 bench 校正と重複ゆえ実質追加なし。
+- **R-1 二重計上 (cost)**: valueModel は gross 値を返す前提を厳守。AI 側 mana 会計 (applyActionForLookahead) と cost を二重に引かない。
+- **R-2 root スカラー打ち消し** (PR3-1 F-1 の轍): 局面依存値は root の digest 計算 (computeCardDigest、root GameState で valueModel 評価) で決定し、digest スカラーとして探索木へ伝播。深い negamax での再計算はしない (W-1 root スカラー方式維持)。
+- **R-3 set 増分価値 vs 既設持続価値 (M1 H-1 由来)**: トラップの「今 set する増分価値」と「既設トラップの持続価値」は同一 valueModel で評価し、**digest にその局面依存 cp を保持**することで両方を表現 (approach (i))。set 時のみ加算し digest から除く approach (ii) は持続価値を失うため不採用。
+- **R-4 棋力退化**: トラップ価値変更で advanced/expert の手が変わる。bench before/after + 決定的 unit test の相対順序で退化検出。S3c で校正。
+- **R-5 校正 flaky 再来** (PR3-3 C-13 の轍): 決定的 unit test (`evaluate-action.test.ts` の相対 assert) + sanity-only bench (`perf-bench-card-usage`) に分離 (§6)。strict per-scenario assert は bench に置かない。
+- **R-6 PoC-2 仮係数**: E_damage / P_min / P_max / SAFETY_* は placeholder。S3c bench 校正まで本採用値未確定。
+- **D-NP (no_promote 指標、要決定 §9)**: no_promote の P_trigger に自玉露出度を流用するのは意味的に誤り (相手の成り阻止カードで自玉王手確率と無関係、PoC-2 caveat)。→ §9 で「相手成り脅威指標を S3a で実装 (両トラップ対象)」か「S3 を check_break 1枚に絞り no_promote を S4 へ」をユーザー確認。
+- **L-2 未使用係数**: `CHECK_BREAK_TRIGGER_THRESHOLD` (しきい値方式) は連続値 valueModel と思想不一致で活用されない見込み。S3 完了時に未使用なら削除 (DoD、AGENTS 実装ガイド10 デッドコード禁止)。`MIN_MANA_RESERVE_FOR_TRAP` も valueModel が cost を引かない設計 (§2) との整合を確認。
+- **L-3 盤面系 valueModel=0 のセンチネル**: S3b の SSOT 宣言時、盤面系4枚の `0` は「価値ゼロ」でなく「別経路 (盤面 eval) で捕捉=ここでは加算しない」を意味する。doc/コメントで明示し将来の誤解バグを防ぐ。
+
+## 6. 検証ゲート / bench 方法論 (M1 反映)
+各段 lint → typecheck → test:ci (全 green 維持) → build。S3b/c は bench 追加。
+- **決定的 calibration**: `evaluate-action.test.ts` に相対順序 assert を追加 (同一 AiTurnState で複数 action のスコアを計算し相対関係を assert = 盤面 eval が共通成分で打ち消し calibration 差のみ残す)。例: 露出度に対し check_break 価値が単調増加 / 安全玉では trapScore 低・露出玉では高。flaky 回避の正本 (PR3-3 C-13 方式、既存 `evaluate-action.test.ts:282-291` の相対 assert を踏襲)。
+- **局面依存挙動の実証 (M1 M-2)**: **安全玉版 (expected=move/draw) ↔ 露出玉版 (expected=playCard:trap) のペア bench/unit シナリオ**を追加し、「局面依存化が実際にカード選択を変えた」ことを直接判定する (単一 calib シナリオでは複合条件で寄与を切り分けられないため)。
+- **sanity-only bench**: `perf-bench-card-usage` (cardCount>=1 + breakdown log テレメトリ)、`perf-bench-kernel-search` (OFF==ON depth 同値 = ロジック健全性)。`RUN_PERF_BENCH=true` gate。
+- **棋力**: `docs/bench-results/issue-235-before-baseline.json` (advanced/expert 57%) を基準に phase別カード使用率の改善傾向 + depthCompleted ±10% (epic §12 多面指標)。
+- **「局面依存化 ≠ 棋力向上」** のため bench で別途評価 (epic §8.4.5 caveat 3)。
+
+## 7. rollback
+- S3a = additive (valueModel 実装 + 自前 king-exposure、production 未配線) ゆえ revert 安全。D-KS=C は移設を伴わないため king-safety 関連の後方互換懸念なし。
+- **S3b が主 cutover** = `git revert` 対象 (digest の `trapValueDelta` 経路 → 旧 `trapPresence` + `TRAP_VALUE_*` 経路へ差し戻し、`evaluateAction` 直接加算も復帰)。digest シグネチャ変更 (gameState 追加) を含むため revert は経路まるごとの差し戻し。1コミットに収めて単一 revert を維持。
+- S3c は係数調整 (値のみ) のため revert は値の差し戻し。
+
+## 8. S3 DoD
+- [ ] D-NP 確定 (§9、check_break 1枚 or 両トラップ + 相手成り脅威指標)。
+- [ ] D-KS=C で card-spec-server が自前 king-exposure を持ち、`cards/ → ai/` 上向き依存を作らない。
+- [ ] 対象トラップの valueModel を局面依存実装 + 特性化テスト (局面で変動を pin、PoC-2 カーブ再現)。
+- [ ] `computeCardDigest`/`updateCardDigest` に gameState 供給 + トラップ項 `trapValueDelta` 化。`evaluateAction` 直接加算も valueModel 経由へ統一 (2系統解消)。`CARD_VALUE_BRIDGE` トラップ二重定義解消。
+- [ ] PoC-2 仮係数を bench 校正・確定。決定的 unit test で相対順序 + 安全玉↔露出玉ペアを pin。
+- [ ] 棋力退化なし (depthCompleted ±10% + phase別カード使用率) を bench 実証。
+- [ ] 未使用係数 (CHECK_BREAK_TRIGGER_THRESHOLD 等) が S3 完了時も未使用なら削除。盤面系 valueModel=0 のセンチネル意味をコメント明示。
+- [ ] 各段 lint / typecheck / test:ci / build green。段階順序 S3a → S3b → S3c (S3b が単一 revert 主点)。
+- [ ] 盤面系カード / digest 集約キャッシュ / trap onTrigger は S4 / 別サブタスクへ申し送り (非ゴール明記)。
+
+## 9. M1 マイルストーン1レビュー反映 (策定直後、2026-06-10、AGENTS.md ルール8)
+独立 adversarial agent (general-purpose、実コード精読) でレビュー。**総合判定: 当初版は high 2件で要修正 → 本版で反映済**。骨子 (段階分割・rollback・非ゴール線引き・検証ゲート) は妥当と確認。
+
+### 確定事項
+- **D-KS = C** (当初推奨 B から変更): `cards/effects.ts:7` が既に `../moves` を import 済 = `cards→moves` は確立済正方向依存。C は新規層違反ゼロ・新ディレクトリ不要、再校正コストは S3c bench 校正と重複ゆえ実質追加なし。B のフル king-safety 流用は囲いボーナスが P_trigger に混入する意味的ノイズリスク。→ §3 S3a / §4 / §5 / §7 反映。
+- **H-1 (high) 反映**: 実 production 経路 (lookaheadPly=1) のトラップ価値は digest.trapPresence 間接経由 (PR3-3 C-6 で直接加算削除済)。digest は GameState 非保持ゆえ局面依存化には **digest 計算へ gameState 供給 + トラップ項 `trapValueDelta` 化 (approach (i))** が必要。「set 時1回加算 + digest 除去 (approach (ii))」は既設トラップ持続価値を失うため不採用。→ §2 呼び出し点 / §3 S3b / §5 R-2/R-3 反映。
+- **H-2 (high) 反映**: `evaluateTrapPresence`/`evaluateCardDigest` は GameState 非受領。H-1 の approach (i) (digest へ gameState 供給) で配線方針を明記し自動解消。→ §3 S3b / §4 反映。
+- **M-1 反映**: `evaluateAction` (lookaheadPly=0、`search.ts:784-791`) のトラップ直接加算が当初棚卸しから漏れ。S3b で同時に valueModel 経由へ統一 (2系統ドリフト防止)。→ §3 S3b / §4 反映。
+- **M-2 反映**: bench に安全玉↔露出玉のペアシナリオを追加し局面依存挙動差を直接判定。→ §6 反映。
+- **M-4 反映**: `card-spec.test.ts` の入力非依存テスト (532-540) も更新対象に明記。→ §3 S3a 反映。
+- **L-2 / L-3 反映**: 未使用係数の S3 完了時削除、盤面系 valueModel=0 のセンチネル意味明示を DoD へ。→ §5 / §8 反映。
+
+### 要ユーザー決定 (D-NP、本 doc 提示時に確認)
+- **medium M-3 (no_promote の trigger 指標)**: no_promote は相手の成りを阻止するカードで、P_trigger に**自玉露出度を流用するのは意味的に誤り** (PoC-2 caveat `noPromoteTriggerPerspective` も明記)。正しくは「相手の成り脅威指標」(相手の未成り駒の敵陣接近度等) が必要だが、これは新規設計+校正を要する。
+  - **選択肢 A (推奨候補)**: S3 を **check_break 1枚に絞り**、no_promote は S4 へ送る (no_promote は現状の固定値 50 を維持 = 退化なし)。絞込型の趣旨に最も合致、誤指標リスクゼロ。
+  - **選択肢 B**: S3a で no_promote 用に「相手成り脅威指標」を新規実装し両トラップを局面依存化 (epic §7「TRAP_VALUE_* 脱却」を2枚とも達成だが設計+校正コスト増)。
+  - → 本 doc 提示時にユーザー確認。

--- a/docs/plans/issue-235-s3-valuemodel.md
+++ b/docs/plans/issue-235-s3-valuemodel.md
@@ -9,7 +9,7 @@
 S3 = L1 ValueModel の内容依存値付け。**S0〜S2 は全て挙動不変の土台整備だったが、S3 は CPU の棋力 (カード選択) を実際に変える最初の段**。現状トラップ2枚の価値が固定係数 (`TRAP_VALUE_CHECK_BREAK=80` / `TRAP_VALUE_NO_PROMOTE=50`) で局面非依存。これを局面依存の ValueModel へ置換する。
 
 **ゴール (絞込型、epic §7 S3 行)**:
-1. **トラップの ValueModel を局面依存化**: PoC-2 実証済の `P_trigger × E_damage` モデルを `card-spec-server.ts` の valueModel に実装し、固定係数 `TRAP_VALUE_*` を脱却する。**対象カードは §9 D-NP の決定に従う** (check_break は確定、no_promote は指標問題があり要決定)。
+1. **トラップ2枚の ValueModel を局面依存化** (D-NP=B 確定、§9): `P_trigger × E_damage` モデルを `card-spec-server.ts` の valueModel に実装し、固定係数 `TRAP_VALUE_*` を脱却。**check_break = 自玉露出度** / **no_promote = 相手成り脅威指標** と P_trigger 指標を明確に分離する (同一カーブ流用禁止)。
 2. **依存反転 (valueModel を SSOT 化)**: AI のトラップ評価を静的 `TRAP_VALUE_*` / `CARD_VALUE_BRIDGE` 参照から `spec.valueModel(...)` 経由へ cutover。`cards/ → ai/` 上向き二重定義 (S2 で温存) を解消。
 3. **bench 校正**: PoC-2 仮係数 (E_damage / P_min / P_max / SAFETY_*) を bench + 決定的 unit test で本採用値に確定。棋力退化なし (§12 多面指標) を実証する。
 
@@ -111,8 +111,11 @@ S1/S2 同様、低リスクな additive → cutover の順:
 - **M-4 反映**: `card-spec.test.ts` の入力非依存テスト (532-540) も更新対象に明記。→ §3 S3a 反映。
 - **L-2 / L-3 反映**: 未使用係数の S3 完了時削除、盤面系 valueModel=0 のセンチネル意味明示を DoD へ。→ §5 / §8 反映。
 
-### 要ユーザー決定 (D-NP、本 doc 提示時に確認)
-- **medium M-3 (no_promote の trigger 指標)**: no_promote は相手の成りを阻止するカードで、P_trigger に**自玉露出度を流用するのは意味的に誤り** (PoC-2 caveat `noPromoteTriggerPerspective` も明記)。正しくは「相手の成り脅威指標」(相手の未成り駒の敵陣接近度等) が必要だが、これは新規設計+校正を要する。
-  - **選択肢 A (推奨候補)**: S3 を **check_break 1枚に絞り**、no_promote は S4 へ送る (no_promote は現状の固定値 50 を維持 = 退化なし)。絞込型の趣旨に最も合致、誤指標リスクゼロ。
-  - **選択肢 B**: S3a で no_promote 用に「相手成り脅威指標」を新規実装し両トラップを局面依存化 (epic §7「TRAP_VALUE_* 脱却」を2枚とも達成だが設計+校正コスト増)。
-  - → 本 doc 提示時にユーザー確認。
+### D-NP 確定 (2026-06-10、ユーザー決定 = 選択肢 B「罠2枚とも賢くする」)
+- **medium M-3 (no_promote の trigger 指標)**: no_promote は相手の成りを阻止するカードで、P_trigger に自玉露出度を流用するのは意味的に誤り (PoC-2 caveat `noPromoteTriggerPerspective`)。
+- **決定 = B**: S3a で no_promote 用に **「相手成り脅威指標」を新規実装**し、check_break (自玉露出度) と no_promote (相手成り脅威) の**両トラップを局面依存化**する。epic §7「TRAP_VALUE_* 脱却」を2枚とも達成。
+- **相手成り脅威指標の設計方針 (S3a)**: no_promote 価値 = `P_promo(相手の成りそう度) × E_damage_no_promote`。
+  - `P_promo`: 相手 (opponent) の**未成り・成り可能駒** (歩/香/桂/銀/角/飛) が**相手の成り地点 (= 自陣側 3 段)** にどれだけ接近しているかを `lib/shogi/moves` プリミティブで盤面走査して算出し、`[P_MIN, P_MAX]` へ正規化 (check_break の king-exposure→確率マッピングと同型)。盤面の向き (先後) を player で正しく反転すること。
+  - `E_damage_no_promote`: 成り阻止の価値 (cp、PoC-2 `NO_PROMOTE_E_DAMAGE=160` 出発点、S3c 校正)。
+  - 既存の成り判定/成り地点ヘルパ (moves/rules) を再利用し、無ければ最小実装 (cards→moves 正方向)。
+- **影響**: §0 ゴール1 の対象は check_break + no_promote の2枚。S3a の実装対象・特性化テスト・S3c 校正が2枚分に増える。check_break は self-king-exposure、no_promote は opponent-promotion-threat と**指標を明確に分離**する (同一カーブ流用を禁止)。

--- a/docs/plans/issue-235-s3-valuemodel.md
+++ b/docs/plans/issue-235-s3-valuemodel.md
@@ -119,3 +119,25 @@ S1/S2 同様、低リスクな additive → cutover の順:
   - `E_damage_no_promote`: 成り阻止の価値 (cp、PoC-2 `NO_PROMOTE_E_DAMAGE=160` 出発点、S3c 校正)。
   - 既存の成り判定/成り地点ヘルパ (moves/rules) を再利用し、無ければ最小実装 (cards→moves 正方向)。
 - **影響**: §0 ゴール1 の対象は check_break + no_promote の2枚。S3a の実装対象・特性化テスト・S3c 校正が2枚分に増える。check_break は self-king-exposure、no_promote は opponent-promotion-threat と**指標を明確に分離**する (同一カーブ流用を禁止)。
+
+## 10. S3a M2 マイルストーンレビュー (実装後、2026-06-10、AGENTS.md ルール8)
+
+S3a = トラップ2枚の valueModel を局面依存実装する **additive** 段 (production 未配線=挙動不変)。
+
+### 変更
+- `card-spec-server.ts`: check_break valueModel = 自玉露出度 `kingExposure` (玉8近傍の被利き数 + 王手中加点) → `P_trigger × CHECK_BREAK_E_DAMAGE` (gross)。no_promote valueModel = 相手成り脅威度 `promotionThreat` (相手の成り可能・未成り駒の成り地点接近度) → `P_trigger × NO_PROMOTE_E_DAMAGE` (gross)。残り5枚は `STATIC_CARD_VALUE` (mana_up=30 / 盤面系4枚=0 センチネル)。D-KS=C: king-exposure/promotion-threat は `findKing`/`isSquareAttackedByFast` (moves) + `PIECE_DEF_MAP`/`STANDARD_VARIANT` (variants/standard) で自前計算 = cards→ai を作らない。係数は PoC-2 仮値 (S3c 校正)。
+- `card-spec.test.ts`: valueModel テストを静的5枚 + トラップ2枚の局面依存テスト (安全玉↔露出玉・脅威ゼロ↔接近・promoted 除外・gote 視点反転) へ更新 (29→37 件)。
+
+### 検証実測
+- lint 0err (22 warning は既存・純増ゼロ) / typecheck / test:ci **579 passed** (e955d47 baseline 573 + 新規6、既存573不変) / build 緑。
+- bench は S3a が production 未配線 (valueModel を読む production コードゼロ) のため不要 (S3b/c で実施)。
+
+### 総合判定
+**S3a は commit/push 可 (指摘ゼロ)**。独立 adversarial agent (general-purpose、41 tool uses、ミューテーションテスト併用) で **additive 維持・metric 正当・発散点ゼロ** を確認:
+- additive: `spec.valueModel` を読む production コードはゼロ (world-kernel/action-generator は effect/meta/useCondition/checkUsage/targeting のみ参照)。既存テスト573不変。
+- metric: 盤面向き (先後反転) は canonical `isInPromotionZone` (board.ts) と完全一致、attacker 指定は canonical 王手判定 (moves.ts:374) と一致、gross 値は PoC-2 の cost 込み値と意図的分離 (二重計上回避) で正しい。テストは promotionDistance 分岐反転で3件落ちる=実効性実証。
+- 層: card-spec-server は ai/ を import せず (D-KS=C)、循環なし。card-shogi variant も STANDARD_VARIANT spread (9×9/pz=3) ゆえ promotionZoneRows 流用は正しい。
+
+### S3b への申し送り
+- valueModel は gross のため、digest 経路への gameState 供給時に mana cost を別途確実に引く (計画 §3 S3b 方針)。
+- root スカラー1回評価 (R-2) を維持し深い negamax で再計算しない。

--- a/docs/plans/issue-235-s3-valuemodel.md
+++ b/docs/plans/issue-235-s3-valuemodel.md
@@ -141,3 +141,35 @@ S3a = トラップ2枚の valueModel を局面依存実装する **additive** �
 ### S3b への申し送り
 - valueModel は gross のため、digest 経路への gameState 供給時に mana cost を別途確実に引く (計画 §3 S3b 方針)。
 - root スカラー1回評価 (R-2) を維持し深い negamax で再計算しない。
+
+## 11. S3b M2 マイルストーンレビュー (cutover 実装後、2026-06-10、AGENTS.md ルール8)
+
+S3b = トラップ評価を固定係数 (TRAP_VALUE_*) から局面依存 valueModel へ cutover + 依存反転。**CPU の棋力が実際に変わる behavior-changing 段**。
+
+### 変更
+- `digest.ts`: `CardDigest.trapPresence` (defId ペア) → `trapValueDelta: number` (sente 絶対視点 cp)。`computeCardDigest`/`updateCardDigest` に gameState 引数追加 + `computeTrapValueDelta` ヘルパ (sente トラップ +valueModel(sente) / gote -valueModel(gote)、gameState 省略時 0)。`evaluateCardDigest` は `digest.trapValueDelta` を加算。`evaluateTrapPresence` 削除、TRAP_VALUE_* import 削除、`getCardValue` import。
+- `search.ts`: `evaluateAction` (ply=0) のトラップ分岐を `getCardValue(defId, gameState, player)` へ。digest 呼び出し 8 点に post-action gameState 供給。TRAP_VALUE_* import 削除。
+- `engine.ts`: root `computeCardDigest(options.cardState, state)`。
+- `card-spec-server.ts`: `getCardValue(id, gameState, player)` アクセサ追加 (ai → L1 依存反転)。
+- `heuristics.ts`: TRAP_VALUE_NO_PROMOTE/CHECK_BREAK 撤去 (dead code 除去、§5 L-2)。
+- テスト: card-digest.test / evaluate-action.test を trapValueDelta + valueModel 期待値へ更新 (固定値ハードコード排除)。trap-only calibration を相手成り脅威盤面へ更新。perf-bench コメント更新。
+
+### 設計判断 (M1 H-1/H-2 反映)
+- **approach (i)**: digest にトラップの局面依存価値を precompute (gameState 供給時、valueModel)。digest は GameState を持たないため evaluate 時の再計算は不可 = root スカラー方式 (W-1) を維持しつつ局面依存化。「set 時1回加算+digest 除去」(approach ii) は既設トラップの持続価値を失うため不採用。
+- **gameState は任意パラメータ** (省略時 trapValueDelta=0): card-digest.test の 62 呼び出しのうちトラップ非関与 (大半) は churn せず維持。production 全 9 呼び出しは gameState を必ず渡す (トラップ価値が機能)。
+- **gross 値**: valueModel はコストを引かない (AI の mana 会計が別途処理、二重計上回避)。
+- **依存反転**: digest/search が card-spec-server.getCardValue を import (ai → L1 正方向)、循環なし。
+
+### 検証実測
+- lint 0err / typecheck 緑 / test:ci **580 passed** (S3a 579 + card-digest 新規1。既存等価ゲート world-kernel-equivalence/reducer/effects/kernel-search-equivalence すべて緑=デグレなし) / build 緑。
+- bench (RUN_PERF_BENCH): kernel-search **OFF==ON depthCompleted 維持** (digest 局面依存化は OFF/ON 両経路に等しく作用=ロジック健全)。card-usage sanity (cardCount>=1) pass。
+
+### 挙動変化 (意図的)
+- **AI のトラップ価値が局面依存に**: check_break は自玉が危ない局面ほど高く (安全玉 ~15cp ↔ 露出玉 ~270cp gross)、no_promote は相手の成り脅威が高い局面ほど高く評価 (固定 80/50 を脱却)。狙い = advanced/expert の使い渋り (57%) の一因 P2 (価値圧縮) の緩和。**仮係数は PoC-2 由来で S3c bench 校正**。
+- UI/ゲームルール/standard variant = 不変。
+
+### 総合判定
+**S3b は commit/push 可 (high/medium 指摘ゼロ)**。独立 adversarial agent (general-purpose、47 tool uses、手計算併用) で **cutover 正当・二重計上なし・符号正 (sente 絶対視点)・gameState 配線正 (8点)・root スカラー持続価値保全・等価性成立・依存反転循環なし・standard 不変・テスト非 vacuous** を確認。指摘は low cosmetic 2件 (digest ヘッダコメント / テスト名の stale) のみ → 本段で修正済。
+
+### S3c への申し送り
+- PoC-2 仮係数 (TRAP_P_MIN/MAX / E_DAMAGE / KING_EXPOSURE_REF / PROMO_THREAT_REF 等) を bench 校正し本採用値を確定。安全玉↔露出玉ペアの決定的 unit test (§6 M-2) を追加。phase別カード使用率で 57% 非対称の改善傾向を測定。未使用係数の最終確認。

--- a/src/app/api/ai-move/route.ts
+++ b/src/app/api/ai-move/route.ts
@@ -7,8 +7,13 @@
 // - maxDuration: 10 秒 (Vercel Hobby 上限 60s に対する余裕大)。
 //   Issue #176 timeout-fix で 5→10 に拡大し、cold start spike + Neon DB resume
 //   + Prisma init + TT alloc の累積を 5s 以内に詰め込めない問題を解消。
-//   内部探索 deadline (engine.ts の timeLimitMs) は最大 3500ms (expert) で、
-//   blunder guard 200ms budget と合わせても hard stop 4.0 秒以内に収まる。
+//   内部探索 deadline (engine.ts の timeLimitMs) は最大 3500ms (expert)。
+//   Issue #235 派生 (2026-06-10 Vercel 504 対策): deep search 後の root アクション評価
+//   フェーズ (カード/ドロー lookahead + double_move super-action) は従来 unbounded で、
+//   終盤の高分岐局面で 10s を超過し FUNCTION_INVOCATION_TIMEOUT が発生していた。
+//   ACTION_PHASE_BUDGET_RATIO (engine.ts、timeLimitMs × 0.4 = expert 1400ms) で hard bound し、
+//   最悪総時間 ≈ deep 3.5s + アクション評価 1.4s + blunder guard 0.2s ≈ 5.1s に収まる
+//   (maxDuration 10s に対し約 2 倍の安全余裕)。
 //   Vercel Pro upgrade 後 (Issue #190) は 15〜30s に再調整可。
 // - request.signal を SearchContext.signal に伝播し、client abort (待った /
 //   終局 / unmount) を即時に探索へ伝える

--- a/src/components/game/__tests__/ai-thinking-indicator.test.tsx
+++ b/src/components/game/__tests__/ai-thinking-indicator.test.tsx
@@ -1,0 +1,39 @@
+// Issue #235 派生 (504 UX 改善): AiThinkingIndicator の表示分岐テスト。
+//
+// - visible=false → 何も描画しない (CPU 手番以外でレイヤを残さない)
+// - visible=true / longThinking=false → 「考え中 ...」 (CPU 手番のデフォルト表示)
+// - visible=true / longThinking=true → 「長考中 ...」 (自動リトライ中の切替表示)
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { AiThinkingIndicator } from "../ai-thinking-indicator";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AiThinkingIndicator", () => {
+  it("visible=false では何も描画しない", () => {
+    render(<AiThinkingIndicator visible={false} longThinking={false} />);
+    expect(screen.queryByTestId("ai-thinking-indicator")).toBeNull();
+  });
+
+  it("visible=true / longThinking=false で「考え中 ...」を表示", () => {
+    render(<AiThinkingIndicator visible longThinking={false} />);
+    expect(screen.getByText("考え中 ...")).toBeTruthy();
+    expect(screen.queryByText("長考中 ...")).toBeNull();
+  });
+
+  it("visible=true / longThinking=true で「長考中 ...」へ切替", () => {
+    render(<AiThinkingIndicator visible longThinking />);
+    expect(screen.getByText("長考中 ...")).toBeTruthy();
+    expect(screen.queryByText("考え中 ...")).toBeNull();
+  });
+
+  it("操作を妨げない (pointer-events-none) かつ盤相対の中央配置レイヤである", () => {
+    render(<AiThinkingIndicator visible longThinking={false} />);
+    const layer = screen.getByTestId("ai-thinking-indicator");
+    expect(layer.className).toContain("pointer-events-none");
+    expect(layer.className).toContain("absolute");
+  });
+});

--- a/src/components/game/ai-thinking-indicator.tsx
+++ b/src/components/game/ai-thinking-indicator.tsx
@@ -8,8 +8,11 @@
 // - 自動リトライも失敗した場合は AiErrorModal (もう一度試す / 投了する) が出る。
 //
 // 設計:
-// - BoardOverlay (z-10、王手・トラップ発動等のイベント演出) と同じ盤コンテナ相対の
-//   absolute レイヤだが z-[8] で下層に置き、イベント演出を常に優先表示する。
+// - ShogiBoard のグリッド div (relative) の直下に absolute inset-0 で重ねて描画される
+//   (shogi-board.tsx)。これによりラベル行・列・スペーサーのオフセットに依らず常に
+//   盤グリッドの中央に表示される (全レイアウト・先後で 1px 正確)。
+// - z-[8] は BoardOverlay (王手・トラップ発動等のイベント演出、wrapper 側 z-10) より
+//   下層に置き、イベント演出を常に優先表示する。
 // - pointer-events-none で操作を一切妨げない (CPU 手番中のみの表示で実害もない)。
 // - アニメーションは Tailwind animate-pulse (CSS opacity keyframes) のみ = JS タイマー
 //   不使用・再レイアウトなしでモバイル負荷ゼロ近傍 (AGENTS UI/UX 方針)。
@@ -33,7 +36,8 @@ export function AiThinkingIndicator({ visible, longThinking }: AiThinkingIndicat
       aria-live="polite"
       data-testid="ai-thinking-indicator"
     >
-      <div className="animate-pulse rounded-full bg-black/60 px-5 py-2 text-sm font-medium text-white/90 shadow-lg sm:text-base">
+      {/* もう少し大きめの表示 (ユーザー要望): text-lg / sm 以上で text-xl。 */}
+      <div className="animate-pulse rounded-full bg-black/65 px-7 py-3 text-lg font-semibold text-white shadow-lg sm:text-xl">
         {longThinking ? "長考中 ..." : "考え中 ..."}
       </div>
     </div>

--- a/src/components/game/ai-thinking-indicator.tsx
+++ b/src/components/game/ai-thinking-indicator.tsx
@@ -1,0 +1,41 @@
+// Issue #235 派生 (504 UX 改善、2026-06-10): CPU 手番中に盤中央へ常時表示する思考インジケータ。
+//
+// 仕様 (ユーザー要件):
+// - プレイヤーが手を指す / カードを使い CPU 手番になったら、CPU が手を返すまで
+//   「考え中 ...」を盤中央に表示する (デフォルト機能)。
+// - AI リクエストが一過性失敗し自動リトライへ入ったら「長考中 ...」へ切替え、
+//   失敗を露出せず「CPU が長考している」ように見せる (use-ai-request の onAutoRetry 連動)。
+// - 自動リトライも失敗した場合は AiErrorModal (もう一度試す / 投了する) が出る。
+//
+// 設計:
+// - BoardOverlay (z-10、王手・トラップ発動等のイベント演出) と同じ盤コンテナ相対の
+//   absolute レイヤだが z-[8] で下層に置き、イベント演出を常に優先表示する。
+// - pointer-events-none で操作を一切妨げない (CPU 手番中のみの表示で実害もない)。
+// - アニメーションは Tailwind animate-pulse (CSS opacity keyframes) のみ = JS タイマー
+//   不使用・再レイアウトなしでモバイル負荷ゼロ近傍 (AGENTS UI/UX 方針)。
+// - 観戦モード (CPU vs CPU) では両者 AI で常時表示になってしまうため、呼び出し側で
+//   visible=false にする (card-shogi-game.tsx)。
+
+"use client";
+
+export interface AiThinkingIndicatorProps {
+  // CPU が思考中 (= AI リクエスト in-flight) のときだけ表示する。
+  visible: boolean;
+  // 自動リトライ中は「長考中 ...」へ切替 (use-ai-request onAutoRetry 連動)。
+  longThinking: boolean;
+}
+
+export function AiThinkingIndicator({ visible, longThinking }: AiThinkingIndicatorProps) {
+  if (!visible) return null;
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-[8] flex items-center justify-center"
+      aria-live="polite"
+      data-testid="ai-thinking-indicator"
+    >
+      <div className="animate-pulse rounded-full bg-black/60 px-5 py-2 text-sm font-medium text-white/90 shadow-lg sm:text-base">
+        {longThinking ? "長考中 ..." : "考え中 ..."}
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -21,6 +21,7 @@ import { CardShogiHistory } from "./card-shogi-history";
 import { GameControls, GAME_CONTROLS_HEIGHT } from "../game-controls";
 import { PromotionDialog } from "../promotion-dialog";
 import { BoardOverlay, type OverlayEvent } from "../board-overlay";
+import { AiThinkingIndicator } from "../ai-thinking-indicator";
 import { KingSlashOverlay } from "../king-slash-overlay";
 import { AiErrorModal } from "../ai-error-modal";
 import { RematchErrorBanner } from "../rematch-error-banner";
@@ -414,6 +415,7 @@ export function CardShogiGame({
     undoDoubleMoveFirst,
     cancelDoubleMove,
     aiError,
+    aiAutoRetrying,
     retryAiMove,
     // Issue #193 / PR1a: 観戦モード専用 (一時停止 / 再開)。spectatorMode は
     // serializableConfig 経由で取得済 (上の const spectatorMode = ...)。
@@ -1743,6 +1745,13 @@ export function CardShogiGame({
               hiddenSquares={hiddenBoardSquares}
               forbiddenMateSquares={forbiddenMateMoves.map((m) => m.to)}
             />
+            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+                観戦モード (両者 AI) では常時表示になり鬱陶しいため非表示。
+                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
+            <AiThinkingIndicator
+              visible={isAiThinking && !spectatorMode}
+              longThinking={aiAutoRetrying}
+            />
             <BoardOverlay
               key={overlayEvent?.key}
               event={overlayEvent?.event ?? null}
@@ -2150,6 +2159,13 @@ export function CardShogiGame({
               noPromoteSquares={noPromoteSquares}
               hiddenSquares={hiddenBoardSquares}
               forbiddenMateSquares={forbiddenMateMoves.map((m) => m.to)}
+            />
+            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+                観戦モード (両者 AI) では常時表示になり鬱陶しいため非表示。
+                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
+            <AiThinkingIndicator
+              visible={isAiThinking && !spectatorMode}
+              longThinking={aiAutoRetrying}
             />
             <BoardOverlay
               key={overlayEvent?.key}

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -21,7 +21,6 @@ import { CardShogiHistory } from "./card-shogi-history";
 import { GameControls, GAME_CONTROLS_HEIGHT } from "../game-controls";
 import { PromotionDialog } from "../promotion-dialog";
 import { BoardOverlay, type OverlayEvent } from "../board-overlay";
-import { AiThinkingIndicator } from "../ai-thinking-indicator";
 import { KingSlashOverlay } from "../king-slash-overlay";
 import { AiErrorModal } from "../ai-error-modal";
 import { RematchErrorBanner } from "../rematch-error-banner";
@@ -1744,13 +1743,11 @@ export function CardShogiGame({
               noPromoteSquares={noPromoteSquares}
               hiddenSquares={hiddenBoardSquares}
               forbiddenMateSquares={forbiddenMateMoves.map((m) => m.to)}
-            />
-            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
-                観戦モード (両者 AI) では常時表示になり鬱陶しいため非表示。
-                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
-            <AiThinkingIndicator
-              visible={isAiThinking && !spectatorMode}
-              longThinking={aiAutoRetrying}
+              // Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+              // ShogiBoard 内でグリッド中央に正確に重ねる。観戦モード (両者 AI) は非表示。
+              // 自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。
+              aiThinkingIndicatorVisible={isAiThinking && !spectatorMode}
+              aiThinkingLongThinking={aiAutoRetrying}
             />
             <BoardOverlay
               key={overlayEvent?.key}
@@ -2159,13 +2156,11 @@ export function CardShogiGame({
               noPromoteSquares={noPromoteSquares}
               hiddenSquares={hiddenBoardSquares}
               forbiddenMateSquares={forbiddenMateMoves.map((m) => m.to)}
-            />
-            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
-                観戦モード (両者 AI) では常時表示になり鬱陶しいため非表示。
-                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
-            <AiThinkingIndicator
-              visible={isAiThinking && !spectatorMode}
-              longThinking={aiAutoRetrying}
+              // Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+              // ShogiBoard 内でグリッド中央に正確に重ねる。観戦モード (両者 AI) は非表示。
+              // 自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。
+              aiThinkingIndicatorVisible={isAiThinking && !spectatorMode}
+              aiThinkingLongThinking={aiAutoRetrying}
             />
             <BoardOverlay
               key={overlayEvent?.key}

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -4,6 +4,7 @@ import { forwardRef, memo, useCallback, useImperativeHandle, useRef, type CSSPro
 
 import { cn } from "@/lib/utils";
 import { ShogiPiece } from "./shogi-piece";
+import { AiThinkingIndicator } from "./ai-thinking-indicator";
 import { useBoardLayout } from "@/components/board-layout/board-layout-provider";
 import { useTouchHandler } from "@/hooks/use-touch-handler";
 import {
@@ -41,6 +42,15 @@ interface ShogiBoardProps {
   // 赤背景 + × アイコンを表示し、クリック時にダイアログで禁止理由を説明する。
   // クリック自体は通常通り onSquareClick が発火するので、禁止マスかどうかの判定は呼出元 (UI) で行う。
   forbiddenMateSquares?: Position[];
+  // Issue #235 派生 (504 UX 改善): CPU 思考中インジケータ (「考え中 ...」/ 自動リトライ中
+  // 「長考中 ...」) を盤グリッドの中央に表示するか。盤の幾何 (ラベル行・列・スペーサーの
+  // オフセット) は ShogiBoard が単一の真実源として持つため、インジケータをグリッド div の
+  // 直下に重ねることで全レイアウト (PC/タブレット/モバイル・先後) で 1px 正確に中央化する。
+  // 既定 false (= 標準将棋の従来表示を変えない呼出経路は影響なし)。観戦モード等の抑止は
+  // 呼出側が本フラグを false にして制御する。
+  aiThinkingIndicatorVisible?: boolean;
+  // 自動リトライ中フラグ。true で「長考中 ...」へ切替 (失敗を露出せず長考に見せる)。
+  aiThinkingLongThinking?: boolean;
 }
 
 // 先手目線のラベル
@@ -290,6 +300,8 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
     noPromoteSquares,
     hiddenSquares,
     forbiddenMateSquares,
+    aiThinkingIndicatorVisible,
+    aiThinkingLongThinking,
   },
   forwardedRef,
 ) {
@@ -463,6 +475,15 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
               );
             })
           )}
+
+          {/* Issue #235 派生 (504 UX 改善): CPU 思考インジケータ。グリッド div (relative) の
+              直下に absolute inset-0 で重ねることで、ラベル行・列・スペーサーのオフセットに
+              依らず常に盤グリッドの中央に表示される (全レイアウト・先後で 1px 正確)。
+              z-[8] は BoardOverlay (王手/トラップ演出、wrapper 側 z-10) より下層。 */}
+          <AiThinkingIndicator
+            visible={aiThinkingIndicatorVisible ?? false}
+            longThinking={aiThinkingLongThinking ?? false}
+          />
         </div>
 
         {/* ランクラベル（右） */}

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -12,6 +12,7 @@ import { MoveHistory } from "./move-history";
 import { GameControls } from "./game-controls";
 import { PromotionDialog } from "./promotion-dialog";
 import { BoardOverlay } from "./board-overlay";
+import { AiThinkingIndicator } from "./ai-thinking-indicator";
 import type { OverlayEvent } from "./board-overlay";
 import { AiErrorModal } from "./ai-error-modal";
 import { RematchErrorBanner } from "./rematch-error-banner";
@@ -118,6 +119,7 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
     isAiThinking,
     promotionPendingMove,
     aiError,
+    aiAutoRetrying,
     selectSquare,
     selectHandPiece,
     confirmPromotion,
@@ -308,6 +310,9 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
               squareSize={squareSize}
               isMobile={isMobile}
             />
+            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
+            <AiThinkingIndicator visible={isAiThinking} longThinking={aiAutoRetrying} />
             <BoardOverlay key={overlayEvent?.key} event={overlayEvent?.event ?? null} />
             {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (永続) を重ねる */}
             <KingSlashOverlay

--- a/src/components/game/shogi-game.tsx
+++ b/src/components/game/shogi-game.tsx
@@ -12,7 +12,6 @@ import { MoveHistory } from "./move-history";
 import { GameControls } from "./game-controls";
 import { PromotionDialog } from "./promotion-dialog";
 import { BoardOverlay } from "./board-overlay";
-import { AiThinkingIndicator } from "./ai-thinking-indicator";
 import type { OverlayEvent } from "./board-overlay";
 import { AiErrorModal } from "./ai-error-modal";
 import { RematchErrorBanner } from "./rematch-error-banner";
@@ -309,10 +308,11 @@ export function ShogiGame({ initialGameState, gameId, gameConfig: serializableCo
               onSquareClick={selectSquare}
               squareSize={squareSize}
               isMobile={isMobile}
+              // Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
+              // ShogiBoard 内でグリッド中央に正確に重ねる。自動リトライ中は「長考中 ...」。
+              aiThinkingIndicatorVisible={isAiThinking}
+              aiThinkingLongThinking={aiAutoRetrying}
             />
-            {/* Issue #235 派生 (504 UX 改善): CPU 思考中の盤中央インジケータ。
-                自動リトライ中は「長考中 ...」へ切替 (失敗を露出せず長考として見せる)。 */}
-            <AiThinkingIndicator visible={isAiThinking} longThinking={aiAutoRetrying} />
             <BoardOverlay key={overlayEvent?.key} event={overlayEvent?.event ?? null} />
             {/* Issue #225: 詰み時に負けた側の玉へ赤い斬撃演出 (永続) を重ねる */}
             <KingSlashOverlay

--- a/src/hooks/ai/__tests__/use-ai-request.test.ts
+++ b/src/hooks/ai/__tests__/use-ai-request.test.ts
@@ -285,6 +285,69 @@ describe("useAiRequest - HTTP / network retry 経路", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  // Issue #235 派生 (504 UX 改善): 自動リトライ開始の UI 通知 (「長考中 ...」切替) コールバック。
+  it("onAutoRetry はリトライ試行へ入った時のみ 1 回発火 (503 → 200)、初回成功では不発", async () => {
+    const onAutoRetry = vi.fn();
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useAiRequest({ onError, onAutoRetry, maxRetries: 1 }),
+    );
+
+    // ケース 1: 初回成功 → onAutoRetry 不発
+    fetchSpy.mockResolvedValueOnce(jsonResponse(sampleAiResponse));
+    let p1!: ReturnType<ReturnType<typeof useAiRequest>["requestMove"]>;
+    await act(async () => {
+      p1 = result.current.requestMove(makeParams());
+    });
+    const r1 = await p1;
+    expect(r1.stale).toBe(false);
+    expect(onAutoRetry).not.toHaveBeenCalled();
+
+    // ケース 2: 503 → 200 のリトライ成功 → onAutoRetry が 1 回発火、onError 不発
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ error: "unavail" }, { status: 503 }))
+      .mockResolvedValueOnce(jsonResponse(sampleAiResponse));
+    let p2!: ReturnType<ReturnType<typeof useAiRequest>["requestMove"]>;
+    await act(async () => {
+      p2 = result.current.requestMove(makeParams());
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    const r2 = await p2;
+    expect(r2.stale).toBe(false);
+    expect(onAutoRetry).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("onAutoRetry はリトライも失敗 (504×2) の場合も 1 回のみ発火し、その後 onError が発火", async () => {
+    const onAutoRetry = vi.fn();
+    const onError = vi.fn<(e: AiRequestError) => void>();
+    const { result } = renderHook(() =>
+      useAiRequest({ onError, onAutoRetry, maxRetries: 1 }),
+    );
+
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ error: "timeout" }, { status: 504 }))
+      .mockResolvedValueOnce(jsonResponse({ error: "timeout" }, { status: 504 }));
+
+    let promise!: ReturnType<ReturnType<typeof useAiRequest>["requestMove"]>;
+    await act(async () => {
+      promise = result.current.requestMove(makeParams());
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const r = await promise;
+    expect(r.stale).toBe(true);
+    expect(onAutoRetry).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "http", status: 504 }),
+    );
+  });
+
   it("HTTP 4xx (例: 400) は retry せず onError を発火し fetch は 1 回のみ", async () => {
     const onError = vi.fn<(e: AiRequestError) => void>();
     const { result } = renderHook(() =>

--- a/src/hooks/ai/use-ai-request.ts
+++ b/src/hooks/ai/use-ai-request.ts
@@ -126,8 +126,10 @@ function generateRequestId(): string {
 }
 
 // Issue #176 timeout-fix F4: 指数バックオフを 300ms 起点 (cap 1500ms) に縮小。
-// maxRetries=1 + overallTimeoutMs=12000ms と組み合わせ、最悪累積 (10s + 0.3s
-// + 10s = 10.3s) ≪ 12s で overall timer が retry 中に発火しないよう整合させる。
+// Issue #235 派生 (2026-06-10): overallTimeoutMs を 24000ms へ拡張したことに伴い、
+// maxRetries=1 + overallTimeoutMs=24000ms で最悪累積 (11s + 0.3s + 11s ≈ 22.3s)
+// < 24s となり、retry 2 回目にも完全な実行窓を与えつつ overall timer が retry 中に
+// 発火しないよう整合させる (backoff 自体の値は不変)。
 //
 // 504 原因別 retry 効果見積もり:
 //   A: maxDuration 超過        → retry 効果薄 (warm 再走でも同遅延)

--- a/src/hooks/ai/use-ai-request.ts
+++ b/src/hooks/ai/use-ai-request.ts
@@ -63,16 +63,25 @@ export interface AiMoveResponse {
 export interface UseAiRequestOptions {
   // 連続失敗時に呼ばれる。ユーザー向けエラーモーダルを表示する想定。
   onError?: (err: AiRequestError) => void;
+  // Issue #235 派生 (504 UX 改善、2026-06-10): 自動リトライ試行へ入った瞬間に呼ばれる。
+  // UI 側はこれを受けて思考表示を「考え中 ...」→「長考中 ...」へ切替え、ユーザーには
+  // 「CPU が長考している」ように見せる (失敗を露出せず待ちの姿勢を作る)。
+  // リトライも失敗した場合は従来どおり onError → エラーモーダルでユーザーに委ねる。
+  onAutoRetry?: () => void;
   // 全体タイムアウト (ms)。リトライを含む overall 上限。
-  // Issue #176 timeout-fix F4: maxDuration=10s × 2 試行 + backoff 300ms = 20.3s が
-  // 最悪論理累積だが、overallTimeoutMs はその外側に来る hard deadline で 12s に
-  // 設定 (1 試行 10s + backoff 300ms + 2 試行目 1.7s で打切 → modal 提示)。
-  // デフォルト 12000ms。
+  // Issue #176 timeout-fix F4 で 12s に設定していたが、その値では 1 試行目が 504
+  // (サーバ応答 ≈ 10.3〜11s) のときリトライ 2 試行目が ~1.7s しか走れず、
+  // 「自動リトライがあるのに 504 連鎖では構造的に無力」だった。
+  // Issue #235 派生 (2026-06-10): 2 試行目にも完全な実行窓を与える 24s へ拡張
+  // (最悪連鎖 = 1 試行目 11s + backoff 0.3s + 2 試行目 11s ≈ 22.3s < 24s)。
+  // エンジン側は同日の 504 修正 (action-phase budget) で最悪 ≈ 5.1s に bound 済のため、
+  // 通常はこの上限に遠く届かない (本値は真の 504 連鎖時の外側 hard deadline)。
+  // デフォルト 24000ms。
   overallTimeoutMs?: number;
   // 自動リトライ回数 (これ以外に最初の試行 1 回がある)。デフォルト 1。
   // Issue #176 timeout-fix F4: 旧 default=2 では (1 試行 5s × 3 + backoff 累積)
   // が 15s を踏み超え overall timer が retry 中に発火 → 永久停止の誘発要因と
-  // なっていた。retry=1 + backoff 短縮で累積 10.3s ≪ 12s に整合。
+  // なっていた。retry=1 を維持 (1 回目の失敗 = 自動リトライ、2 回目の失敗 = modal)。
   maxRetries?: number;
 }
 
@@ -153,7 +162,7 @@ function delay(ms: number, signal: AbortSignal): Promise<void> {
 }
 
 export function useAiRequest(options: UseAiRequestOptions = {}) {
-  const { onError, overallTimeoutMs = 12000, maxRetries = 1 } = options;
+  const { onError, onAutoRetry, overallTimeoutMs = 24000, maxRetries = 1 } = options;
 
   // 現在 in-flight な AbortController。新規 request で前回を abort し、stale 応答
   // を確実に捨てる。
@@ -233,6 +242,9 @@ export function useAiRequest(options: UseAiRequestOptions = {}) {
             return handleAbort();
           }
           if (attempt > 0) {
+            // Issue #235 派生 (504 UX 改善): 自動リトライ開始を UI へ通知
+            // (「考え中 ...」→「長考中 ...」切替。失敗を露出せず長考として見せる)。
+            onAutoRetry?.();
             try {
               await delay(backoffMs(attempt), controller.signal);
             } catch {
@@ -286,7 +298,7 @@ export function useAiRequest(options: UseAiRequestOptions = {}) {
         }
       }
     },
-    [maxRetries, onError, overallTimeoutMs],
+    [maxRetries, onError, onAutoRetry, overallTimeoutMs],
   );
 
   return { requestMove, cancel };

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -93,12 +93,18 @@ export function useCardShogiGame({
   // Issue #176: AI 思考リクエストを Route Handler 経由に統一する。
   const [aiError, setAiError] = useState<AiRequestError | null>(null);
   const [aiRetryCounter, setAiRetryCounter] = useState(0);
+  // Issue #235 派生 (504 UX 改善): 自動リトライ中フラグ。思考インジケータの文言を
+  // 「考え中 ...」→「長考中 ...」へ切替える (失敗を露出せず長考として見せる)。
+  // リクエスト解決 (成功 / stale / onError → モーダル) で必ずクリアする。
+  const [aiAutoRetrying, setAiAutoRetrying] = useState(false);
   const handleAiError = useCallback((err: AiRequestError) => {
     setAiError(err);
     dispatch({ type: "SET_AI_THINKING", thinking: false });
   }, []);
+  const handleAiAutoRetry = useCallback(() => setAiAutoRetrying(true), []);
   const { requestMove: aiRequestMove, cancel: cancelAiRequest } = useAiRequest({
     onError: handleAiError,
+    onAutoRetry: handleAiAutoRetry,
   });
 
   // AI 自動応手
@@ -149,6 +155,9 @@ export function useCardShogiGame({
         // PR1a (E-1): 観戦モード時は route 側で timeLimitMs を SPECTATOR_TIME_LIMIT_MS=1500ms に短縮する。
         spectatorMode: state.spectatorMode,
       });
+      // Issue #235 派生 (504 UX 改善): リクエスト解決 = 自動リトライ局面の終了。
+      // 成功 / stale (キャンセル・モーダル発火済) のどちらでも「長考中」表示を解除する。
+      setAiAutoRetrying(false);
       if (result.stale) {
         // 待った / 終局 / unmount / 上書き / onError 経由の早期 abort。
         // 既に setAiError 済みかキャンセル済みなので thinking 解除のみ。
@@ -620,6 +629,8 @@ export function useCardShogiGame({
     isCheckBreakAnimating: state.isCheckBreakAnimating,
     doubleMove: state.doubleMove,
     aiError,
+    // Issue #235 派生 (504 UX 改善): 自動リトライ中 = 思考表示を「長考中 ...」へ切替
+    aiAutoRetrying,
     dismissAiError,
     retryAiMove,
     // Issue #193 / PR1a: 観戦モード専用の状態と操作

--- a/src/hooks/use-shogi-game.ts
+++ b/src/hooks/use-shogi-game.ts
@@ -273,12 +273,17 @@ export function useShogiGame({
   // - retry trigger は aiRetryCounter で effect 再走させる
   const [aiError, setAiError] = useState<AiRequestError | null>(null);
   const [aiRetryCounter, setAiRetryCounter] = useState(0);
+  // Issue #235 派生 (504 UX 改善): 自動リトライ中フラグ。思考インジケータの文言を
+  // 「考え中 ...」→「長考中 ...」へ切替える (card-shogi 側と同一パターン)。
+  const [aiAutoRetrying, setAiAutoRetrying] = useState(false);
   const handleAiError = useCallback((err: AiRequestError) => {
     setAiError(err);
     dispatch({ type: "SET_AI_THINKING", thinking: false });
   }, []);
+  const handleAiAutoRetry = useCallback(() => setAiAutoRetrying(true), []);
   const { requestMove: aiRequestMove, cancel: cancelAiRequest } = useAiRequest({
     onError: handleAiError,
+    onAutoRetry: handleAiAutoRetry,
   });
 
   // AI自動応手
@@ -303,6 +308,9 @@ export function useShogiGame({
         variantId: gameConfig.variant.id,
         clientMoveCount: gameState.moveCount,
       });
+      // Issue #235 派生 (504 UX 改善): リクエスト解決 = 自動リトライ局面の終了。
+      // 成功 / stale のどちらでも「長考中」表示を解除する。
+      setAiAutoRetrying(false);
       if (result.stale) {
         // 待った / 終局 / unmount / 上書きで stale 化、あるいは onError で
         // 既に setAiError 済み。ここでは isAiThinking のクリーンアップのみ。
@@ -499,6 +507,8 @@ export function useShogiGame({
     isAiThinking: state.isAiThinking,
     promotionPendingMove: state.promotionPendingMove,
     aiError,
+    // Issue #235 派生 (504 UX 改善): 自動リトライ中 = 思考表示を「長考中 ...」へ切替
+    aiAutoRetrying,
     selectSquare,
     selectHandPiece,
     confirmPromotion,

--- a/src/lib/shogi/ai/__tests__/action-generator.test.ts
+++ b/src/lib/shogi/ai/__tests__/action-generator.test.ts
@@ -114,17 +114,45 @@ describe("getCardActions (BEGIN_PLAY_CARD 7 項目を AI 側で再現)", () => {
     expect(actions).toEqual([]);
   });
 
-  it("PlayCardAction の cardInstanceId は手札の instance.instanceId と一致 (重複 instance がない)", () => {
+  it("同一 defId の重複インスタンスは dedupe され先頭インスタンスのみ候補化 (Vercel 504 対策)", () => {
+    // Issue #235 派生: 使用可否 ((4)〜(7))・効果・評価は defId と局面にのみ依存しコピー間で
+    // 完全等価のため、2 枚目以降の同種カードは候補化しない。旧仕様は instance ごとに重複候補を
+    // 生成し、二手指し複数枚で super-action (数秒/回) が枚数分重複評価され Vercel maxDuration
+    // 10s 超過 (FUNCTION_INVOCATION_TIMEOUT) の主因だった (実測: 3 枚で計 11.4s)。
+    // 採用 instanceId は旧仕様でも argmax の strict > により先頭コピーだったため選択結果は不変。
     const state = makeAiTurnState();
     state.cardState.hand.sente = [
       makeCardInstance("pawn_return", "sente-unique-id-1"),
       makeCardInstance("pawn_return", "sente-unique-id-2"),
     ];
     const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
-    // それぞれの instance で別の PlayCardAction 群が生成される (square ごとに instance 別)
     const ids = new Set(actions.map((a) => (a.kind === "playCard" ? a.cardInstanceId : null)));
     expect(ids.has("sente-unique-id-1")).toBe(true);
-    expect(ids.has("sente-unique-id-2")).toBe(true);
+    expect(ids.has("sente-unique-id-2")).toBe(false);
+    // dedupe してもターゲット列挙 (先頭インスタンス分) は維持される
+    expect(actions.length).toBeGreaterThan(0);
+  });
+
+  it("二手指し複数枚は 1 候補に dedupe される (重複 super-action 評価の防止)", () => {
+    const state = makeAiTurnState();
+    state.cardState.mana.sente = 20;
+    state.cardState.hand.sente = [
+      makeCardInstance("double_move", "dm-1"),
+      makeCardInstance("double_move", "dm-2"),
+      makeCardInstance("double_move", "dm-3"),
+      makeCardInstance("pawn_return", "pr-1"),
+    ];
+    const actions = Array.from(getCardActions(state, "sente", CARD_SHOGI_VARIANT));
+    const dmActions = actions.filter(
+      (a) => a.kind === "playCard" && a.defId === "double_move",
+    );
+    expect(dmActions).toHaveLength(1);
+    expect(dmActions[0].kind === "playCard" && dmActions[0].cardInstanceId).toBe("dm-1");
+    // 異種カード (pawn_return) の候補は dedupe の影響を受けない
+    const prActions = actions.filter(
+      (a) => a.kind === "playCard" && a.defId === "pawn_return",
+    );
+    expect(prActions.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/lib/shogi/ai/__tests__/card-digest.test.ts
+++ b/src/lib/shogi/ai/__tests__/card-digest.test.ts
@@ -23,19 +23,42 @@ import {
   HAND_VALUE_BASE,
   HAND_VALUE_DECAY,
   DRAW_PROGRESS_COEFFICIENT,
-  TRAP_VALUE_NO_PROMOTE,
-  TRAP_VALUE_CHECK_BREAK,
   NO_PROMOTE_MARK_COEFFICIENT,
   DEAD_MANA_THRESHOLD,
   DEAD_MANA_PENALTY_COEF,
 } from "../cards/heuristics";
+import { CARD_SPECS } from "@/lib/shogi/cards/card-spec-server";
 import { createInitialCardState } from "@/lib/shogi/cards/state";
 import { INITIAL_MANA, MANA_CAP } from "@/lib/shogi/cards/definitions";
 import { STANDARD_VARIANT } from "@/lib/shogi/variants/standard";
 import { CARD_SHOGI_VARIANT } from "@/lib/shogi/variants/card-shogi";
+import type { Board, GameState, Piece } from "@/lib/shogi/types";
 
 // テスト用の最小デッキ (Fisher-Yates シャッフルあるが、結果に影響しない構造のみ)。
 const SAMPLE_DECK = [{ defId: "pawn_return" as const, count: 10 }];
+
+// Issue #235 S3b: トラップの局面依存価値 (valueModel) を決定論化する最小盤面。
+// 両玉を安全位置に配置 (check_break=自玉露出度0 / no_promote=相手成り脅威0 → 各カード下限値)。
+// トラップ価値の符号・wiring 検証用。期待値は CARD_SPECS[id].valueModel(GS, player) で算出する
+// (固定定数をハードコードせず、valueModel との一致を pin)。
+function makeGameState(): GameState {
+  const board: Board = Array.from({ length: 9 }, () => Array<Piece | null>(9).fill(null));
+  board[8][4] = { type: "king", owner: "sente" };
+  board[0][4] = { type: "king", owner: "gote" };
+  return {
+    board,
+    hand: { sente: {}, gote: {} },
+    currentPlayer: "sente",
+    moveHistory: [],
+    positionHistory: [],
+    status: "active",
+    moveCount: 0,
+  };
+}
+const GS = makeGameState();
+// 期待トラップ価値 (sente 絶対視点: sente トラップ +、gote トラップ -)。
+const CHECK_BREAK_VM_SENTE = CARD_SPECS.check_break.valueModel(GS, "sente");
+const NO_PROMOTE_VM_GOTE = CARD_SPECS.no_promote.valueModel(GS, "gote");
 
 describe("computeCardDigest (W-2: sente 絶対視点)", () => {
   it("初期 cardState の manaDelta は INITIAL_MANA.sente - INITIAL_MANA.gote (= -1)", () => {
@@ -111,7 +134,7 @@ describe("evaluateCardDigest (W-3: variant ガード + W-2: sente 絶対視点)"
     manaCap: MANA_CAP,
     handValueDelta: 5,
     drawProgressDelta: 2,
-    trapPresence: { sente: null, gote: null },
+    trapValueDelta: 0,
     noPromoteMarkCountDelta: 0,
     // PR3-1: 両者 DEAD_MANA_THRESHOLD 以下に設定し、死にマナペナルティ=0 で
     // 既存アサーションの数式 (manaDelta×COEF + handValueDelta + drawProgressDelta×COEF) を維持。
@@ -138,7 +161,7 @@ describe("evaluateCardDigest (W-3: variant ガード + W-2: sente 絶対視点)"
       manaCap: MANA_CAP,
       handValueDelta: 0,
       drawProgressDelta: 0,
-      trapPresence: { sente: null, gote: null },
+      trapValueDelta: 0,
       noPromoteMarkCountDelta: 0,
       manaAbsolute: { sente: 0, gote: 0 },
     };
@@ -212,35 +235,41 @@ describe("handValue 単調減衰関数 (F-5 仮基準)", () => {
   });
 });
 
-describe("computeCardDigest PR1d-4 拡張 (trapPresence / noPromoteMarkCountDelta)", () => {
-  it("初期 cardState は trapPresence={sente:null,gote:null} / noPromoteMarkCountDelta=0", () => {
+describe("computeCardDigest S3b 拡張 (trapValueDelta / noPromoteMarkCountDelta)", () => {
+  it("トラップなし → trapValueDelta=0 / noPromoteMarkCountDelta=0", () => {
     const cardState = createInitialCardState(SAMPLE_DECK);
-    const digest = computeCardDigest(cardState);
-    expect(digest.trapPresence).toEqual({ sente: null, gote: null });
+    const digest = computeCardDigest(cardState, GS);
+    expect(digest.trapValueDelta).toBe(0);
     expect(digest.noPromoteMarkCountDelta).toBe(0);
   });
 
-  it("sente 盤上トラップは trapPresence.sente に defId 反映、gote は null", () => {
+  it("gameState 省略時はトラップ保有でも trapValueDelta=0 (局面情報なしで算出不可)", () => {
+    const cardState = createInitialCardState(SAMPLE_DECK);
+    cardState.trap.sente = { instanceId: "t-s1", defId: "check_break", owner: "sente" };
+    expect(computeCardDigest(cardState).trapValueDelta).toBe(0);
+  });
+
+  it("sente 盤上トラップは +valueModel(sente)、gote 不在", () => {
     const cardState = createInitialCardState(SAMPLE_DECK);
     cardState.trap.sente = {
       instanceId: "t-s1",
       defId: "check_break",
       owner: "sente",
     };
-    const digest = computeCardDigest(cardState);
-    expect(digest.trapPresence.sente).toBe("check_break");
-    expect(digest.trapPresence.gote).toBeNull();
+    const digest = computeCardDigest(cardState, GS);
+    expect(digest.trapValueDelta).toBe(CHECK_BREAK_VM_SENTE);
+    expect(CHECK_BREAK_VM_SENTE).toBeGreaterThan(0); // gross 値は常に正
   });
 
-  it("両者盤上トラップは sente/gote それぞれの defId を保持", () => {
+  it("両者盤上トラップは +valueModel(sente) - valueModel(gote) (sente 絶対視点)", () => {
     const cardState = createInitialCardState(SAMPLE_DECK);
     cardState.trap.sente = { instanceId: "t-s", defId: "no_promote", owner: "sente" };
     cardState.trap.gote = { instanceId: "t-g", defId: "check_break", owner: "gote" };
-    const digest = computeCardDigest(cardState);
-    expect(digest.trapPresence).toEqual({
-      sente: "no_promote",
-      gote: "check_break",
-    });
+    const digest = computeCardDigest(cardState, GS);
+    const expected =
+      CARD_SPECS.no_promote.valueModel(GS, "sente") -
+      CARD_SPECS.check_break.valueModel(GS, "gote");
+    expect(digest.trapValueDelta).toBe(expected);
   });
 
   it("noPromoteMarkCountDelta は sente 数 - gote 数 (ギャップ1=案A: 玉位置非依存)", () => {
@@ -266,34 +295,22 @@ describe("computeCardDigest PR1d-4 拡張 (trapPresence / noPromoteMarkCountDelt
     expect(digest.noPromoteMarkCountDelta).toBe(0 - 3);
   });
 
-  it("PR1d-4 コミット 2: sente 盤上 check_break trap は +TRAP_VALUE_CHECK_BREAK", () => {
+  it("S3b: sente 盤上 check_break trap は evaluate に +valueModel(sente)", () => {
     const base = createInitialCardState(SAMPLE_DECK);
     const withTrap = createInitialCardState(SAMPLE_DECK);
     withTrap.trap.sente = { instanceId: "t", defId: "check_break", owner: "sente" };
-    const baseScore = evaluateCardDigest(
-      computeCardDigest(base),
-      CARD_SHOGI_VARIANT,
-    );
-    const trapScore = evaluateCardDigest(
-      computeCardDigest(withTrap),
-      CARD_SHOGI_VARIANT,
-    );
-    expect(trapScore - baseScore).toBe(TRAP_VALUE_CHECK_BREAK);
+    const baseScore = evaluateCardDigest(computeCardDigest(base, GS), CARD_SHOGI_VARIANT);
+    const trapScore = evaluateCardDigest(computeCardDigest(withTrap, GS), CARD_SHOGI_VARIANT);
+    expect(trapScore - baseScore).toBe(CHECK_BREAK_VM_SENTE);
   });
 
-  it("PR1d-4 コミット 2: gote 盤上 no_promote trap は -TRAP_VALUE_NO_PROMOTE (sente 絶対視点)", () => {
+  it("S3b: gote 盤上 no_promote trap は evaluate に -valueModel(gote) (sente 絶対視点)", () => {
     const base = createInitialCardState(SAMPLE_DECK);
     const withTrap = createInitialCardState(SAMPLE_DECK);
     withTrap.trap.gote = { instanceId: "t", defId: "no_promote", owner: "gote" };
-    const baseScore = evaluateCardDigest(
-      computeCardDigest(base),
-      CARD_SHOGI_VARIANT,
-    );
-    const trapScore = evaluateCardDigest(
-      computeCardDigest(withTrap),
-      CARD_SHOGI_VARIANT,
-    );
-    expect(trapScore - baseScore).toBe(-TRAP_VALUE_NO_PROMOTE);
+    const baseScore = evaluateCardDigest(computeCardDigest(base, GS), CARD_SHOGI_VARIANT);
+    const trapScore = evaluateCardDigest(computeCardDigest(withTrap, GS), CARD_SHOGI_VARIANT);
+    expect(trapScore - baseScore).toBe(-NO_PROMOTE_VM_GOTE);
   });
 
   it("PR1d-4 コミット 2: noPromoteMarkCountDelta × NO_PROMOTE_MARK_COEFFICIENT が評価に反映", () => {
@@ -315,12 +332,12 @@ describe("computeCardDigest PR1d-4 拡張 (trapPresence / noPromoteMarkCountDelt
     expect(markScore - baseScore).toBe((2 - 1) * NO_PROMOTE_MARK_COEFFICIENT);
   });
 
-  it("PR1d-4 コミット 2: standard variant はトラップ価値も 0 (W-3 ガード維持)", () => {
+  it("S3b: standard variant はトラップ価値も 0 (W-3 ガード維持)", () => {
     const withTrap = createInitialCardState(SAMPLE_DECK);
     withTrap.trap.sente = { instanceId: "t", defId: "check_break", owner: "sente" };
     withTrap.noPromoteMarks.sente = [{ row: 6, col: 0 }];
     expect(
-      evaluateCardDigest(computeCardDigest(withTrap), STANDARD_VARIANT),
+      evaluateCardDigest(computeCardDigest(withTrap, GS), STANDARD_VARIANT),
     ).toBe(0);
   });
 });
@@ -447,7 +464,7 @@ describe("PR3-2 updateCardDigest (増分更新)", () => {
     expect(updated).toEqual(prev);
     // 変化なしフィールドはオブジェクトを参照流用 (再生成なし) で性能寄与
     expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
-    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.trapValueDelta).toBe(prev.trapValueDelta);
   });
 
   it("マナのみ変化 → manaDelta / manaAbsolute 更新、他は prev 流用", () => {
@@ -459,7 +476,7 @@ describe("PR3-2 updateCardDigest (増分更新)", () => {
     expect(updated.manaDelta).toBe(csNew.mana.sente - csNew.mana.gote);
     expect(updated.manaAbsolute).toEqual({ sente: csNew.mana.sente, gote: cs.mana.gote });
     // 他フィールドは prev と reference equality
-    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.trapValueDelta).toBe(prev.trapValueDelta);
     expect(updated.handValueDelta).toBe(prev.handValueDelta);
     expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
     expect(updated.noPromoteMarkCountDelta).toBe(prev.noPromoteMarkCountDelta);
@@ -475,39 +492,41 @@ describe("PR3-2 updateCardDigest (増分更新)", () => {
     expect(updated.handValueDelta).toBeGreaterThan(prev.handValueDelta);
     // mana / trap / drawProgress / marks は変化なし
     expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
-    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.trapValueDelta).toBe(prev.trapValueDelta);
     expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
     expect(updated.noPromoteMarkCountDelta).toBe(prev.noPromoteMarkCountDelta);
   });
 
-  it("トラップ設置 (gote: check_break) → trapPresence 更新", () => {
+  it("トラップ設置 (gote: check_break) → trapValueDelta 更新 (-valueModel(gote))", () => {
     const cs = createInitialCardState(SAMPLE_DECK);
-    const prev = computeCardDigest(cs);
+    const prev = computeCardDigest(cs, GS);
     const csNew = clone(cs);
     csNew.trap.gote = {
       instanceId: "tg-1",
       defId: "check_break",
       owner: "gote",
     };
-    const updated = updateCardDigest(prev, cs, csNew);
-    expect(updated.trapPresence).toEqual({ sente: null, gote: "check_break" });
+    const updated = updateCardDigest(prev, cs, csNew, GS);
+    // gote トラップは sente 絶対視点で負 (= -valueModel(check_break, gote))。
+    expect(updated.trapValueDelta).toBe(-CARD_SPECS.check_break.valueModel(GS, "gote"));
+    expect(updated.trapValueDelta).toBeLessThan(0);
     // 他は流用
     expect(updated.manaAbsolute).toBe(prev.manaAbsolute);
     expect(updated.handValueDelta).toBe(prev.handValueDelta);
   });
 
-  it("トラップ解除 (gote: check_break → null) → trapPresence 更新", () => {
+  it("トラップ解除 (gote: check_break → null) → trapValueDelta 更新 (0 へ)", () => {
     const cs = createInitialCardState(SAMPLE_DECK);
     cs.trap.gote = {
       instanceId: "tg-1",
       defId: "check_break",
       owner: "gote",
     };
-    const prev = computeCardDigest(cs);
+    const prev = computeCardDigest(cs, GS);
     const csNew = clone(cs);
     csNew.trap.gote = null;
-    const updated = updateCardDigest(prev, cs, csNew);
-    expect(updated.trapPresence).toEqual({ sente: null, gote: null });
+    const updated = updateCardDigest(prev, cs, csNew, GS);
+    expect(updated.trapValueDelta).toBe(0);
   });
 
   it("noPromote マーク追加 → noPromoteMarkCountDelta 更新", () => {
@@ -542,7 +561,7 @@ describe("PR3-2 updateCardDigest (増分更新)", () => {
     expect(updated.manaAbsolute).toEqual({ sente: csNew.mana.sente, gote: cs.mana.gote });
     expect(updated.handValueDelta).toBeLessThan(prev.handValueDelta);
     // 変化なしフィールドは流用
-    expect(updated.trapPresence).toBe(prev.trapPresence);
+    expect(updated.trapValueDelta).toBe(prev.trapValueDelta);
     expect(updated.drawProgressDelta).toBe(prev.drawProgressDelta);
   });
 
@@ -689,9 +708,11 @@ describe("PR3-2 updateCardDigest 等価性 fixture (= computeCardDigest と byte
       const next = clone(prev);
       sc.mutate(next);
 
-      const prevDigest = computeCardDigest(prev);
-      const updated = updateCardDigest(prevDigest, prev, next);
-      const recomputed = computeCardDigest(next);
+      // S3b: 同一 gameState (GS) を全呼び出しに供給し、トラップ価値も含めた等価性を検証する
+      // (prev は check_break トラップを保有するため trapValueDelta が非0)。
+      const prevDigest = computeCardDigest(prev, GS);
+      const updated = updateCardDigest(prevDigest, prev, next, GS);
+      const recomputed = computeCardDigest(next, GS);
 
       // byte-level 一致 (各フィールドが厳密に同値)
       expect(updated).toEqual(recomputed);
@@ -713,21 +734,22 @@ describe("PR3-3 C-8 evaluateCardDigest 数値固定 (F-5 解消)", () => {
       manaCap: MANA_CAP,
       handValueDelta: 0,
       drawProgressDelta: 0,
-      trapPresence: { sente: null, gote: null },
+      trapValueDelta: 0,
       noPromoteMarkCountDelta: 0,
       manaAbsolute: { sente: 10, gote: 7 }, // 両者しきい値以下で dead mana penalty=0
     };
     expect(evaluateCardDigest(d, CARD_SHOGI_VARIANT)).toBe(30);
   });
 
-  it("数値固定: 純粋 trapPresence sente=check_break (他全 0) → +80 cp", () => {
-    // TRAP_VALUE_CHECK_BREAK=80 が変われば fail
+  it("数値固定: 純粋 trapValueDelta=80 (他全 0) → +80 cp (evaluate がそのまま加算)", () => {
+    // S3b: トラップ価値は digest.trapValueDelta に precompute 済 (局面依存)。evaluateCardDigest は
+    // それをそのまま加算するだけ = digest に 80 を入れれば評価値 80 (加算ロジックの pin)。
     const d: CardDigest = {
       manaDelta: 0,
       manaCap: MANA_CAP,
       handValueDelta: 0,
       drawProgressDelta: 0,
-      trapPresence: { sente: "check_break", gote: null },
+      trapValueDelta: 80,
       noPromoteMarkCountDelta: 0,
       manaAbsolute: { sente: 10, gote: 10 },
     };
@@ -741,7 +763,7 @@ describe("PR3-3 C-8 evaluateCardDigest 数値固定 (F-5 解消)", () => {
       manaCap: MANA_CAP,
       handValueDelta: 0,
       drawProgressDelta: 0,
-      trapPresence: { sente: null, gote: null },
+      trapValueDelta: 0,
       noPromoteMarkCountDelta: 0,
       manaAbsolute: { sente: 20, gote: 16 }, // sente overflow=4, gote overflow=0
     };
@@ -755,7 +777,7 @@ describe("PR3-3 C-8 evaluateCardDigest 数値固定 (F-5 解消)", () => {
       manaCap: MANA_CAP,
       handValueDelta: 0,
       drawProgressDelta: 0,
-      trapPresence: { sente: null, gote: null },
+      trapValueDelta: 0,
       noPromoteMarkCountDelta: 0,
       manaAbsolute: { sente: 10, gote: 10 },
     };

--- a/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
+++ b/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
@@ -591,3 +591,63 @@ describe("evaluateAction calibration (S3c: トラップ valueModel 係数校正�
     );
   });
 });
+
+// Issue #235 派生 (Vercel 504 対策、2026-06-10): root アクション評価フェーズの専用 deadline。
+//
+// 背景: deep search (findBestMove) が ctx.deadlineAt を使い切った後に走る root カード評価
+// (engine.ts) と double_move super-action (search.ts) には時間チェックがなく、終盤の高分岐局面
+// (持ち駒ドロップで 2 手目候補 ~130 手) で super-action 1 回 ≈ 4s 超 → Vercel maxDuration 10s
+// 超過の FUNCTION_INVOCATION_TIMEOUT (504) が発生していた。engine が ctx.actionPhaseDeadlineAt
+// を設定し、super-action の first/second move ループが isActionPhaseTimeUp で打ち切る。
+describe("アクション評価フェーズ deadline (Vercel 504 対策、Issue #235 派生)", () => {
+  function buildDmState(): AiTurnState {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    const cs = createInitialCardState(TEST_DECK);
+    cs.hand.sente = [{ instanceId: "dm-test-1", defId: "double_move" as const }];
+    cs.mana.sente = 10;
+    return { gameState: gs, cardState: cs, doubleMove: null, isRoot: true };
+  }
+  const dmAction: TurnAction = {
+    kind: "playCard",
+    cardInstanceId: "dm-test-1",
+    defId: "double_move",
+  };
+
+  it("actionPhaseDeadlineAt 超過時、double_move super-action は即座に NEG_INF (kernel ON/OFF 両経路)", () => {
+    for (const useKernelSearch of [true, false]) {
+      const state = buildDmState();
+      const ctx = createSearchContext({ timeLimitMs: 60_000, useKernelSearch });
+      ctx.actionPhaseDeadlineAt = 0; // 過去時刻 = 即時超過 (1 combo も評価せず打ち切り)
+      const score = evaluateActionWithLookahead(
+        state,
+        dmAction,
+        "sente",
+        CARD_SHOGI_VARIANT,
+        ctx,
+        false,
+        1,
+      );
+      // 全 combo 打ち切り → bestScore/bestScoreIgnoringTadasute とも NEG_INF
+      // → engine 側は move フォールバック (move は予算設定前に評価済) で安全。
+      expect(score).toBe(Number.NEGATIVE_INFINITY);
+    }
+  });
+
+  it("actionPhaseDeadlineAt 未設定 (undefined) は無制限互換 = 従来通り有限スコア", () => {
+    for (const useKernelSearch of [true, false]) {
+      const state = buildDmState();
+      const ctx = createSearchContext({ timeLimitMs: 60_000, useKernelSearch });
+      // actionPhaseDeadlineAt 未設定 (テスト / fixture 生成の決定論互換)
+      const score = evaluateActionWithLookahead(
+        state,
+        dmAction,
+        "sente",
+        CARD_SHOGI_VARIANT,
+        ctx,
+        false,
+        1,
+      );
+      expect(Number.isFinite(score)).toBe(true);
+    }
+  });
+});

--- a/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
+++ b/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
@@ -23,6 +23,7 @@ import { createSearchContext } from "../search-context";
 import { getFullLegalMoves } from "@/lib/shogi/moves";
 import type { AiTurnState } from "../turn/types";
 import type { TurnAction } from "../turn/types";
+import type { GameState } from "@/lib/shogi/types";
 
 const TEST_DECK = [
   { defId: "pawn_return" as const, count: 4 },
@@ -460,5 +461,133 @@ describe("evaluateActionWithLookahead calibration regression (deterministic、PR
     );
     // mana 余剰増 → getDrawValue 増 (DRAW_MANA_SURPLUS_COEF=3 経由) + opp scan は同盤面
     expect(drawHigh).toBeGreaterThan(drawLow);
+  });
+});
+
+// Issue #235 S3c: トラップ valueModel 係数校正 (TRAP_P_MIN 0.05 → 0.10) の決定的回帰テスト。
+//
+// 背景 (計画 docs/plans/issue-235-s3-valuemodel.md §6 M-2 / §12):
+// - S3b でトラップ価値を局面依存 valueModel に cutover 済。S3c は PoC-2 仮係数を校正し本採用。
+// - 検証は noise を含む findBestMove ではなく evaluateActionWithLookahead / evaluateAction を
+//   直接呼び決定論化 (C-13 と同方式)。同一 AiTurnState 上で複数 action のスコアを比較し相対順序を
+//   pin する (盤面 eval が共通成分で打ち消し calibration 差のみ残す)。
+//
+// 校正で担保する挙動 (§12):
+// - no_promote: 相手成り脅威が高い局面で trap > move、脅威なしで move > trap (局面依存が機能)。
+// - check_break: 露出玉ほど valueModel が上がり trap の「決定価値」(vs draw) が上がる。ただし露出玉
+//   そのものでは「玉を安全マスへ逃がす move」が trap より勝つ (能動防御が正。check_break は
+//   checkUsage="forbidden" で王手中は使用不可ゆえ、本来の使い所は **予防セット**)。よって
+//   check_break の決定レベル検証は (a) 露出が trap の対 draw 決定価値を押し上げること、
+//   (b) TRAP_P_MIN=0.10 校正で「静かな盤面 + dead マナ → dormant trap セット (option value)」が
+//   正 EV になり「静かな盤面 + 通常マナ → move (過剰セット抑止)」を保つこと、の 2 点で pin する。
+describe("evaluateAction calibration (S3c: トラップ valueModel 係数校正、deterministic)", () => {
+  function buildTrapState(opts: {
+    board?: (gs: GameState) => void;
+    trapId: "no_promote" | "check_break";
+    manaSente: number;
+    manaGote: number;
+  }): AiTurnState {
+    const gs = createInitialGameState(CARD_SHOGI_VARIANT);
+    gs.moveCount = 50; // phase=1 mid
+    if (opts.board) opts.board(gs);
+    const cs = createInitialCardState([
+      { defId: "no_promote" as const, count: 4 },
+      { defId: "check_break" as const, count: 4 },
+    ]);
+    cs.hand.sente = [
+      { instanceId: `t-${opts.trapId}-0`, defId: opts.trapId },
+      { instanceId: `t-${opts.trapId}-1`, defId: opts.trapId },
+    ];
+    cs.deck.sente = []; // 山札空 → draw を候補外に (純粋に move vs trap を比較)
+    cs.mana.sente = opts.manaSente;
+    cs.mana.gote = opts.manaGote;
+    return { gameState: gs, cardState: cs, doubleMove: null, isRoot: true };
+  }
+
+  function firstMove(state: AiTurnState): TurnAction {
+    const moves = getFullLegalMoves(state.gameState, "sente", CARD_SHOGI_VARIANT);
+    return { kind: "move", move: moves[0] };
+  }
+
+  function trapAction(state: AiTurnState, defId: "no_promote" | "check_break"): TurnAction {
+    return {
+      kind: "playCard",
+      cardInstanceId: state.cardState.hand.sente[0].instanceId,
+      defId,
+      target: undefined,
+    };
+  }
+
+  // 相手 (gote) の未成り駒を gote 成り地点 (下 3 段 rows 6-8) 近傍に置き、no_promote を高価値に。
+  function placePromotionThreat(gs: GameState) {
+    gs.board[5][2] = { type: "pawn", owner: "gote" };
+    gs.board[5][4] = { type: "pawn", owner: "gote" };
+    gs.board[6][6] = { type: "silver", owner: "gote" };
+  }
+
+  // sente 玉を中央 (4,4) へ動かし、gote 飛車で近傍を攻撃 (玉自身は外して王手回避)。
+  // → 自玉露出度が最大化し check_break valueModel が P_MAX に到達。
+  function exposeSenteKing(gs: GameState) {
+    gs.board[8][4] = null;
+    gs.board[4][4] = { type: "king", owner: "sente" };
+    gs.board[2][3] = null; // gote 歩をどけて縦利きを通す
+    gs.board[0][3] = { type: "rook", owner: "gote" }; // 列3縦 → 近傍 (3,3)(4,3)(5,3)
+    gs.board[2][5] = null;
+    gs.board[1][5] = { type: "rook", owner: "gote" }; // 列5縦 → 近傍 (3,5)(4,5)(5,5)
+  }
+
+  const ply = 1; // production 経路 (engine root → evaluateActionWithLookahead lookaheadPly=1)
+  const lookahead = (state: AiTurnState, action: TurnAction) =>
+    evaluateActionWithLookahead(state, action, "sente", CARD_SHOGI_VARIANT, undefined, false, ply);
+
+  it("no_promote: 相手成り脅威ありで trap > move、脅威なしで move > trap (局面依存 flip)", () => {
+    // 脅威あり (通常マナ): no_promote の valueModel が高く (相手成り脅威度 → P_MAX 近傍)、trap を選好。
+    const threat = buildTrapState({
+      board: placePromotionThreat,
+      trapId: "no_promote",
+      manaSente: 8,
+      manaGote: 8,
+    });
+    expect(lookahead(threat, trapAction(threat, "no_promote"))).toBeGreaterThan(
+      lookahead(threat, firstMove(threat)),
+    );
+    // 脅威なし (同マナ・同手札、盤面のみ初期): valueModel は下限値、mana cost を上回らず move を選好。
+    const quiet = buildTrapState({ trapId: "no_promote", manaSente: 8, manaGote: 8 });
+    expect(lookahead(quiet, trapAction(quiet, "no_promote"))).toBeLessThan(
+      lookahead(quiet, firstMove(quiet)),
+    );
+  });
+
+  it("check_break: 露出玉は安全玉より trap の決定価値 (vs draw) が高い (valueModel が決定に伝播)", () => {
+    // evaluateAction(ply=0) の trap = eval(現局面) + valueModel、draw = eval(現局面) + getDrawValue。
+    // 同マナ/手札なら getDrawValue は両局面で同値 → (trap - draw) = valueModel - getDrawValue。
+    // 露出玉 (valueModel 高) と安全玉 (valueModel 下限) の差は valueModel 差そのものに帰着する
+    // (盤面 eval が共通成分で打ち消し)。露出が trap の決定価値を押し上げることを pin。
+    const exposed = buildTrapState({
+      board: exposeSenteKing,
+      trapId: "check_break",
+      manaSente: 8,
+      manaGote: 8,
+    });
+    const safe = buildTrapState({ trapId: "check_break", manaSente: 8, manaGote: 8 });
+    const diff = (s: AiTurnState) =>
+      evaluateAction(s, trapAction(s, "check_break"), "sente", CARD_SHOGI_VARIANT) -
+      evaluateAction(s, { kind: "draw" }, "sente", CARD_SHOGI_VARIANT);
+    expect(diff(exposed)).toBeGreaterThan(diff(safe));
+  });
+
+  it("check_break: 静かな盤面で dead マナなら dormant trap セット、通常マナなら move (S3c 校正 P_MIN=0.10)", () => {
+    // S3c 校正の核: TRAP_P_MIN=0.10 で check_break floor=30cp。マナ上限近接 (19、overflow 3) では
+    // dormant トラップのセットが死にマナ回収 (+12cp) と相まって move をわずかに上回る (option value)。
+    // 通常マナ (8、overflow なし) では floor 30cp < mana cost 効果で move を維持 (過剰セット抑止)。
+    // ※ P_MIN=0.05 (floor 15cp) では dead マナでも move が勝ち flip しない = 本テストが校正の回帰ガード。
+    const dead = buildTrapState({ trapId: "check_break", manaSente: 19, manaGote: 12 });
+    expect(lookahead(dead, trapAction(dead, "check_break"))).toBeGreaterThan(
+      lookahead(dead, firstMove(dead)),
+    );
+    const normal = buildTrapState({ trapId: "check_break", manaSente: 8, manaGote: 8 });
+    expect(lookahead(normal, trapAction(normal, "check_break"))).toBeLessThan(
+      lookahead(normal, firstMove(normal)),
+    );
   });
 });

--- a/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
+++ b/src/lib/shogi/ai/__tests__/evaluate-action.test.ts
@@ -11,13 +11,9 @@
 import { describe, it, expect } from "vitest";
 import { evaluateAction, evaluateActionWithLookahead } from "../search";
 import { computeCardDigest } from "../cards/digest";
-import {
-  getDrawValue,
-  TRAP_VALUE_NO_PROMOTE,
-  TRAP_VALUE_CHECK_BREAK,
-  MANA_DELTA_COEFFICIENT,
-} from "../cards/heuristics";
+import { getDrawValue, MANA_DELTA_COEFFICIENT } from "../cards/heuristics";
 import { CARD_DEFS } from "@/lib/shogi/cards/definitions";
+import { CARD_SPECS } from "@/lib/shogi/cards/card-spec-server";
 import { evaluate } from "../evaluate";
 import { applyMoveForSearch } from "@/lib/shogi/board";
 import { createInitialCardState } from "@/lib/shogi/cards/state";
@@ -153,7 +149,7 @@ describe("evaluateAction (move / draw / playCard 統一評価)", () => {
     expect(resultWithDigest).toBe(evaluate(nextState, CARD_SHOGI_VARIANT, cardDigest));
   });
 
-  it("PR1d-4 playCard no_promote: 現局面評価 + TRAP_VALUE_NO_PROMOTE (sente)", () => {
+  it("S3b playCard no_promote: 現局面評価 + valueModel(no_promote, sente)", () => {
     const state = makeAiTurnState();
     const action: TurnAction = {
       kind: "playCard",
@@ -163,10 +159,10 @@ describe("evaluateAction (move / draw / playCard 統一評価)", () => {
     };
     const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
     const baseEval = evaluate(state.gameState, CARD_SHOGI_VARIANT);
-    expect(result).toBe(baseEval + TRAP_VALUE_NO_PROMOTE);
+    expect(result).toBe(baseEval + CARD_SPECS.no_promote.valueModel(state.gameState, "sente"));
   });
 
-  it("PR1d-4 playCard check_break: 現局面評価 + TRAP_VALUE_CHECK_BREAK (sente)", () => {
+  it("S3b playCard check_break: 現局面評価 + valueModel(check_break, sente)", () => {
     const state = makeAiTurnState();
     const action: TurnAction = {
       kind: "playCard",
@@ -176,10 +172,10 @@ describe("evaluateAction (move / draw / playCard 統一評価)", () => {
     };
     const result = evaluateAction(state, action, "sente", CARD_SHOGI_VARIANT);
     const baseEval = evaluate(state.gameState, CARD_SHOGI_VARIANT);
-    expect(result).toBe(baseEval + TRAP_VALUE_CHECK_BREAK);
+    expect(result).toBe(baseEval + CARD_SPECS.check_break.valueModel(state.gameState, "sente"));
   });
 
-  it("PR1d-4 playCard no_promote: gote 視点は -baseEval + TRAP_VALUE_NO_PROMOTE (符号整合)", () => {
+  it("S3b playCard no_promote: gote 視点は -baseEval + valueModel(no_promote, gote) (符号整合)", () => {
     const state = makeAiTurnState();
     const action: TurnAction = {
       kind: "playCard",
@@ -189,7 +185,7 @@ describe("evaluateAction (move / draw / playCard 統一評価)", () => {
     };
     const result = evaluateAction(state, action, "gote", CARD_SHOGI_VARIANT);
     const baseEval = evaluate(state.gameState, CARD_SHOGI_VARIANT);
-    expect(result).toBe(-baseEval + TRAP_VALUE_NO_PROMOTE);
+    expect(result).toBe(-baseEval + CARD_SPECS.no_promote.valueModel(state.gameState, "gote"));
   });
 });
 
@@ -247,7 +243,7 @@ describe("evaluateActionWithLookahead (PR3-3 C-1)", () => {
     expect(score).toBeGreaterThanOrEqual(draw - 10000); // 範囲 sanity
   });
 
-  it("lookaheadPly=1 playCard no_promote/check_break は opp response + TRAP_VALUE", () => {
+  it("lookaheadPly=1 playCard no_promote/check_break は opp response + valueModel 差 (S3b)", () => {
     const state = makeAiTurnState();
     const npAction: TurnAction = {
       kind: "playCard",
@@ -279,16 +275,17 @@ describe("evaluateActionWithLookahead (PR3-3 C-1)", () => {
       false,
       1,
     );
-    // PR3-3 C-6 wiring 後: 差分は digest 経由で TRAP_VALUE 差 (cb=+80 / np=+50 = +30) と
+    // S3b: 差分は digest 経由の valueModel 差 (check_break - no_promote、局面依存 gross 値) と
     // mana cost 差 (cb=4 / np=3 = +1 → manaDelta -1 → eval -MANA_DELTA_COEFFICIENT) の合算。
-    // 期待値 = (TRAP_VALUE_CHECK_BREAK - TRAP_VALUE_NO_PROMOTE)
+    // 期待値 = (valueModel(check_break) - valueModel(no_promote))
     //        - (CARD_DEFS.check_break.cost - CARD_DEFS.no_promote.cost) * MANA_DELTA_COEFFICIENT
-    //        = 30 - 10 = 20
-    const trapDiff = TRAP_VALUE_CHECK_BREAK - TRAP_VALUE_NO_PROMOTE;
+    const trapDiff =
+      CARD_SPECS.check_break.valueModel(state.gameState, "sente") -
+      CARD_SPECS.no_promote.valueModel(state.gameState, "sente");
     const costDiff =
       (CARD_DEFS["check_break"].cost - CARD_DEFS["no_promote"].cost) *
       MANA_DELTA_COEFFICIENT;
-    expect(cbScore - npScore).toBe(trapDiff - costDiff);
+    expect(cbScore - npScore).toBeCloseTo(trapDiff - costDiff, 6);
   });
 
   it("lookaheadPly=1 playCard double_move は searchDoubleMoveSuperAction に delegate (有限値)", () => {
@@ -404,7 +401,7 @@ describe("evaluateActionWithLookahead calibration regression (deterministic、PR
     expect(drawScore).toBeGreaterThan(moveScore);
   });
 
-  it("trap-only 手札 + 山札空 + マナ上限近接 (mana=19) で trap が move を上回る (digest.trapPresence が機能)", () => {
+  it("trap-only + 山札空 + マナ上限近接 + 相手成り脅威ありで trap が move を上回る (S3b valueModel)", () => {
     const state = buildState({
       moveCount: 50,
       handSize: 2,
@@ -413,6 +410,11 @@ describe("evaluateActionWithLookahead calibration regression (deterministic、PR
       handCardId: "no_promote",
       emptyDeck: true, // draw を候補から外す → 純粋に move vs trap の比較
     });
+    // S3b: no_promote の価値は局面依存 (相手成り脅威度)。相手 (gote) の成り可能・未成り駒を
+    // gote の成り地点近傍 (下段、row5 は初期盤面で空) に配置し、no_promote を高価値局面にする。
+    state.gameState.board[5][2] = { type: "pawn", owner: "gote" };
+    state.gameState.board[5][4] = { type: "pawn", owner: "gote" };
+    state.gameState.board[5][6] = { type: "pawn", owner: "gote" };
     const moveScore = evaluateActionWithLookahead(
       state, someMove(state), "sente", CARD_SHOGI_VARIANT, undefined, false, 1,
     );
@@ -425,10 +427,9 @@ describe("evaluateActionWithLookahead calibration regression (deterministic、PR
     const trapScore = evaluateActionWithLookahead(
       state, trapAction, "sente", CARD_SHOGI_VARIANT, undefined, false, 1,
     );
-    // digest.trapPresence で +TRAP_VALUE_NO_PROMOTE (=50) が opp scan の eval に乗る。
-    // mana 19 → 16 (cost 3 消費) で死にマナ overflow 3 → 0、+12cp 改善。
-    // 合計 +50+12=+62cp が manaDelta -3*10=-30cp と hand -1 の小減を上回り、move を超える。
-    // calibration regression (例: TRAP_VALUE_NO_PROMOTE=0) なら逆転して fail。
+    // digest.trapValueDelta で +valueModel(no_promote, sente) (相手成り脅威で高値) が opp scan の
+    // eval に乗る + 死にマナ回収 (mana 19→16 で overflow 3→0、+12cp)。合計が manaDelta -30cp と
+    // hand -1 の小減を上回り move を超える。calibration regression (脅威0でも trap 選好等) なら fail。
     expect(trapScore).toBeGreaterThan(moveScore);
   });
 

--- a/src/lib/shogi/ai/__tests__/perf-bench-card-usage.test.ts
+++ b/src/lib/shogi/ai/__tests__/perf-bench-card-usage.test.ts
@@ -161,7 +161,7 @@ function makeScenarios(): BenchScenario[] {
     {
       // (f) 手札 trap のみ + 山札空 + マナ上限近接 → trap セットを期待
       // 山札空で canDraw=false (draw を候補から除外)、純粋に move vs trap の比較に。
-      // digest.trapPresence で +TRAP_VALUE_NO_PROMOTE + 死にマナペナルティ改善で move を上回る。
+      // S3b: digest.trapValueDelta (valueModel 局面依存値) + 死にマナペナルティ改善で move を上回る。
       label: "calib-trap-only-no-draw",
       state: midState,
       player: "sente",

--- a/src/lib/shogi/ai/cards/digest.ts
+++ b/src/lib/shogi/ai/cards/digest.ts
@@ -1,7 +1,7 @@
 // Issue #193 / PR1d-1: cardDigest 評価ダイジェスト構造 + 計算/評価関数。
 //
 // 設計の核 (親計画 md L350-356 / PR1d 計画 md L178-189):
-// - 探索開始時に root で 1 回だけ computeCardDigest(cardState) を呼ぶ
+// - 探索開始時に root で 1 回だけ computeCardDigest(cardState, gameState) を呼ぶ
 // - evaluate の戻り値に evaluateCardDigest(cardDigest, variant) を加算 (1 op、ホットパス影響無視可)
 // - cardDigest を引数として子ノードに伝播 (= ホットパスでの再計算を構造的に禁止、W-1 反映)
 // - sente 絶対視点で固定 (W-2 反映、evaluate 既存実装 sign = piece.owner === "sente" ? 1 : -1 と符号整合)
@@ -11,21 +11,20 @@
 // - PR1d-3: doubleMoveActive は **スキップ** (判断2=案B)。CardGameState に doubleMove
 //   フィールドが無く production root では常に null のため root スカラー化が無意味。
 //   二手指し価値は search.ts の super-action 局所探索が直接捕捉する。
-// - PR1d-4 (本コミット): trapPresence (TrapInstance.defId 抽出) +
-//   noPromoteMarkCountDelta (ギャップ1=案A: 玉位置非依存の sente-gote マーク数差。
-//   計画 md L1310 の positions 配列は evaluateCardDigest が GameState/玉位置を
-//   持たず proximity 不可のため単純カウント差に簡略化、ZZ 反映)。
+// - PR1d-4: noPromoteMarkCountDelta (ギャップ1=案A: 玉位置非依存の sente-gote マーク数差)。
+// - Issue #235 S3b: トラップ価値を trapPresence (defId) + 固定 TRAP_VALUE_* から、gameState を
+//   供給して局面依存 valueModel で precompute する `trapValueDelta` (cp) へ cutover。digest は
+//   GameState を持たないため evaluate 時の再計算は不可 = root スカラー方式 (W-1) を維持しつつ局面依存化。
 
-import type { CardGameState, CardId } from "../../cards/types";
-import type { RuleVariant } from "../../types";
+import type { CardGameState } from "../../cards/types";
+import type { GameState, RuleVariant } from "../../types";
 import { MANA_CAP } from "../../cards/definitions";
+import { getCardValue } from "../../cards/card-spec-server";
 import {
   MANA_DELTA_COEFFICIENT,
   HAND_VALUE_BASE,
   HAND_VALUE_DECAY,
   DRAW_PROGRESS_COEFFICIENT,
-  TRAP_VALUE_NO_PROMOTE,
-  TRAP_VALUE_CHECK_BREAK,
   NO_PROMOTE_MARK_COEFFICIENT,
   DEAD_MANA_THRESHOLD,
   DEAD_MANA_PENALTY_COEF,
@@ -40,10 +39,13 @@ export interface CardDigest {
   handValueDelta: number;
   // drawProgress.sente - drawProgress.gote (W-2: sente 絶対視点)
   drawProgressDelta: number;
-  // PR1d-4: 盤上トラップ存在。各プレイヤーの TrapInstance.defId (なければ null)。
-  // W-2 整合: sente/gote 両者を絶対視点で保持し、evaluateCardDigest で
-  // 「sente 盤上トラップ = +、gote 盤上トラップ = -」に変換。
-  trapPresence: { sente: CardId | null; gote: CardId | null };
+  // Issue #235 S3b: 盤上トラップの局面依存価値 (sente 絶対視点、cp)。
+  // sente 盤上トラップ = +valueModel(sente)、gote = -valueModel(gote)。valueModel は
+  // 局面依存 (check_break=自玉露出度 / no_promote=相手成り脅威度、card-spec-server S3a) の
+  // gross 値。**S3a 以前は trapPresence (defId) + 固定 TRAP_VALUE_* だったが、digest 計算へ
+  // gameState を供給して局面依存値を precompute する方式へ cutover** (digest は GameState を
+  // 持たないため evaluate 時の再計算は不可 = W-1 root スカラー方式を維持しつつ局面依存化)。
+  trapValueDelta: number;
   // PR1d-4 (ギャップ1=案A): no_promote マーク数差 = sente 数 - gote 数。
   // W-2 sente 絶対視点。計画 md L1310 の positions 配列 + proximity 評価は
   // evaluateCardDigest が GameState/玉位置非依存 (W-1 root スカラー方式) のため
@@ -61,19 +63,16 @@ export interface CardDigest {
  * W-2 反映: sente 絶対視点で固定 (player 引数なし)。evaluate 既存実装と符号整合し、
  * 観戦モードでも両プレイヤーで同じ digest を共有可能。
  */
-export function computeCardDigest(cardState: CardGameState): CardDigest {
+export function computeCardDigest(
+  cardState: CardGameState,
+  gameState?: GameState,
+): CardDigest {
   const manaDelta = cardState.mana.sente - cardState.mana.gote;
   const handValueDelta =
     computeHandValue(cardState.hand.sente.length) -
     computeHandValue(cardState.hand.gote.length);
   const drawProgressDelta =
     cardState.drawProgress.sente - cardState.drawProgress.gote;
-  // PR1d-4: cardState.trap は Record<Player, TrapInstance | null>。
-  // TrapInstance.defId を抽出 (盤上トラップなしは null)。
-  const trapPresence = {
-    sente: cardState.trap.sente?.defId ?? null,
-    gote: cardState.trap.gote?.defId ?? null,
-  };
   // PR1d-4 (ギャップ1=案A): cardState.noPromoteMarks は Record<Player, PieceMark[]>。
   // 玉位置非依存の単純カウント差 (sente 数 - gote 数、W-2 sente 絶対視点)。
   const noPromoteMarkCountDelta =
@@ -83,11 +82,30 @@ export function computeCardDigest(cardState: CardGameState): CardDigest {
     manaCap: MANA_CAP,
     handValueDelta,
     drawProgressDelta,
-    trapPresence,
+    // S3b: 盤上トラップの局面依存価値を gameState から precompute (W-1 root スカラー)。
+    trapValueDelta: computeTrapValueDelta(cardState, gameState),
     noPromoteMarkCountDelta,
     // PR3-1: 死にマナペナルティ用に絶対値を併せて保持 (O(1) 追加のみ)。
     manaAbsolute: { sente: cardState.mana.sente, gote: cardState.mana.gote },
   };
+}
+
+// Issue #235 S3b: 盤上トラップの sente 絶対視点価値 (cp)。
+// sente トラップ = +valueModel(sente)、gote トラップ = -valueModel(gote)。valueModel は局面依存
+// (card-spec-server、S3a) で gross 値を返す。**gameState 省略時はトラップ価値 0** (= 局面情報なしで
+// 局面依存値を算出不可。トラップ非保有局面の digest や trap 非対象テストで使用)。production の探索/engine は
+// 常に gameState を渡す。コスト (マナ消費) は AI 側 mana 会計が別途反映するため本値はコストを引かない。
+function computeTrapValueDelta(
+  cardState: CardGameState,
+  gameState?: GameState,
+): number {
+  if (!gameState) return 0;
+  let v = 0;
+  const senteDefId = cardState.trap.sente?.defId;
+  if (senteDefId) v += getCardValue(senteDefId, gameState, "sente");
+  const goteDefId = cardState.trap.gote?.defId;
+  if (goteDefId) v -= getCardValue(goteDefId, gameState, "gote");
+  return v;
 }
 
 // 単調減衰関数 (F-5 仮基準): handSize が増えるほど追加 1 枚の価値が下がる。
@@ -111,8 +129,9 @@ export function evaluateCardDigest(
     digest.manaDelta * MANA_DELTA_COEFFICIENT +
     digest.handValueDelta +
     digest.drawProgressDelta * DRAW_PROGRESS_COEFFICIENT;
-  // PR1d-4: 盤上トラップ価値 (sente 絶対視点: sente 盤上トラップ = +、gote = -)
-  value += evaluateTrapPresence(digest.trapPresence);
+  // S3b: 盤上トラップの局面依存価値 (sente 絶対視点)。computeCardDigest/updateCardDigest が
+  // gameState から valueModel で precompute 済 (W-1 root スカラー方式維持)。
+  value += digest.trapValueDelta;
   // PR1d-4 (ギャップ1=案A): no_promote マーク数差 × 係数 (玉位置非依存)。
   // sente 絶対視点: sente の no_promote マークが多いほど + (敵の成りを抑止して有利)。
   value += digest.noPromoteMarkCountDelta * NO_PROMOTE_MARK_COEFFICIENT;
@@ -128,19 +147,6 @@ export function evaluateCardDigest(
   // 本項目 (digest 評価) 単独では不十分。
   value += evaluateDeadManaPenalty(digest);
   return value;
-}
-
-// 盤上トラップの sente 絶対視点価値。sente の盤上トラップは正、gote は負。
-// check_break は王手回避用途で no_promote より戦略価値が高い (定数で表現)。
-function evaluateTrapPresence(
-  trapPresence: CardDigest["trapPresence"],
-): number {
-  let v = 0;
-  if (trapPresence.sente === "no_promote") v += TRAP_VALUE_NO_PROMOTE;
-  else if (trapPresence.sente === "check_break") v += TRAP_VALUE_CHECK_BREAK;
-  if (trapPresence.gote === "no_promote") v -= TRAP_VALUE_NO_PROMOTE;
-  else if (trapPresence.gote === "check_break") v -= TRAP_VALUE_CHECK_BREAK;
-  return v;
 }
 
 // PR3-1: 死にマナペナルティ (sente 絶対視点)。
@@ -166,10 +172,9 @@ function evaluateDeadManaPenalty(digest: CardDigest): number {
  * - 比較は length / 数値 === / null チェックのみで O(1)、変化がないフィールドは
  *   exp() 呼び出しもスキップ。
  *
- * 振る舞いキープ (本 PR スコープ):
- * - 本関数は新規追加のみで production コードからは未呼び出し。PR3-3 で wiring。
- * - 等価性: updateCardDigest(computeCardDigest(prev), prev, new) は computeCardDigest(new) と
- *   完全に同じ値を返す (本ファイル隣接の `card-digest.test.ts` 等価性 fixture で保証)。
+ * 振る舞いキープ:
+ * - 等価性: updateCardDigest(computeCardDigest(prev, gs), prev, new, gs) は computeCardDigest(new, gs)
+ *   と完全に同じ値を返す (同一 gameState 供給時。本ファイル隣接の `card-digest.test.ts` 等価性 fixture で保証)。
  *
  * 注意 (W-2 sente 絶対視点維持):
  * - 全フィールドの符号方針は computeCardDigest と同一 (sente が有利なら正)。
@@ -183,6 +188,7 @@ export function updateCardDigest(
   prev: CardDigest,
   prevCardState: CardGameState,
   newCardState: CardGameState,
+  gameState?: GameState,
 ): CardDigest {
   const manaChanged =
     prevCardState.mana.sente !== newCardState.mana.sente ||
@@ -193,15 +199,16 @@ export function updateCardDigest(
   const drawChanged =
     prevCardState.drawProgress.sente !== newCardState.drawProgress.sente ||
     prevCardState.drawProgress.gote !== newCardState.drawProgress.gote;
-  // PR3-3 C-9 (レビュー F-10) 補足: trap 比較は `defId` のみで `instanceId` は無視。
-  // digest.trapPresence は CardId | null 型で `evaluateTrapPresence` も defId のみに
-  // 依存するため (同 defId のトラップは同等価値)、instanceId 差分は digest 変化を
-  // 引き起こさない。hand 比較 (length のみ) と整合する設計判断。
+  // S3b: trap 比較は `defId` のみで `instanceId` は無視 (同 defId のトラップは同 valueModel)。
+  // trap 変化時のみ valueModel で trapValueDelta を再算出する (gameState 供給時)。trap 不変なら
+  // prev.trapValueDelta を流用 = root スカラー方式維持 (盤面が動いてもトラップ価値は再計算しない、
+  // R-2: 局面依存値は root 1 回評価。深い再計算は S4)。
+  const prevSenteTrapDefId = prevCardState.trap.sente?.defId ?? null;
+  const prevGoteTrapDefId = prevCardState.trap.gote?.defId ?? null;
   const senteTrapDefId = newCardState.trap.sente?.defId ?? null;
   const goteTrapDefId = newCardState.trap.gote?.defId ?? null;
   const trapChanged =
-    senteTrapDefId !== prev.trapPresence.sente ||
-    goteTrapDefId !== prev.trapPresence.gote;
+    senteTrapDefId !== prevSenteTrapDefId || goteTrapDefId !== prevGoteTrapDefId;
   const marksChanged =
     prevCardState.noPromoteMarks.sente.length !==
       newCardState.noPromoteMarks.sente.length ||
@@ -224,9 +231,9 @@ export function updateCardDigest(
     drawProgressDelta: drawChanged
       ? newCardState.drawProgress.sente - newCardState.drawProgress.gote
       : prev.drawProgressDelta,
-    trapPresence: trapChanged
-      ? { sente: senteTrapDefId, gote: goteTrapDefId }
-      : prev.trapPresence,
+    trapValueDelta: trapChanged
+      ? computeTrapValueDelta(newCardState, gameState)
+      : prev.trapValueDelta,
     noPromoteMarkCountDelta: marksChanged
       ? newCardState.noPromoteMarks.sente.length -
         newCardState.noPromoteMarks.gote.length

--- a/src/lib/shogi/ai/cards/heuristics.ts
+++ b/src/lib/shogi/ai/cards/heuristics.ts
@@ -81,15 +81,15 @@ export const DOUBLE_MOVE_TOP_K = 10;
 //   脅威度) へ移行し、本ファイルから撤去した。digest/search は getCardValue 経由で評価する (依存反転)。
 export const NO_PROMOTE_MARK_COEFFICIENT = 30;
 
-// PR1d-4 コミット 3 (action-generator トラップ系候補生成) で使用予定の
-// 使用条件ヒューリスティクスしきい値 (計画 md L1392-1394、コミット 3 で参照):
-//   ・EARLY_GAME_THRESHOLD: no_promote を「序盤に 1 回」セットする両者合計 ply 上限
-//   ・MIN_MANA_RESERVE_FOR_TRAP: トラップセット時に確保したいマナ余裕
-//   ・CHECK_BREAK_TRIGGER_THRESHOLD: check_break をプリエンプティブセットする
-//     玉の安全度悪化しきい値 (cp、負方向)
+// EARLY_GAME_THRESHOLD: computePhaseStage の序盤(0)→中盤(1)境界 (両者合計 ply)。
+// no_promote 序盤判定とも共通閾値で意味整合 (PR1d-4)。
 export const EARLY_GAME_THRESHOLD = 40;
-export const MIN_MANA_RESERVE_FOR_TRAP = 6;
-export const CHECK_BREAK_TRIGGER_THRESHOLD = -200;
+
+// Issue #235 S3c: 旧 MIN_MANA_RESERVE_FOR_TRAP / CHECK_BREAK_TRIGGER_THRESHOLD は
+// 「PR1d-4 コミット 3 で使用予定」のしきい値方式トラップ候補生成ヒューリスティクスだったが、
+// S3 で連続値 valueModel (card-spec-server、トラップ価値を P_trigger × E_damage で局面依存算出)
+// へ移行し、しきい値方式は不採用となった (計画 docs/plans/issue-235-s3-valuemodel.md §5 L-2)。
+// 実参照ゼロのデッドコードのため S3c で削除 (AGENTS.md 実装ガイド10「デッドコードを残さない」)。
 
 // ===== PR3-1: 局面段階判定 + 動的ドロー価値 + 死にマナペナルティ =====
 //

--- a/src/lib/shogi/ai/cards/heuristics.ts
+++ b/src/lib/shogi/ai/cards/heuristics.ts
@@ -72,15 +72,13 @@ export const DOUBLE_MOVE_TOP_K = 10;
 // 将来 reducer の doubleMove を route.ts 経由で AI に渡す統合時に再検討
 // (計画 md PR1d-3 コミット 3 セクションに ZZ 反映)。
 
-// PR1d-4: トラップ系カード (no_promote / check_break) の cardDigest 評価係数
-// (sente 絶対視点、PIECE_VALUES と整合する cp 単位、bench で調整、計画 md L1390-1395)。
-//   ・TRAP_VALUE_NO_PROMOTE: 盤上 no_promote トラップ 1 枚の価値
-//   ・TRAP_VALUE_CHECK_BREAK: 盤上 check_break トラップ 1 枚の価値 (王手対応で no_promote より高評価)
+// PR1d-4: no_promote マーク数差の cardDigest 評価係数 (sente 絶対視点、cp 単位)。
 //   ・NO_PROMOTE_MARK_COEFFICIENT: no_promote マーク 1 個あたり価値 (ギャップ1=案A の
 //     玉位置非依存カウント差に対する係数。計画 md L1395 NO_PROMOTE_PROXIMITY_BONUS=30 を
 //     proximity でなく単純カウント差の係数として流用、ZZ 反映)
-export const TRAP_VALUE_NO_PROMOTE = 50;
-export const TRAP_VALUE_CHECK_BREAK = 80;
+// 注 (Issue #235 S3b): 盤上トラップ自体の価値 (旧 TRAP_VALUE_NO_PROMOTE=50 / CHECK_BREAK=80 の
+//   固定係数) は局面依存 valueModel (card-spec-server、check_break=自玉露出度 / no_promote=相手成り
+//   脅威度) へ移行し、本ファイルから撤去した。digest/search は getCardValue 経由で評価する (依存反転)。
 export const NO_PROMOTE_MARK_COEFFICIENT = 30;
 
 // PR1d-4 コミット 3 (action-generator トラップ系候補生成) で使用予定の

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -9,6 +9,7 @@ import {
 import {
   createSearchContext,
   finalizeStats,
+  isActionPhaseTimeUp,
   type SearchStats,
 } from "./search-context";
 import { evaluate, evaluateWithBreakdown } from "./evaluate";
@@ -95,6 +96,17 @@ const BLUNDER_GUARD_TIE_MARGIN = 150;
 const BEGINNER_TADASUTE_ALLOW_RATE = 0.3;
 
 // hasHangingPiece は PR3-3 C-3 で blunder-guard.ts へ移動 (search.ts double_move でも利用するため共通化)
+
+// Issue #235 派生 (Vercel 504 対策、2026-06-10): root アクション評価フェーズ (カード/ドロー
+// lookahead + double_move super-action) の時間予算 (timeLimitMs 比)。
+// deep search (findBestMove) は timeLimitMs を使い切ってから返るため、その後に走る本フェーズを
+// bound しないと総実行時間が無制限になる。実測 (終盤近似局面、持ち駒 飛+歩3 = 合法手 130):
+// 二手指し super-action 1 回 ≈ 4.3s、3 枚重複で計 11.4s → Vercel maxDuration 10s 超過で
+// FUNCTION_INVOCATION_TIMEOUT (504) が発生していた。
+// 0.4 = expert 3500ms × 0.4 = 1400ms。最悪総時間 ≈ deep 3.5s + 本フェーズ 1.4s +
+// blunder guard 0.2s ≈ 5.1s で maxDuration 10s に対し約 2 倍の安全余裕を確保する。
+// 予算超過時は評価済み候補までで打ち切る (move は常に最初に評価済 = 安全フォールバック)。
+const ACTION_PHASE_BUDGET_RATIO = 0.4;
 
 // 難易度の表示名
 export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
@@ -315,6 +327,14 @@ export function findBestMoveWithStats(
     };
     const allActions = rules.getLegalActions(aiTurnState, player);
 
+    // Issue #235 派生 (Vercel 504 対策): 本フェーズ専用の hard deadline を設定。
+    // deep search が ctx.deadlineAt を使い切った後なので、ここから ACTION_PHASE_BUDGET_RATIO
+    // 分の新規予算を切る。super-action / 候補ループが isActionPhaseTimeUp で参照する。
+    // fixture 生成 (options.maxDepth 指定) では effectiveTimeLimitMs = MAX_SAFE_INTEGER のため
+    // 実質無制限 = 決定論を維持 (時間でテスト結果が変わらない)。
+    ctx.actionPhaseDeadlineAt =
+      performance.now() + effectiveTimeLimitMs * ACTION_PHASE_BUDGET_RATIO;
+
     // PR3-3 C-2: 旧 evaluateAction (depth=0 評価) を evaluateActionWithLookahead に
     // 置換。各 TurnAction 候補に「相手 1 ply 最善応答」を加えた lookahead score で
     // 比較することで、move 側の見かけ +100cp tactical が opp 応答後に ±0 へ収束し、
@@ -333,6 +353,15 @@ export function findBestMoveWithStats(
 
     for (const action of allActions) {
       if (action.kind === "move") continue; // move は上で評価済
+      // Issue #235 派生 (Vercel 504 対策): フェーズ予算超過で残候補を打ち切り。
+      // move は先に評価済 (bestActionScore 初期値) のため、打ち切っても安全に move へ
+      // フォールバックする。発生は稀 (終盤の高分岐局面) なので warn で観測可能にする。
+      if (isActionPhaseTimeUp(ctx)) {
+        console.warn(
+          "[ai-engine] action-phase budget exceeded; remaining card/draw candidates skipped",
+        );
+        break;
+      }
       // applyTadasuteGuard 時、カード適用がタダ捨てになる手は -Inf を返し採用されない。
       const score = evaluateActionWithLookahead(
         aiTurnState,

--- a/src/lib/shogi/ai/engine.ts
+++ b/src/lib/shogi/ai/engine.ts
@@ -191,7 +191,7 @@ export function findBestMoveWithStats(
   // ガードと二重化することで standard variant への影響を完全排除。
   const cardDigest: CardDigest | undefined =
     options.cardState !== undefined && variant.id === "card-shogi"
-      ? computeCardDigest(options.cardState)
+      ? computeCardDigest(options.cardState, state)
       : undefined;
 
   const ctx = createSearchContext({

--- a/src/lib/shogi/ai/search-context.ts
+++ b/src/lib/shogi/ai/search-context.ts
@@ -62,6 +62,14 @@ export interface SearchContext {
   // 既定 false。AI 探索の lookahead は手番時間を持たないため manaCharge の早指し判定は
   // 本来不要だが、kernel の makeMoveWithEffects に正しく伝播するため保持する。
   spectatorMode?: boolean;
+  // Issue #235 派生 (Vercel 504 対策、2026-06-10): root アクション評価フェーズ (カード/ドロー
+  // lookahead + double_move super-action) 専用の hard deadline (performance.now() 基準)。
+  // deep search は deadlineAt (= startedAt + timeLimitMs) を使い切ってから返るため、その後に
+  // 走るアクション評価は別予算で bound しないと無制限になる (実測: 終盤の二手指し super-action
+  // 1 回 ≈ 4s 超 → Vercel maxDuration 10s 超過で FUNCTION_INVOCATION_TIMEOUT)。
+  // engine.ts が ACTION_PHASE_BUDGET_RATIO から設定する。未設定 (undefined) = 無制限
+  // (既存テスト / fixture 生成 (maxDepth 指定) の決定論を保つ互換動作)。
+  actionPhaseDeadlineAt?: number;
 }
 
 export interface CreateSearchContextOptions {
@@ -111,6 +119,17 @@ export function shouldStop(ctx: SearchContext): boolean {
     }
   }
   return false;
+}
+
+// root アクション評価フェーズの時間切れ判定 (Vercel 504 対策)。
+// 呼び出し頻度は super-action の combo 単位 (~数百〜千回/手、1 combo ≈ ms 級) のため、
+// node カウンタによる間引きは不要 (performance.now() 直呼びのコストは combo 処理の 1/10000 以下)。
+// ctx 未渡し / actionPhaseDeadlineAt 未設定の経路 (テスト・fixture) では常に false = 無制限互換。
+export function isActionPhaseTimeUp(ctx: SearchContext | undefined): boolean {
+  return (
+    ctx?.actionPhaseDeadlineAt !== undefined &&
+    performance.now() >= ctx.actionPhaseDeadlineAt
+  );
 }
 
 // 探索終了時に SearchStats を構築する。

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -8,11 +8,10 @@ import { applyMoveForSearch } from "../board";
 import { evaluate, scoreMoveForOrdering } from "./evaluate";
 import { cardResultIntroducesTadasute, hasHangingPiece } from "./blunder-guard";
 import { simulateCardEffect } from "../cards/effects";
+import { getCardValue } from "../cards/card-spec-server";
 import {
   getDrawValue,
   DOUBLE_MOVE_TOP_K,
-  TRAP_VALUE_NO_PROMOTE,
-  TRAP_VALUE_CHECK_BREAK,
 } from "./cards/heuristics";
 import { CurrentRules } from "./turn/current-rules";
 import type { AiTurnState, TurnAction } from "./turn/types";
@@ -740,8 +739,9 @@ export function findBestMove(
 //   Number.NEGATIVE_INFINITY を返して候補から除外
 // - playCard "double_move": PR1d-3 で searchDoubleMoveSuperAction (2 手指し組合せの
 //   depth=0 局所探索、判断 1 = 案 B) に委譲
-// - playCard "no_promote" / "check_break": PR1d-4 で現局面評価 + TRAP_VALUE_* 加算
-//   (targeting:none で盤面不変、トラップセット増分価値の固定近似、bench で係数調整)
+// - playCard "no_promote" / "check_break": 現局面評価 + valueModel 局面依存値 (S3b)
+//   (targeting:none で盤面不変、トラップセット増分価値。check_break=自玉露出度 / no_promote=
+//    相手成り脅威度で gross 値を算出、固定 TRAP_VALUE_* を脱却)
 //
 // 注: depth=0 評価のため、move の深く読んだスコア (findBestMove 反復深化結果) との
 // 直接比較は不公平だが、engine.ts root 経路 (PR1d-2) で move も evaluateAction で
@@ -776,18 +776,15 @@ export function evaluateAction(
       if (action.defId === "double_move") {
         return searchDoubleMoveSuperAction(state, player, variant, ctx, excludeTadasute);
       }
-      // PR1d-4: トラップ系 (no_promote / check_break) は targeting:none で盤面不変
-      // (simulateCardEffect は null)。カード使用で自盤面にトラップがセットされる
-      // 増分価値を現局面評価 (player 視点) に加算 (= draw の getDrawValue 加算と同型)。
-      // 「いつ使うべきか」(序盤 / king safety) の精度は固定価値の近似で代替し、
-      // heuristics.ts の TRAP_VALUE_* を bench で調整 (計画 md L1267 警告に対応)。
+      // PR1d-4 / S3b: トラップ系 (no_promote / check_break) は targeting:none で盤面不変
+      // (simulateCardEffect は null)。カード使用で自盤面にトラップがセットされる増分価値を
+      // 現局面評価 (player 視点) に加算 (= draw の getDrawValue 加算と同型)。
+      // S3b: 固定 TRAP_VALUE_* を脱却し valueModel (局面依存 gross 値、player 視点) へ統一
+      // (check_break=自玉露出度 / no_promote=相手成り脅威度。card-spec-server、ai → L1 依存反転)。
       if (action.defId === "no_promote" || action.defId === "check_break") {
         const trapRaw = evaluate(state.gameState, variant, cardDigest);
         const trapSigned = player === "sente" ? trapRaw : -trapRaw;
-        const trapBonus =
-          action.defId === "no_promote"
-            ? TRAP_VALUE_NO_PROMOTE
-            : TRAP_VALUE_CHECK_BREAK;
+        const trapBonus = getCardValue(action.defId, state.gameState, player);
         return trapSigned + trapBonus;
       }
       const nextGameState = simulateCardEffect(
@@ -894,11 +891,11 @@ function searchDoubleMoveSuperAction(
   const prevDigest =
     ctx?.cardDigest ??
     (variant.id === "card-shogi"
-      ? computeCardDigest(state.cardState)
+      ? computeCardDigest(state.cardState, state.gameState)
       : undefined);
   const innerDigest =
     prevDigest !== undefined
-      ? updateCardDigest(prevDigest, state.cardState, newCardState)
+      ? updateCardDigest(prevDigest, state.cardState, newCardState, afterCardWiredCS.gameState)
       : undefined;
 
   // Step 2: 1 手目候補生成 (move-only)。性能配慮で heuristic 上位 K 手に絞る。
@@ -992,7 +989,7 @@ function searchDoubleMoveSuperActionKernel(
   // digest prev (root)。ctx 未渡フォールバックは OFF 版 (computeCardDigest) と同方針。
   const prevDigest =
     ctx.cardDigest ??
-    (variant.id === "card-shogi" ? computeCardDigest(state.cardState) : undefined);
+    (variant.id === "card-shogi" ? computeCardDigest(state.cardState, state.gameState) : undefined);
 
   // Step 2: 1 手目候補生成 (move-only)。OFF 同様 heuristic 上位 K 手に絞る。
   const firstMovesAll = getSearchLegalMoves(worldDM.gameState, player, variant);
@@ -1017,7 +1014,7 @@ function searchDoubleMoveSuperActionKernel(
     if (afterFirst.turnEnded) {
       const innerDigest =
         prevDigest !== undefined
-          ? updateCardDigest(prevDigest, state.cardState, worldF.cardState)
+          ? updateCardDigest(prevDigest, state.cardState, worldF.cardState, worldF.gameState)
           : undefined;
       const raw = evaluate(worldF.gameState, variant, innerDigest);
       const score = player === "sente" ? raw : -raw;
@@ -1041,7 +1038,7 @@ function searchDoubleMoveSuperActionKernel(
       // per-combo digest (kernel の worldS.cardState = cost 正確消費 + lazy drawProgress 反映済)。
       const innerDigest =
         prevDigest !== undefined
-          ? updateCardDigest(prevDigest, state.cardState, worldS.cardState)
+          ? updateCardDigest(prevDigest, state.cardState, worldS.cardState, worldS.gameState)
           : undefined;
       const raw = evaluate(worldS.gameState, variant, innerDigest);
       const score = player === "sente" ? raw : -raw;
@@ -1322,11 +1319,11 @@ export function evaluateActionWithLookahead(
   // - standard variant (variant.id !== "card-shogi") では digest は意味を持たないため undefined のまま
   let prevDigest = ctx?.cardDigest;
   if (prevDigest === undefined && variant.id === "card-shogi") {
-    prevDigest = computeCardDigest(state.cardState);
+    prevDigest = computeCardDigest(state.cardState, state.gameState);
   }
   const newDigest =
     prevDigest !== undefined
-      ? updateCardDigest(prevDigest, state.cardState, applied.cardState)
+      ? updateCardDigest(prevDigest, state.cardState, applied.cardState, applied.gameState)
       : prevDigest;
 
   const oppScore = getOpponentResponseScore(
@@ -1344,9 +1341,8 @@ export function evaluateActionWithLookahead(
     return oppScore + getDrawValue(state.gameState, player, state.cardState);
   }
 
-  // PR3-3 C-6: トラップ系 (no_promote / check_break) は digest.trapPresence で
-  // TRAP_VALUE_* が既に反映されている (newDigest.trapPresence に当該 trap が set)。
-  // 旧実装は ここで TRAP_VALUE_* を明示加算していたが、digest 経由で自然に反映される
-  // ようになったので削除 (重複加算回避)。
+  // PR3-3 C-6 / S3b: トラップ系 (no_promote / check_break) の価値は newDigest.trapValueDelta に
+  // 反映済 (updateCardDigest が applied.gameState から valueModel で局面依存値を precompute、
+  // opp scan の各 evaluate に乗る)。ここでの明示加算は不要 (重複加算回避)。
   return oppScore;
 }

--- a/src/lib/shogi/ai/search.ts
+++ b/src/lib/shogi/ai/search.ts
@@ -35,6 +35,7 @@ import { getCaptureMovesForSearch, getPromotionMovesForSearch } from "./captureG
 import {
   MAX_DEPTH,
   createSearchContext,
+  isActionPhaseTimeUp,
   shouldStop,
   type SearchContext,
 } from "./search-context";
@@ -912,6 +913,10 @@ function searchDoubleMoveSuperAction(
   let bestScoreIgnoringTadasute = NEG_INF; // PR3-3 C-3: フォールバック (R-3)
   // Step 3: 各 1 手目 × 全 2 手目を局所探索、2 手指し後を depth=0 評価
   for (const firstMove of firstMoves) {
+    // Issue #235 派生 (Vercel 504 対策): フェーズ予算超過で打ち切り (評価済み combo の
+    // best を返す = 時間制限探索の標準挙動。全滅時は NEG_INF → engine が move へフォールバック)。
+    // 実測で 1 super-action ≈ 4s 超 (終盤、2 手目に持ち駒ドロップ ~130 手) のため必須。
+    if (isActionPhaseTimeUp(ctx)) break;
     const afterFirst = rules.applyAction(afterCardWiredCS, { kind: "move", move: firstMove });
     // 不変条件: 二手指し 1 手目は turnEnded=false (= player 反転禁止の構造的保証)
     if (afterFirst.turnEnded) {
@@ -922,6 +927,8 @@ function searchDoubleMoveSuperAction(
     const secondMoves = getSearchLegalMoves(afterFirst.next.gameState, player, variant);
     if (secondMoves.length === 0) continue; // 2 手目なしはこの 1 手目をスキップ
     for (const secondMove of secondMoves) {
+      // 504 対策: combo 単位 (~ms 級処理) での時間チェック。now() コストは無視できる。
+      if (isActionPhaseTimeUp(ctx)) break;
       const afterSecond = rules.applyAction(afterFirst.next, {
         kind: "move",
         move: secondMove,
@@ -1005,6 +1012,10 @@ function searchDoubleMoveSuperActionKernel(
   let bestScoreIgnoringTadasute = NEG_INF;
 
   for (const firstMove of firstMoves) {
+    // Issue #235 派生 (Vercel 504 対策): OFF 版と同様、フェーズ予算超過で打ち切り。
+    // kernel 経路は combo ごとに applyTurnAction (makeMoveWithEffects = evaluateGameEnd 込み
+    // ≈ ms 級) を呼ぶため、ここが 504 の主因だった (実測 1 super-action ≈ 4.3s)。
+    if (isActionPhaseTimeUp(ctx)) break;
     const afterFirst = applyTurnAction(worldDM, { kind: "move", move: firstMove }, { spectatorMode });
     const worldF = afterFirst.world;
 
@@ -1027,6 +1038,8 @@ function searchDoubleMoveSuperActionKernel(
     const secondMoves = getSearchLegalMoves(worldF.gameState, player, variant);
     if (secondMoves.length === 0) continue;
     for (const secondMove of secondMoves) {
+      // 504 対策: combo 単位での時間チェック (OFF 版と同方針)。
+      if (isActionPhaseTimeUp(ctx)) break;
       const afterSecond = applyTurnAction(worldF, { kind: "move", move: secondMove }, { spectatorMode });
       const worldS = afterSecond.world;
       // 不変条件: 2 手目で turnEnded=true (ターン終了)。

--- a/src/lib/shogi/ai/turn/action-generator.ts
+++ b/src/lib/shogi/ai/turn/action-generator.ts
@@ -46,7 +46,18 @@ export function* getCardActions(
   // (2) 自分の手番でなければ使用禁止
   if (state.gameState.currentPlayer !== player) return;
 
+  // Issue #235 派生 (Vercel 504 対策、2026-06-10): 同一 defId の重複インスタンスは dedupe し
+  // 先頭インスタンスのみ候補化する。使用可否判定 ((4)〜(7)) と効果・評価は defId と盤面/カード
+  // 状態のみに依存しインスタンス間で完全に等価なため、「どのコピーを切るか」は探索上無意味。
+  // dedupe なしだと手札に同種カードが N 枚あるとき同一評価が N 回走り、特に二手指し
+  // (super-action 内部探索 ≈ 数秒/回) の重複が Vercel maxDuration 10s 超過 (504) の主因だった
+  // (実測: 二手指し 3 枚で計 11.4s)。採用される instanceId は従来も argmax の strict > により
+  // 先頭コピーだったため、選択結果は不変。
+  const seenDefIds = new Set<CardId>();
+
   for (const card of state.cardState.hand[player]) {
+    if (seenDefIds.has(card.defId)) continue;
+    seenDefIds.add(card.defId);
     const spec = CARD_SPECS[card.defId];
 
     // (3) 手札にないカードは for...of で自然にスキップ済 (state.cardState.hand[player] が手札全件)

--- a/src/lib/shogi/cards/__tests__/card-spec.test.ts
+++ b/src/lib/shogi/cards/__tests__/card-spec.test.ts
@@ -509,34 +509,106 @@ describe("useCondition ≡ CARD_USE_CONDITIONS (§8)", () => {
   });
 });
 
-// ===== 8. valueModel snapshot =====
+// ===== 8. valueModel (S3a: 静的5枚 + トラップ2枚の局面依存) =====
 
-describe("valueModel snapshot (S2 stub、入力非依存)", () => {
-  const EXPECTED: Record<CardId, number> = {
-    no_promote: 50,
-    check_break: 80,
+describe("valueModel: 静的カード (mana_up / 盤面系 / double_move)", () => {
+  // トラップ2枚を除く5枚は S3a でも静的 (mana_up=30、盤面系4枚=0 のセンチネル)。
+  const STATIC_EXPECTED: Partial<Record<CardId, number>> = {
     mana_up: 30,
     pawn_return: 0,
-    piece_return: 0,
     double_pawn: 0,
+    piece_return: 0,
     double_move: 0,
   };
 
-  it("各カードの valueModel が期待静的値を返す", () => {
-    const gs = makeState();
-    for (const id of ALL_CARD_IDS) {
-      expect(CARD_SPECS[id].valueModel(gs, "sente")).toBe(EXPECTED[id]);
-    }
-  });
-
-  it("valueModel は gameState / player に依存しない (S2 stub)", () => {
+  it("期待静的値を返す & gameState / player に依存しない", () => {
     const gsA = makeState();
     const gsB = makeState({ currentPlayer: "gote", moveCount: 50 });
     place(gsB, { row: 4, col: 4 }, { type: "rook", owner: "gote" });
-    for (const id of ALL_CARD_IDS) {
+    for (const [id, expected] of Object.entries(STATIC_EXPECTED) as [CardId, number][]) {
       const vm = CARD_SPECS[id].valueModel;
-      expect(vm(gsA, "sente")).toBe(vm(gsB, "gote"));
+      expect(vm(gsA, "sente")).toBe(expected);
+      expect(vm(gsA, "sente")).toBe(vm(gsB, "gote")); // 入力非依存
     }
+  });
+});
+
+describe("valueModel 局面依存 (S3a): check_break = 自玉露出度", () => {
+  const vm = CARD_SPECS.check_break.valueModel;
+  const P_MIN_VAL = 0.05 * 300; // 露出ゼロ時の gross 下限 (= 15)
+  const P_MAX_VAL = 0.9 * 300; // 露出最大時の gross 上限 (= 270)
+
+  it("安全玉 (露出ゼロ) / 玉不在は下限値", () => {
+    const safe = makeState();
+    place(safe, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+    expect(vm(safe, "sente")).toBeCloseTo(P_MIN_VAL, 5);
+    // 自玉不在 (異常局面) も露出度 0 = 下限
+    expect(vm(makeState(), "sente")).toBeCloseTo(P_MIN_VAL, 5);
+  });
+
+  it("露出玉 (相手の利き + 王手) は安全玉より高価値、上限以内", () => {
+    const safe = makeState();
+    place(safe, { row: 8, col: 4 }, { type: "king", owner: "sente" });
+    const exposed = makeState();
+    place(exposed, { row: 4, col: 4 }, { type: "king", owner: "sente" });
+    // gote 飛車2枚で縦横から玉を王手 + 近傍に利きを通す。
+    place(exposed, { row: 0, col: 4 }, { type: "rook", owner: "gote" }); // 縦 → 近傍{3,4} + 玉{4,4}王手
+    place(exposed, { row: 4, col: 0 }, { type: "rook", owner: "gote" }); // 横 → 近傍{4,3}
+    const exposedVal = vm(exposed, "sente");
+    expect(exposedVal).toBeGreaterThan(vm(safe, "sente"));
+    expect(exposedVal).toBeLessThanOrEqual(P_MAX_VAL + 1e-6);
+    expect(exposedVal).toBeGreaterThanOrEqual(P_MIN_VAL);
+  });
+
+  it("露出度が大きいほど単調に価値が上がる", () => {
+    // low: 王手なし・近傍のみ被利き / high: 王手あり・近傍被利き
+    const low = makeState();
+    place(low, { row: 4, col: 4 }, { type: "king", owner: "sente" });
+    place(low, { row: 0, col: 3 }, { type: "rook", owner: "gote" }); // 列3縦利き (玉は列4=非王手)
+    const high = makeState();
+    place(high, { row: 4, col: 4 }, { type: "king", owner: "sente" });
+    place(high, { row: 0, col: 4 }, { type: "rook", owner: "gote" }); // 列4縦利き → 王手 + 近傍{3,4}
+    expect(vm(high, "sente")).toBeGreaterThan(vm(low, "sente"));
+  });
+});
+
+describe("valueModel 局面依存 (S3a): no_promote = 相手成り脅威度", () => {
+  const vm = CARD_SPECS.no_promote.valueModel;
+  const P_MIN_VAL = 0.05 * 160; // 脅威ゼロ時の gross 下限 (= 8)
+  const P_MAX_VAL = 0.9 * 160; // 脅威最大時の gross 上限 (= 144)
+
+  it("相手の成り脅威ゼロ (相手駒なし / 成り地点から遠い) は下限値", () => {
+    expect(vm(makeState(), "sente")).toBeCloseTo(P_MIN_VAL, 5);
+    const far = makeState();
+    // sente 視点で相手=gote。gote 成り地点は下3段 (rows 6-8)。row 0 は最遠 (距離6) = 脅威0。
+    place(far, { row: 0, col: 4 }, { type: "pawn", owner: "gote" });
+    expect(vm(far, "sente")).toBeCloseTo(P_MIN_VAL, 5);
+  });
+
+  it("相手の成り可能駒が成り地点に接近するほど高価値、上限以内", () => {
+    const near = makeState();
+    place(near, { row: 7, col: 2 }, { type: "pawn", owner: "gote" }); // 成り地点内 (距離0)
+    place(near, { row: 7, col: 6 }, { type: "rook", owner: "gote" }); // 成り地点内 (距離0)
+    const nearVal = vm(near, "sente");
+    expect(nearVal).toBeGreaterThan(P_MIN_VAL);
+    expect(nearVal).toBeLessThanOrEqual(P_MAX_VAL + 1e-6);
+  });
+
+  it("成り済み駒 (promoted_*) や金は脅威にカウントしない", () => {
+    const noThreat = makeState();
+    place(noThreat, { row: 7, col: 2 }, { type: "promoted_pawn", owner: "gote" }); // canPromote:false
+    place(noThreat, { row: 7, col: 6 }, { type: "gold", owner: "gote" }); // canPromote:false
+    expect(vm(noThreat, "sente")).toBeCloseTo(P_MIN_VAL, 5);
+  });
+
+  it("player 視点で相手側を正しく判定する (gote 視点では相手=sente の上3段)", () => {
+    // gote が no_promote を持つ場合、相手=sente の成り地点は上3段 (rows 0-2)。
+    const goteView = makeState();
+    place(goteView, { row: 1, col: 2 }, { type: "pawn", owner: "sente" }); // sente 成り地点内
+    place(goteView, { row: 1, col: 6 }, { type: "rook", owner: "sente" });
+    expect(vm(goteView, "gote")).toBeGreaterThan(P_MIN_VAL);
+    // 同じ盤面を sente 視点で見ると、相手=gote 駒は無い → 脅威0
+    expect(vm(goteView, "sente")).toBeCloseTo(P_MIN_VAL, 5);
   });
 });
 

--- a/src/lib/shogi/cards/__tests__/card-spec.test.ts
+++ b/src/lib/shogi/cards/__tests__/card-spec.test.ts
@@ -535,7 +535,7 @@ describe("valueModel: 静的カード (mana_up / 盤面系 / double_move)", () =
 
 describe("valueModel 局面依存 (S3a): check_break = 自玉露出度", () => {
   const vm = CARD_SPECS.check_break.valueModel;
-  const P_MIN_VAL = 0.05 * 300; // 露出ゼロ時の gross 下限 (= 15)
+  const P_MIN_VAL = 0.1 * 300; // 露出ゼロ時の gross 下限 (= 30、S3c 校正 TRAP_P_MIN=0.10)
   const P_MAX_VAL = 0.9 * 300; // 露出最大時の gross 上限 (= 270)
 
   it("安全玉 (露出ゼロ) / 玉不在は下限値", () => {
@@ -574,7 +574,7 @@ describe("valueModel 局面依存 (S3a): check_break = 自玉露出度", () => {
 
 describe("valueModel 局面依存 (S3a): no_promote = 相手成り脅威度", () => {
   const vm = CARD_SPECS.no_promote.valueModel;
-  const P_MIN_VAL = 0.05 * 160; // 脅威ゼロ時の gross 下限 (= 8)
+  const P_MIN_VAL = 0.1 * 160; // 脅威ゼロ時の gross 下限 (= 16、S3c 校正 TRAP_P_MIN=0.10)
   const P_MAX_VAL = 0.9 * 160; // 脅威最大時の gross 上限 (= 144)
 
   it("相手の成り脅威ゼロ (相手駒なし / 成り地点から遠い) は下限値", () => {

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -18,9 +18,17 @@
 //     registry は plies 数のメタのみ保持し effect は持たない (A1/A2)。
 //   - **trap = Route B** (R-1): `setTrap` は **set のみ** registry 化。trigger (no_promote 成り抑止 /
 //     check_break 王手崩し) は move-effects.ts インライン温存。`onTrigger` は型枠のみ (@deferred、実配線 S3)。
-//   - **valueModel は枠のみ** (R-4): S3 値付けの interface 固定先。中身は静的 per-card 値を返す薄い stub。
+//   - **valueModel** (Issue #235 S3a): トラップ2枚 (check_break/no_promote) を局面依存値付け
+//     (P_trigger × E_damage、gross 値) に実装。check_break = 自玉露出度 / no_promote = 相手成り脅威度 で
+//     trigger 確率を算出する (D-KS=C: king-exposure / promotion-threat は moves / variants プリミティブで
+//     自前計算し cards → ai の上向き依存を作らない。S3 計画 docs/plans/issue-235-s3-valuemodel.md §3/§5)。
+//     残り5枚は静的 (mana_up は deprecated、盤面系4枚は 0 = 盤面 eval / super-action 探索が間接捕捉する
+//     "別経路で捕捉" のセンチネル、§5 L-3)。**AI 側の評価切替 (TRAP_VALUE_* → valueModel) と依存反転は S3b、
+//     PoC-2 仮係数の bench 校正は S3c**。S3a は production 未配線 (additive) のため挙動不変。
 
 import type { GameState, Player, Position } from "@/lib/shogi/types";
+import { findKing, isSquareAttackedByFast } from "@/lib/shogi/moves";
+import { PIECE_DEF_MAP, STANDARD_VARIANT } from "@/lib/shogi/variants/standard";
 import type { CardCheckUsage, CardGameState, CardId, CardTarget, CardTargeting, TrapTrigger } from "./types";
 import type { CardEventKind, CardMeta } from "./card-spec";
 import { CARD_META, deriveEventKind } from "./card-spec";
@@ -79,25 +87,20 @@ export interface CardSpec {
   eventKind: CardEventKind;
 }
 
-// ===== valueModel ブリッジ (S2 stub、R-4) =====
-// **本ブリッジが card 価値の将来 SSOT (L1)**。現状 ai/cards/heuristics の TRAP_VALUE_NO_PROMOTE=50 /
-// TRAP_VALUE_CHECK_BREAK=80 / (MANA_DELTA_COEFFICIENT=10 × +3 mana = 30) と同値だが、`cards/ → ai/` の
-// 上向き依存を新規導入しないため import せず併記する。S3 で valueModel を card 価値の単一源とし、ai 側を
-// 本 valueModel 参照へ切替えて依存を正方向 (ai → L1) に統一する。それまで両者は同値を保つ
-// (valueModel は S2 では未配線 = inert のため、仮に drift しても探索挙動には影響しない)。
-// 盤面系 (pawn_return/piece_return/double_pawn) と double_move は現行で静的 per-card 値を持たず
-// (局面評価 digest / super-action 探索が間接捕捉)、S3 で局面依存値付けするまで 0。
-const CARD_VALUE_BRIDGE: Record<CardId, number> = {
-  no_promote: 50,
-  check_break: 80,
+// ===== valueModel: 静的値 (5枚) + 局面依存値 (トラップ2枚、S3a) =====
+
+// 静的 per-card 価値 (cp)。トラップ2枚は S3a で局面依存 valueModel に移行したため本表から除外。
+// mana_up は deprecated (AI 候補から除外済) だが registry 整合のため値を保持。盤面系4枚は 0 =
+// 「価値ゼロ」ではなく「盤面 eval / super-action 探索が別経路で間接捕捉する」センチネル (§5 L-3)。
+const STATIC_CARD_VALUE: Partial<Record<CardId, number>> = {
   mana_up: 30,
   pawn_return: 0,
-  piece_return: 0,
   double_pawn: 0,
+  piece_return: 0,
   double_move: 0,
 };
 
-// 静的値を返す valueModel stub (gameState/player は S3 まで未使用)。
+// 静的値を返す valueModel (gameState/player は未使用)。
 function staticValueModel(value: number): ValueModel {
   return (gameState, player) => {
     void gameState;
@@ -105,6 +108,94 @@ function staticValueModel(value: number): ValueModel {
     return value;
   };
 }
+
+// ===== トラップ局面依存値モデル (S3a、PoC-2 docs/bench-results/issue-235-poc2.json) =====
+// 価値 = P_trigger × E_damage の **gross 値** (cp)。カードのマナコストは AI 側の mana 会計
+// (applyActionForLookahead → digest manaDelta) が別途反映するため、ここでは差し引かない (二重計上回避、§5 R-1)。
+// 係数はいずれも **PoC-2 由来の仮値で S3c bench 校正対象** (本採用値未確定)。
+const TRAP_P_MIN = 0.05; // trigger 確率の下限
+const TRAP_P_MAX = 0.9; // trigger 確率の上限
+const CHECK_BREAK_E_DAMAGE = 300; // check_break 発動時の期待効果 (cp)
+const NO_PROMOTE_E_DAMAGE = 160; // no_promote 発動時の期待効果 (cp)
+// D-KS=C: 自玉露出度 / 相手成り脅威度は moves / variants プリミティブで自前算出するため、
+// 露出・脅威 → 確率の正規化基準も本実装独自 (PoC-2 の evaluateKingSafety スケールは非継承、S3c 校正)。
+const KING_EXPOSURE_REF = 6; // 自玉露出度がこの値で P_MAX に到達
+const KING_IN_CHECK_WEIGHT = 3; // 王手中は露出度に加点 (現に王手される確率が高い)
+const PROMO_THREAT_REF = 6; // 相手成り脅威度がこの値で P_MAX に到達
+const PROMO_PROXIMITY_MAX = 3; // 相手の成り地点までの距離がこの値未満の駒を脅威として加点
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+// 自玉露出度: 自玉の 8 近傍のうち相手の利きがあるマス数 + 王手中の加点。
+// 玉不在 (異常局面) は露出度 0 (= 最小 trigger) を返す。
+function kingExposure(gameState: GameState, player: Player): number {
+  const board = gameState.board;
+  const boardSize = { rows: board.length, cols: board[0]?.length ?? 0 };
+  const kingPos = findKing(board, player, boardSize);
+  if (!kingPos) return 0;
+  const opponent: Player = player === "sente" ? "gote" : "sente";
+  let exposure = 0;
+  for (let dr = -1; dr <= 1; dr++) {
+    for (let dc = -1; dc <= 1; dc++) {
+      if (dr === 0 && dc === 0) continue;
+      const r = kingPos.row + dr;
+      const c = kingPos.col + dc;
+      if (r < 0 || r >= boardSize.rows || c < 0 || c >= boardSize.cols) continue;
+      if (isSquareAttackedByFast(board, { row: r, col: c }, opponent, boardSize)) exposure++;
+    }
+  }
+  if (isSquareAttackedByFast(board, kingPos, opponent, boardSize)) exposure += KING_IN_CHECK_WEIGHT;
+  return exposure;
+}
+
+// check_break valueModel: 自玉露出度 → trigger 確率 → P_trigger × E_damage (gross)。
+// 自玉が危ないほど王手 (= 発動) されやすく、王手崩しの価値が高い。
+const checkBreakValueModel: ValueModel = (gameState, player) => {
+  const ratio = clamp01(kingExposure(gameState, player) / KING_EXPOSURE_REF);
+  const pTrigger = TRAP_P_MIN + ratio * (TRAP_P_MAX - TRAP_P_MIN);
+  return pTrigger * CHECK_BREAK_E_DAMAGE;
+};
+
+// 相手駒の行 row から相手の成り地点までの距離 (0 = 既に成り地点内)。
+function promotionDistance(row: number, opponent: Player, boardRows: number, pzDepth: number): number {
+  if (opponent === "sente") {
+    // sente の成り地点 = 上 pzDepth 段 (row < pzDepth)。
+    return Math.max(0, row - (pzDepth - 1));
+  }
+  // gote の成り地点 = 下 pzDepth 段 (row >= boardRows - pzDepth)。
+  return Math.max(0, boardRows - pzDepth - row);
+}
+
+// 相手の成り脅威度: 相手の「成り可能・未成り駒」が相手の成り地点へどれだけ接近しているか。
+// 成り地点に近い駒ほど高重み (PROMO_PROXIMITY_MAX − 距離)。promoted_* は canPromote:false で自然に除外。
+function promotionThreat(gameState: GameState, player: Player): number {
+  const board = gameState.board;
+  const boardRows = board.length;
+  const opponent: Player = player === "sente" ? "gote" : "sente";
+  const pzDepth = STANDARD_VARIANT.rules.promotionZoneRows;
+  let threat = 0;
+  for (let r = 0; r < boardRows; r++) {
+    const rowArr = board[r];
+    for (let c = 0; c < rowArr.length; c++) {
+      const piece = rowArr[c];
+      if (!piece || piece.owner !== opponent) continue;
+      if (!PIECE_DEF_MAP.get(piece.type)?.canPromote) continue;
+      const dist = promotionDistance(r, opponent, boardRows, pzDepth);
+      threat += Math.max(0, PROMO_PROXIMITY_MAX - dist);
+    }
+  }
+  return threat;
+}
+
+// no_promote valueModel: 相手成り脅威度 → trigger 確率 → P_trigger × E_damage (gross)。
+// 相手が成りそうなほど発動しやすく、成り無効化の価値が高い (check_break と指標を明確に分離、D-NP=B)。
+const noPromoteValueModel: ValueModel = (gameState, player) => {
+  const ratio = clamp01(promotionThreat(gameState, player) / PROMO_THREAT_REF);
+  const pPromo = TRAP_P_MIN + ratio * (TRAP_P_MAX - TRAP_P_MIN);
+  return pPromo * NO_PROMOTE_E_DAMAGE;
+};
 
 // modifyBoard effect: applyXxx (Position 受け) を CardTarget (square) 受けに包む薄い wrapper。
 function boardEffect(
@@ -157,44 +248,46 @@ export const CARD_SPECS: Record<CardId, CardSpec> = {
   mana_up: buildSpec(
     "mana_up",
     { type: "modifyResource", mana: 3 },
-    staticValueModel(CARD_VALUE_BRIDGE.mana_up),
+    staticValueModel(STATIC_CARD_VALUE.mana_up ?? 0),
   ),
   // 自盤上の歩 / と金 1 枚を持ち駒へ (unpromote)。
   pawn_return: buildSpec(
     "pawn_return",
     boardEffect(applyPawnReturn),
-    staticValueModel(CARD_VALUE_BRIDGE.pawn_return),
+    staticValueModel(STATIC_CARD_VALUE.pawn_return ?? 0),
   ),
   // 持ち駒の歩 1 枚を自分の歩がいる列の空マスへ (二歩禁則の一時解除)。
   double_pawn: buildSpec(
     "double_pawn",
     boardEffect(applyDoublePawn),
-    staticValueModel(CARD_VALUE_BRIDGE.double_pawn),
+    staticValueModel(STATIC_CARD_VALUE.double_pawn ?? 0),
   ),
   // 自盤上の駒 (玉以外) 1 枚を持ち駒へ (unpromote)。歩戻しの上位互換。
   piece_return: buildSpec(
     "piece_return",
     boardEffect(applyPieceReturn),
-    staticValueModel(CARD_VALUE_BRIDGE.piece_return),
+    staticValueModel(STATIC_CARD_VALUE.piece_return ?? 0),
   ),
   // トラップ: 相手の王手宣言時に王手駒を全て持ち駒化 (発火は move-effects インライン = Route B)。
+  // S3a: valueModel を自玉露出度ベースの局面依存値に (危ない局面ほど高価値)。
   check_break: buildSpec(
     "check_break",
     { type: "setTrap", trigger: "check_declared" },
-    staticValueModel(CARD_VALUE_BRIDGE.check_break),
+    checkBreakValueModel,
   ),
   // 二手指し: 1 ターンに続けて 2 手指す。effect なし・multiPly: 2 のみ (A1/A2)。
   double_move: buildSpec(
     "double_move",
     undefined,
-    staticValueModel(CARD_VALUE_BRIDGE.double_move),
+    staticValueModel(STATIC_CARD_VALUE.double_move ?? 0),
     { multiPly: 2 },
   ),
   // トラップ: 相手の成り宣言を無効化し「成り不可」を永続付与 (発火は move-effects インライン = Route B)。
+  // S3a: valueModel を相手成り脅威度ベースの局面依存値に (相手が成りそうなほど高価値)。
   no_promote: buildSpec(
     "no_promote",
     { type: "setTrap", trigger: "promotion_declared" },
-    staticValueModel(CARD_VALUE_BRIDGE.no_promote),
+    noPromoteValueModel,
   ),
 };
 

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -300,3 +300,10 @@ export function getCardSpec(id: CardId): CardSpec {
 export function getAllCardSpecs(): CardSpec[] {
   return Object.values(CARD_SPECS);
 }
+
+// カードの局面依存価値 (cp、player 視点の gross 値) を取得する SSOT アクセサ (S3b 依存反転)。
+// AI 側 (digest / search) はトラップ評価を本関数経由に統一し、固定係数 TRAP_VALUE_* を脱却する
+// (ai → L1 の正方向依存。cost は AI の mana 会計が別途処理するため本値はコストを引かない gross)。
+export function getCardValue(id: CardId, gameState: GameState, player: Player): number {
+  return CARD_SPECS[id].valueModel(gameState, player);
+}

--- a/src/lib/shogi/cards/card-spec-server.ts
+++ b/src/lib/shogi/cards/card-spec-server.ts
@@ -109,16 +109,25 @@ function staticValueModel(value: number): ValueModel {
   };
 }
 
-// ===== トラップ局面依存値モデル (S3a、PoC-2 docs/bench-results/issue-235-poc2.json) =====
+// ===== トラップ局面依存値モデル (S3a 実装 / S3c 校正、PoC-2 docs/bench-results/issue-235-poc2.json) =====
 // 価値 = P_trigger × E_damage の **gross 値** (cp)。カードのマナコストは AI 側の mana 会計
 // (applyActionForLookahead → digest manaDelta) が別途反映するため、ここでは差し引かない (二重計上回避、§5 R-1)。
-// 係数はいずれも **PoC-2 由来の仮値で S3c bench 校正対象** (本採用値未確定)。
-const TRAP_P_MIN = 0.05; // trigger 確率の下限
-const TRAP_P_MAX = 0.9; // trigger 確率の上限
-const CHECK_BREAK_E_DAMAGE = 300; // check_break 発動時の期待効果 (cp)
-const NO_PROMOTE_E_DAMAGE = 160; // no_promote 発動時の期待効果 (cp)
+// 係数は **S3c で bench + 決定的 unit test で校正済の本採用値** (PoC-2 仮値からの確定経緯は計画 §12)。
+//
+// **S3c 校正 (TRAP_P_MIN 0.05 → 0.10)**: PoC-2 仮値 0.05 は「set 済の dormant トラップが生涯で
+//   trigger する確率」を過小評価していた (王手/成りは 1 局を通じて高頻度で発生するため、置いた
+//   トラップが将来発火する確率は 5% より明らかに高い)。0.10 へ引き上げることで:
+//     - 静かな盤面 + マナ上限近接 (= dead マナ) では dormant トラップのセットが正 EV になる
+//       (浪費されるはずのマナを option value に変換する好手。check_break floor 15→30cp / no_promote 8→16cp)。
+//     - 静かな盤面 + 通常マナでは依然 move を選好 (P_MIN<0.127 でトラップの過剰セットを抑止)。
+//     - 危険局面 (露出玉 / 相手成り脅威) では P_trigger が ratio で押し上がり高価値 = 挙動不変。
+//   決定的検証は evaluate-action.test.ts「S3c calibration」(noise なし evaluateActionWithLookahead)。
+const TRAP_P_MIN = 0.1; // trigger 確率の下限 (dormant トラップの生涯 trigger 確率、S3c 校正)
+const TRAP_P_MAX = 0.9; // trigger 確率の上限 (最大露出/脅威時)
+const CHECK_BREAK_E_DAMAGE = 300; // check_break 発動時の期待効果 (cp、王手駒の捕獲 = 大駒級)
+const NO_PROMOTE_E_DAMAGE = 160; // no_promote 発動時の期待効果 (cp、成り阻止)
 // D-KS=C: 自玉露出度 / 相手成り脅威度は moves / variants プリミティブで自前算出するため、
-// 露出・脅威 → 確率の正規化基準も本実装独自 (PoC-2 の evaluateKingSafety スケールは非継承、S3c 校正)。
+// 露出・脅威 → 確率の正規化基準も本実装独自 (PoC-2 の evaluateKingSafety スケールは非継承)。
 const KING_EXPOSURE_REF = 6; // 自玉露出度がこの値で P_MAX に到達
 const KING_IN_CHECK_WEIGHT = 3; // 王手中は露出度に加点 (現に王手される確率が高い)
 const PROMO_THREAT_REF = 6; // 相手成り脅威度がこの値で P_MAX に到達


### PR DESCRIPTION
## Summary
Issue #235 epic の **S3 (L1 ValueModel 局面依存値付け) 全段** と、検証中に発見した派生修正をまとめる。S3 完了をもって L1 (CardSpec registry + ValueModel) が完成。

- **S3a/S3b/S3c (本体)**: トラップ2枚 (check_break / no_promote) の AI 価値評価を固定係数から**局面依存 valueModel** へ移行 (S3a additive → S3b cutover → S3c 校正)。S3c で `TRAP_P_MIN` を 0.05→0.10 に校正し本採用値を確定。
- **S4 設計 docs**: 次段 S4 に「汎用評価拡張基盤 (EvalFeature registry)」をスコープ追加 (状態異常を含む将来要素を宣言的に評価/探索へ差し込む基盤、5接面標準化)。3観点 adversarial 検証反映済。
- **派生 fix (#235 同居、rule 2)**:
  - **Vercel 504 解消**: deep search 後の root アクション評価フェーズが時間無制限で、終盤の二手指し super-action が `maxDuration` 10s を超過していた (実測 16.8s)。dedupe + action-phase budget + super-action deadline で最悪 ≈5.1s に bound。
  - **思考表示 UX**: CPU 手番中に盤グリッド中央へ「考え中 ...」を表示、自動リトライ中は「長考中 ...」に切替。リトライも失敗時のみ従来のエラーモーダル。

## 挙動変化
- AI のトラップ価値が局面依存に (S3、意図的な棋力変化)。bench で depthCompleted 全難易度 Δ0.0% = 退化なし、card% beginner/intermediate 86%→100%・advanced/expert 57%不変 (P1 深さ非対称は S4 マター)。
- AI 応答の 504 が解消し終盤でも安定応答。
- CPU 思考中の盤中央インジケータ表示 (UI)。
- standard variant / ゲームルールは不変。

## Test plan
- lint 0 errors / 22 warnings (baseline)
- typecheck pass
- test:ci 592 passed | 12 skipped
- build success
- bench (RUN_PERF_BENCH): kernel-search OFF==ON / card-usage sanity 緑、3-run baseline depthCompleted Δ0.0%
- M2 adversarial レビュー (S3c) 指摘ゼロ

Refs #235
