### PR TITLE
fix: 駒移動系カード利用時の盤上ハイライト制御を修正

### DIFF
--- a/docs/plans/issue-242-card-move-highlight.md
+++ b/docs/plans/issue-242-card-move-highlight.md
@@ -1,0 +1,141 @@
+# Issue #242: 駒移動系カード利用による盤上背景色制御修正
+
+## 1. 問題 (バグ内容)
+
+カード将棋で、カードによる駒移動 (歩戻し / 駒戻し / 二歩指し / 二手指し / 王手崩し) を行ったとき、
+直前手を示す緑ハイライト (背景色) が反映されない。どのマスに作用したのか一目で分からず UX が低い。
+
+要望 (Issue 本文):
+1. **歩戻し / 駒戻し**: 盤上→持ち駒に戻したとき、対象駒が居た位置を緑に
+2. **二歩指し**: 歩を打った位置を緑に
+3. **二手指し**: 2手分の指し手の軌跡を緑に
+4. **王手崩し**: 相手駒が持駒に移動するとき、対象駒が元居た位置を緑に
+5. その他カードも必要に応じて適切に盛り込む
+
+## 2. 根本原因
+
+緑ハイライト (直前手) は `gameState.moveHistory[moveHistory.length - 1]` の `from`/`to` から
+`ShogiBoard` が導出している (`card-shogi-game.tsx:1736,2149` → `shogi-board.tsx:372-377 isLastMoveSquare`)。
+
+- カード効果 (`applyCardEffectLogic`) は **`moveHistory` を更新しない** (カードは指し手ではない / SFX・
+  学習サンプル・待ったスコープ・千日手判定に影響させない設計) → 緑が出ない。
+- 二手指しは `makeMoveWithEffects` を 2 回呼ぶので `moveHistory` には 2 手入るが、`lastMove` は
+  末尾 1 手しか見ない → 1手目が緑にならない。
+- 王手崩しは `trapTriggerEvent` で除去位置を持つが、これも `moveHistory` には乗らない。
+
+つまり「直前のターンで作用したマス」を `moveHistory[-1]` だけから導出する現設計では
+カード由来の盤面変化を表現できないのが根本原因。
+
+## 3. 設計方針 (単一情報源 + イベント駆動)
+
+「直前の盤面変化アクションで強調すべきマス集合」を reducer state の **単一情報源**
+`lastActionHighlights: Position[]` として持つ。reducer は各遷移で「何が起きたか」を正確に
+把握しているため、`GameEvent` から純粋関数でハイライトマスを導出する。
+
+### なぜ reducer state か (component で eventLog を後方走査する案との比較)
+- `eventLog` はリロード時 `[]` に初期化される (`use-card-shogi-game.ts:72`、永続化は `moveHistory` のみ)。
+- component で eventLog を後方走査して「直前ターン分」を切り出す案は、二手指し (move×2 + cardPlayEvent)、
+  王手崩し (trapTriggerEvent の player = トラップ所有者 = 指し手と別プレイヤー)、turn 末尾の
+  manaCharge/draw 混在などで **ターン境界判定が脆く**、デグレ温床になる。
+- reducer は遷移ごとに「このアクションが生成した events」を正確に持つため、`highlightSquaresForEvents`
+  に渡すだけで move / card / 王手崩し / 二手指し蓄積を **後方走査ヒューリスティック無しで** 表現できる。
+- 既存パターン (selectedSquare / legalMoves / forbiddenMateMoves を reducer state で持ち hook 経由で
+  board へ渡す) と完全に同一の流れ = 保守性・疎結合を維持。
+
+### 永続化 / 復元
+- `lastActionHighlights` は UI 派生 state のため DB 永続化しない。
+- 初期化 (新規 / リロード) は `initialState.moveHistory[-1]` から導出 (= 現挙動の緑を非デグレで維持)。
+  カード由来ハイライトはリロードで消えるが、これは「直前アクションの一時的強調」であり許容
+  (現状もカード使用直後しか意味を持たない)。リロード後も通常手の緑は従来通り残る。
+
+## 4. 実装詳細
+
+### 4-1. reducer.ts (純粋ヘルパ 2 つ + 各遷移でセット)
+
+```ts
+// アクションが生成した events からハイライトマスを導出 (move/card/王手崩しを一律に扱う)
+function highlightSquaresForEvents(events: GameEvent[]): Position[] {
+  const out: Position[] = [];
+  for (const ev of events) {
+    if (ev.kind === "moveEvent") {
+      if (ev.move.from) out.push(ev.move.from);
+      out.push(ev.move.to);
+    } else if (ev.kind === "cardPlayEvent") {
+      // 盤上に作用するカードは square target を持つ (pawn_return/piece_return/double_pawn)。
+      // returnedPiece は target と同マスなので target で代表。mana_up/double_move は target 無 → 空。
+      if (ev.target?.kind === "square") out.push({ row: ev.target.row, col: ev.target.col });
+    } else if (ev.kind === "trapTriggerEvent" && ev.capturedPieces) {
+      // 王手崩し: 除去された駒の元位置 (= 攻め駒の着地マス) を強調。
+      for (const cp of ev.capturedPieces) out.push({ row: cp.row, col: cp.col });
+    }
+  }
+  return out;
+}
+
+// 初期化 / リロード / 待った復元用フォールバック (moveHistory 末尾手の from/to)
+export function lastMoveHighlightSquares(gameState: GameState): Position[] {
+  const lm = gameState.moveHistory[gameState.moveHistory.length - 1];
+  if (!lm) return [];
+  return lm.from ? [lm.from, lm.to] : [lm.to];
+}
+```
+
+セット箇所 (いずれも返却オブジェクト literal に 1 行追加。それ以外の遷移は `...state` スプレッドで保持):
+- `MAKE_MOVE` 通常: `lastActionHighlights: highlightSquaresForEvents(result.events)`
+- `MAKE_MOVE` 二手指し1手目 (継続 / gameOver 両分岐): `highlightSquaresForEvents(result.events)`
+- `MAKE_MOVE` 二手指し2手目: `[...state.lastActionHighlights, ...highlightSquaresForEvents(result.events)]`
+  (1手目分は直前 state に残っているので軌跡 2 手分を蓄積)
+- `CONFIRM_PROMOTION`: `MAKE_MOVE` と同じ 3 分岐構造をミラー
+- `CONFIRM_PLAY_CARD` (非 double_move): `const h = highlightSquaresForEvents([applied.event]);`
+  `lastActionHighlights: h.length ? h : state.lastActionHighlights`
+  (mana_up/trap は h=空 → 盤面非変更ゆえ直前の緑を保持 = ちらつき防止 + 意味的に正)
+- `CONFIRM_PLAY_CARD` double_move 分岐: セットしない (1手目を指すまで直前手の緑を維持)
+- `UNDO` (待った): `lastActionHighlights: lastMoveHighlightSquares(target.gameState)`
+- `UNDO_DOUBLE_MOVE_FIRST` / `CANCEL_DOUBLE_MOVE`: 復元 gameState から `lastMoveHighlightSquares` で再導出
+  (取り消した 1手目の緑を残さない)
+- interface `CardShogiGameStateInternal` に `lastActionHighlights: Position[]` 追加
+- `finalizeDoubleMoveCardConsumption`: `...state` スプレッドで蓄積値を保持 (変更不要)
+- COMMIT_PLAY_CARD / COMMIT_CHECK_BREAK / COMMIT_DRAW / applyTurnEndEffects: `...state` で保持 (変更不要)
+
+### 4-2. use-card-shogi-game.ts
+- 初期 state に `lastActionHighlights: lastMoveHighlightSquares(initialState)` 追加 (line 64 の literal)
+- 戻り値に `lastActionHighlights: state.lastActionHighlights` 追加 (line 691)
+
+### 4-3. card-shogi-game.tsx
+- hook 分割代入 (387-424) に `lastActionHighlights` 追加
+- 2 つの `<ShogiBoard>` (1729, 2142) に `lastMoveSquares={lastActionHighlights}` を追加
+
+### 4-4. shogi-board.tsx
+- props に `lastMoveSquares?: Position[]` 追加 (任意。標準将棋は未指定 = 後方互換)
+- 既存 Set 群と同パターンで `lastMoveSet` を構築:
+  ```ts
+  const lastMoveSet = new Set(
+    (lastMoveSquares ??
+      (lastMove ? (lastMove.from ? [lastMove.from, lastMove.to] : [lastMove.to]) : [])
+    ).map((p) => `${p.row}-${p.col}`),
+  );
+  ```
+- `isLastMoveSquare` 関数 (372-377) を削除し、render 内 (440) を
+  `const isLastMoveSq = lastMoveSet.has(`${rowIdx}-${colIdx}`);` に置換
+- 標準将棋 (`shogi-game.tsx:305`) は `lastMoveSquares` 未指定 → `lastMove` から従来通り導出 = 挙動不変
+
+## 5. 非デグレ / 影響範囲
+- 標準将棋: `lastMoveSquares` 未指定で `lastMove` フォールバック → from/to 集合は従来と同一。挙動不変。
+- カード将棋通常手: `highlightSquaresForEvents(moveEvent)` = from/to で従来と同一。
+- 緑の優先順位は最下位のまま (選択/合法手/王手より下) → 既存 UX を変えない。
+- 永続化 (DB save) 対象は不変 (lastActionHighlights は保存しない)。
+- AI / 探索ロジックには非干渉 (UI 表示専用 state)。
+
+## 6. テスト計画
+- reducer ユニット: `highlightSquaresForEvents` (move / 取り / 打ち / cardPlayEvent square / 王手崩し /
+  mana_up=空) + `lastMoveHighlightSquares` (空 / from-to / drop)
+- reducer 統合: MAKE_MOVE / CONFIRM_PLAY_CARD(pawn_return,piece_return,double_pawn,mana_up) /
+  二手指し2手蓄積 / UNDO で `lastActionHighlights` が期待値になること
+- 既存テスト (undo-policy / effects / world-kernel-equivalence) が緑を維持
+- `npm run lint` → `typecheck` → `test:ci` → `build`
+
+## 7. パフォーマンス / UX
+- ハイライトマスは最大 4 (二手指し) の小集合。Set 構築は既存 5 Set と同コスト感、描画増分なし。
+- 追加の再描画・タイマー・アニメーションなし (既存の tint 経路に乗るだけ)。モバイル負荷増なし。
+- カードフライト演出中も対象マスの tint は表示される (駒は hiddenSquares で隠れるがセルは緑) →
+  「どこから戻したか」が演出中から視認でき UX 向上。

--- a/src/components/game/card-shogi/card-shogi-game.tsx
+++ b/src/components/game/card-shogi/card-shogi-game.tsx
@@ -389,6 +389,7 @@ export function CardShogiGame({
     selectedHandPiece,
     legalMoves,
     forbiddenMateMoves,
+    lastActionHighlights,
     isAiThinking,
     promotionPendingMove,
     cardState,
@@ -1733,7 +1734,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               selectedSquare={selectedSquare}
               legalMoves={legalMoves}
-              lastMove={gameState.moveHistory[gameState.moveHistory.length - 1] ?? null}
+              lastMoveSquares={lastActionHighlights}
               isAiThinking={isAiThinking}
               inCheck={inCheck}
               onSquareClick={handleSquareClick}
@@ -2146,7 +2147,7 @@ export function CardShogiGame({
               playerColor={playerColor}
               selectedSquare={selectedSquare}
               legalMoves={legalMoves}
-              lastMove={gameState.moveHistory[gameState.moveHistory.length - 1] ?? null}
+              lastMoveSquares={lastActionHighlights}
               isAiThinking={isAiThinking}
               inCheck={inCheck}
               onSquareClick={handleSquareClick}

--- a/src/components/game/shogi-board.tsx
+++ b/src/components/game/shogi-board.tsx
@@ -25,7 +25,14 @@ interface ShogiBoardProps {
   playerColor: Player;
   selectedSquare: Position | null;
   legalMoves: Move[];
-  lastMove: Move | null;
+  // 直前手の起点・終点 (緑ハイライト)。標準将棋・board-design はこちらを使う。
+  // lastMoveSquares が指定された場合はそちらが優先され、本 prop は無視される (省略可)。
+  lastMove?: Move | null;
+  // Issue #242: 「直前アクションで緑ハイライトすべきマス集合」。カード将棋は通常手に加え
+  // カード作用 (歩戻し/駒戻し/二歩指し/二手指し軌跡/王手崩しの除去位置) も緑にするため、
+  // moveHistory 末尾だけでは表現できない複数マスを reducer 側で算出して渡す。
+  // 指定時は lastMove より優先。空配列 [] は「緑なし」を意味し lastMove へはフォールバックしない。
+  lastMoveSquares?: Position[];
   isAiThinking: boolean;
   inCheck: boolean;
   onSquareClick: (pos: Position) => void;
@@ -134,7 +141,7 @@ const BoardSquare = memo(function BoardSquare({
   // (盤テクスチャが視覚ベースなので OS テーマでの分岐は不要)。
   // 優先順序は元実装の cn() 出現順に合わせる:
   //   forbiddenMate > cardTarget > legalTarget(piece) > legalTarget(empty)
-  //   > selected > kingInCheck > lastMove
+  //   > selected > kingInCheck > lastMoveSq (直前アクション = 通常手 / カード作用マス)
   const tint: string | null = isForbiddenMate
     ? "rgba(220, 38, 38, 0.55)"   // red-600 / 警告
     : isCardTarget
@@ -148,7 +155,7 @@ const BoardSquare = memo(function BoardSquare({
             : isKingInCheck
               ? "rgba(220, 38, 38, 0.65)" // red-600 / 王手警告
               : isLastMoveSq
-                ? "rgba(16, 185, 129, 0.40)" // emerald-500 / 直前手
+                ? "rgba(16, 185, 129, 0.40)" // emerald-500 / 直前アクション
                 : null;
 
   // 盤全体サイズ (= 9 cell + 8 gap)。各マスはここから visual 位置のオフセットだけ
@@ -291,6 +298,7 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
     selectedSquare,
     legalMoves,
     lastMove,
+    lastMoveSquares,
     isAiThinking,
     inCheck,
     onSquareClick,
@@ -344,6 +352,15 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
   const forbiddenMateSet = new Set(
     (forbiddenMateSquares ?? []).map((p) => `${p.row}-${p.col}`)
   );
+  // Issue #242: 直前アクションの緑ハイライト集合。lastMoveSquares 指定時はそれを使い
+  // (空配列なら緑なし。?? は undefined のときだけ lastMove へフォールバックする)、
+  // 未指定の標準将棋・board-design では lastMove の from/to (drop は to のみ) から導出する。
+  const lastMoveSet = new Set(
+    (
+      lastMoveSquares ??
+      (lastMove ? (lastMove.from ? [lastMove.from, lastMove.to] : [lastMove.to]) : [])
+    ).map((p) => `${p.row}-${p.col}`)
+  );
 
   const isGote = playerColor === "gote";
   const cellSize = getShogiBoardCellSize(squareSize);
@@ -368,13 +385,6 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
     isGote,
     onSquareClick,
   });
-
-  const isLastMoveSquare = (row: number, col: number): boolean => {
-    if (!lastMove) return false;
-    const matchTo = lastMove.to.row === row && lastMove.to.col === col;
-    const matchFrom = !!lastMove.from && lastMove.from.row === row && lastMove.from.col === col;
-    return matchTo || matchFrom;
-  };
 
   const isPlayerTurn = currentPlayer === playerColor;
   const canHover = isPlayerTurn && !isAiThinking;
@@ -437,7 +447,7 @@ export const ShogiBoard = memo(forwardRef<ShogiBoardHandle, ShogiBoardProps>(fun
               const isForbiddenMate = forbiddenMateSet.has(`${rowIdx}-${colIdx}`);
               const isNoPromote = noPromoteSet.has(`${rowIdx}-${colIdx}`);
               const isHidden = hiddenSet.has(`${rowIdx}-${colIdx}`);
-              const isLastMoveSq = isLastMoveSquare(rowIdx, colIdx);
+              const isLastMoveSq = lastMoveSet.has(`${rowIdx}-${colIdx}`);
               const isKingInCheck =
                 inCheck &&
                 piece?.type === "king" &&

--- a/src/hooks/card-shogi/__tests__/reducer.test.ts
+++ b/src/hooks/card-shogi/__tests__/reducer.test.ts
@@ -6,7 +6,7 @@ import type { GameState } from "@/lib/shogi/types";
 import type { CardGameState, CardInstance, GameEvent } from "@/lib/shogi/cards/types";
 import { MANA_CAP, DRAW_COST, AUTO_DRAW_INTERVAL, CARD_DEFS } from "@/lib/shogi/cards/definitions";
 
-import { reducer, type CardShogiGameStateInternal } from "../reducer";
+import { reducer, lastMoveHighlightSquares, type CardShogiGameStateInternal } from "../reducer";
 
 // ===== fixtures =====
 
@@ -47,6 +47,8 @@ function makeInitialState(
     isCheckBreakAnimating: false,
     doubleMove: null,
     forbiddenMateMoves: [],
+    // Issue #242: 直前アクションの緑ハイライト集合。production init と同様 moveHistory 末尾から導出。
+    lastActionHighlights: lastMoveHighlightSquares(gameState),
     undoSnapshots: [],
     // Issue #193 / PR1a (B-3 対応): 観戦モード関連の新規フィールド。既存テストでは
     // 常に false (= 人間プレイ時の挙動) を想定。観戦モード固有の挙動 (早指し disable /
@@ -785,6 +787,16 @@ describe("reducer / 王手崩しトラップ (check_break)", () => {
       expect(trapEvent.capturedPieces).toBeDefined();
       expect(trapEvent.capturedPieces!.length).toBeGreaterThan(0);
     }
+    // Issue #242: 王手崩し発動時、攻め手の from/to + 除去された駒の位置を緑ハイライトに含む。
+    // 本ケースでは攻め駒の着地 (3,4) = 除去位置なので dedupe され 2 マス [{3,4},{4,4}] になる。
+    expect(next.lastActionHighlights).toEqual(
+      expect.arrayContaining([
+        { row: 4, col: 4 }, // from (攻め手の起点)
+        { row: 3, col: 4 }, // to = 除去された王手駒の位置
+      ]),
+    );
+    // 重複 (to=除去位置) は除去され距離 1 集合になっている
+    expect(next.lastActionHighlights).toHaveLength(2);
   });
 
   it("COMMIT_CHECK_BREAK で isCheckBreakAnimating がクリアされる", () => {
@@ -2254,5 +2266,276 @@ describe("reducer / 演出オーケストレーション統合 (S1d cutover)", (
     expect(next.pendingPlayCardOpponent).toBe("gote");
     const last = next.eventLog[next.eventLog.length - 1];
     expect(last.kind).toBe("trapSetEvent");
+  });
+});
+
+describe("reducer / Issue #242: 直前アクション緑ハイライト (lastActionHighlights)", () => {
+  it("MAKE_MOVE (通常手): from/to を緑ハイライトに設定", () => {
+    const state = makeInitialState();
+    const move = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "pawn",
+      from: { row: 6, col: 4 },
+      to: { row: 5, col: 4 },
+    };
+    const next = reducer(state, { type: "MAKE_MOVE", move });
+    expect(next.lastActionHighlights).toEqual([
+      { row: 6, col: 4 },
+      { row: 5, col: 4 },
+    ]);
+  });
+
+  it("CONFIRM_PLAY_CARD (歩戻し): 戻した駒の元位置を緑ハイライトに設定", () => {
+    const c = card("pr1", "pawn_return");
+    const state = makeInitialState(
+      undefined,
+      makeInitialCardState({
+        mana: { sente: 5, gote: 0 },
+        hand: { sente: [c], gote: [] },
+        pendingCard: {
+          instance: c,
+          player: "sente",
+          phase: "confirm",
+          target: { kind: "square", row: 6, col: 4 },
+        },
+      }),
+    );
+    const next = reducer(state, { type: "CONFIRM_PLAY_CARD" });
+    // 効果が適用された (盤上の歩が持ち駒へ戻り、マスが空に) こと
+    expect(next.gameState.board[6][4]).toBeNull();
+    // 元位置を緑に
+    expect(next.lastActionHighlights).toEqual([{ row: 6, col: 4 }]);
+  });
+
+  it("CONFIRM_PLAY_CARD (駒戻し): 戻した駒の元位置を緑ハイライトに設定", () => {
+    const c = card("pcr1", "piece_return");
+    // sente の銀 (初期盤面 row8,col2) を持ち駒へ戻す。玉露出しない駒なので合法。
+    const state = makeInitialState(
+      undefined,
+      makeInitialCardState({
+        mana: { sente: 5, gote: 0 },
+        hand: { sente: [c], gote: [] },
+        pendingCard: {
+          instance: c,
+          player: "sente",
+          phase: "confirm",
+          target: { kind: "square", row: 8, col: 2 },
+        },
+      }),
+    );
+    const next = reducer(state, { type: "CONFIRM_PLAY_CARD" });
+    expect(next.gameState.board[8][2]).toBeNull();
+    expect(next.lastActionHighlights).toEqual([{ row: 8, col: 2 }]);
+  });
+
+  it("CONFIRM_PLAY_CARD (二歩指し): 打った位置を緑ハイライトに設定", () => {
+    const c = card("dp1", "double_pawn");
+    // sente に持ち駒の歩を 1 枚追加 (初期盤面は row6 全列に未成り歩あり = 同列条件を満たす)。
+    const baseGame = makeInitialState().gameState;
+    const game: GameState = {
+      ...baseGame,
+      hand: { ...baseGame.hand, sente: { ...baseGame.hand.sente, pawn: 1 } },
+    };
+    const state = makeInitialState(
+      game,
+      makeInitialCardState({
+        mana: { sente: 5, gote: 0 },
+        hand: { sente: [c], gote: [] },
+        pendingCard: {
+          instance: c,
+          player: "sente",
+          phase: "confirm",
+          target: { kind: "square", row: 5, col: 4 },
+        },
+      }),
+    );
+    const next = reducer(state, { type: "CONFIRM_PLAY_CARD" });
+    expect(next.gameState.board[5][4]).toEqual({ type: "pawn", owner: "sente" });
+    expect(next.lastActionHighlights).toEqual([{ row: 5, col: 4 }]);
+  });
+
+  it("CONFIRM_PLAY_CARD (mana_up): 盤面非変更カードは直前の緑ハイライトを保持 (ちらつき防止)", () => {
+    const c = card("mu1", "mana_up");
+    const prevHighlights = [
+      { row: 2, col: 7 },
+      { row: 3, col: 7 },
+    ];
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState(
+        undefined,
+        makeInitialCardState({
+          mana: { sente: 5, gote: 0 },
+          hand: { sente: [c], gote: [] },
+          pendingCard: { instance: c, player: "sente", phase: "confirm" },
+        }),
+      ),
+      lastActionHighlights: prevHighlights,
+    };
+    const next = reducer(state, { type: "CONFIRM_PLAY_CARD" });
+    // mana_up は盤面を変えない → square ハイライト無 → 直前の緑を維持
+    expect(next.lastActionHighlights).toEqual(prevHighlights);
+  });
+
+  it("二手指し: 1手目で move1、2手目完了で move1+move2 の軌跡を蓄積", () => {
+    const dmCard = card("dm1", "double_move");
+    const snapshot = {
+      gameState: makeInitialState().gameState,
+      cardState: makeInitialCardState(),
+      eventLog: [],
+    };
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState(
+        undefined,
+        makeInitialCardState({
+          mana: { sente: 5, gote: 0 },
+          hand: { sente: [dmCard], gote: [] },
+        }),
+      ),
+      doubleMove: {
+        active: "sente",
+        movesLeft: 2,
+        mateInOneAvailable: false,
+        cardInstance: dmCard,
+        cardCost: 5,
+        preFirstMoveState: snapshot,
+        preCardState: snapshot,
+      },
+    };
+    const move1 = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "pawn",
+      from: { row: 6, col: 4 },
+      to: { row: 5, col: 4 },
+    };
+    const afterMove1 = reducer(state, { type: "MAKE_MOVE", move: move1 });
+    expect(afterMove1.doubleMove?.movesLeft).toBe(1);
+    expect(afterMove1.lastActionHighlights).toEqual([
+      { row: 6, col: 4 },
+      { row: 5, col: 4 },
+    ]);
+
+    const move2 = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "pawn",
+      from: { row: 6, col: 3 },
+      to: { row: 5, col: 3 },
+    };
+    const afterMove2 = reducer(afterMove1, { type: "MAKE_MOVE", move: move2 });
+    expect(afterMove2.doubleMove).toBeNull();
+    expect(afterMove2.lastActionHighlights).toEqual([
+      { row: 6, col: 4 },
+      { row: 5, col: 4 },
+      { row: 6, col: 3 },
+      { row: 5, col: 3 },
+    ]);
+  });
+
+  it("UNDO: 復元後の moveHistory 末尾手から緑ハイライトを再導出", () => {
+    const m0 = {
+      type: "move" as const,
+      player: "gote" as const,
+      piece: "pawn",
+      from: { row: 2, col: 4 },
+      to: { row: 3, col: 4 },
+    };
+    const m1 = {
+      type: "move" as const,
+      player: "sente" as const,
+      piece: "pawn",
+      from: { row: 6, col: 4 },
+      to: { row: 5, col: 4 },
+    };
+    const m2 = {
+      type: "move" as const,
+      player: "gote" as const,
+      piece: "pawn",
+      from: { row: 2, col: 5 },
+      to: { row: 3, col: 5 },
+    };
+    const snap0Game: GameState = {
+      ...makeInitialState().gameState,
+      moveHistory: [m0],
+      moveCount: 1,
+    };
+    const snap1Game: GameState = {
+      ...makeInitialState().gameState,
+      moveHistory: [m0, m1],
+      moveCount: 2,
+    };
+    const state: CardShogiGameStateInternal = {
+      ...makeInitialState({
+        ...makeInitialState().gameState,
+        moveHistory: [m0, m1, m2],
+        moveCount: 3,
+      }),
+      // 現在は m2 の軌跡が緑 (UNDO 前)
+      lastActionHighlights: [
+        { row: 2, col: 5 },
+        { row: 3, col: 5 },
+      ],
+      eventLog: [
+        { kind: "moveEvent", move: m0, at: 0 },
+        { kind: "moveEvent", move: m1, at: 1 },
+        { kind: "moveEvent", move: m2, at: 2 },
+      ],
+      undoSnapshots: [
+        { gameState: snap0Game, cardState: makeInitialCardState(), eventLog: [] },
+        {
+          gameState: snap1Game,
+          cardState: makeInitialCardState(),
+          eventLog: [
+            { kind: "moveEvent", move: m0, at: 0 },
+            { kind: "moveEvent", move: m1, at: 1 },
+          ],
+        },
+      ],
+    };
+    const next = reducer(state, { type: "UNDO" });
+    // UNDO 成立 (snap0 = m0 まで巻き戻る)
+    expect(next).not.toBe(state);
+    // 復元後の moveHistory 末尾 (= m0) の from/to が緑に
+    expect(next.lastActionHighlights).toEqual([
+      { row: 2, col: 4 },
+      { row: 3, col: 4 },
+    ]);
+  });
+
+  it("lastMoveHighlightSquares: 空は []、通常手は from+to、打ちは to のみ", () => {
+    const empty = makeInitialState().gameState;
+    expect(lastMoveHighlightSquares(empty)).toEqual([]);
+
+    const withMove: GameState = {
+      ...empty,
+      moveHistory: [
+        {
+          type: "move",
+          player: "sente",
+          piece: "pawn",
+          from: { row: 6, col: 4 },
+          to: { row: 5, col: 4 },
+        },
+      ],
+    };
+    expect(lastMoveHighlightSquares(withMove)).toEqual([
+      { row: 6, col: 4 },
+      { row: 5, col: 4 },
+    ]);
+
+    const withDrop: GameState = {
+      ...empty,
+      moveHistory: [
+        {
+          type: "drop",
+          player: "sente",
+          piece: "pawn",
+          dropPiece: "pawn",
+          to: { row: 4, col: 4 },
+        },
+      ],
+    };
+    expect(lastMoveHighlightSquares(withDrop)).toEqual([{ row: 4, col: 4 }]);
   });
 });

--- a/src/hooks/card-shogi/reducer.ts
+++ b/src/hooks/card-shogi/reducer.ts
@@ -93,6 +93,12 @@ export interface CardShogiGameStateInternal {
   // legalMoves とは別管理。UI で赤×表示し、クリック時にダイアログで禁止理由を説明するため。
   // 通常時 / 二手指し以外の場面では常に空。
   forbiddenMateMoves: Move[];
+  // Issue #242: 直前の盤面変化アクションで「緑ハイライトすべきマス集合」(直前手の単一情報源)。
+  // 通常手は from/to、カード作用 (歩戻し/駒戻し/二歩指し) は対象マス、二手指しは 2手分の軌跡、
+  // 王手崩しは除去された駒の位置を含む。reducer が各遷移で生成 events から純粋に算出して保持する。
+  // moveHistory に乗らないカード由来の盤面変化を表現するために必要 (旧実装は moveHistory 末尾のみ)。
+  // UI 派生 state のため DB 永続化しない。リロード / 待った復元時は moveHistory 末尾手から再導出。
+  lastActionHighlights: Position[];
   isAiThinking: boolean;
   promotionPendingMove: Move | null;
   cardState: CardGameState;
@@ -227,6 +233,50 @@ function pushUndoSnapshot(state: CardShogiGameStateInternal): UndoSnapshot[] {
 function isKingInCheckAfterMove(gameState: GameState, move: Move): boolean {
   const nextState = applyMove(gameState, move);
   return isInCheck(nextState, move.player, CARD_SHOGI_VARIANT);
+}
+
+// Issue #242: 1 アクションが生成した events から「緑ハイライトすべき盤上マス」を導出する純粋関数。
+// move / card / 王手崩しを後方走査ヒューリスティックなしで一律に扱える (reducer が遷移ごとに
+// 当該アクションの events をそのまま渡すため、ターン境界判定が不要)。
+//   - moveEvent      : 起点 from (あれば) + 終点 to (= 通常手 / 二手指し各手 / 攻め手の軌跡)
+//   - cardPlayEvent  : square ターゲット (歩戻し/駒戻し/二歩指しの作用マス)。returnedPiece は
+//                      target と同マスなので target で代表。mana_up / double_move は target 無 → 空。
+//   - trapTriggerEvent: capturedPieces を持つトラップ (現状 check_break) で除去された (持駒化された)
+//                      駒の元位置。王手崩しでは通常 攻め手の to と同一 (= 重複) だが、開き王手など
+//                      to≠除去位置のケースもあるため capturedPieces を明示的に拾う。
+// 同一マスが複数 event 由来で重複しうる (王手崩しの to=除去位置等) ため、最後に dedupe して
+// 「距離 1 の集合」として返す (UI 側も Set 化するが state を素直な集合に保つ)。
+// handPiece ターゲット (現行 production カードには存在しない) は盤上マスでないため対象外。
+// 盤上マスに作用する新カードを追加する際は本関数の分岐拡張が必要 (AGENTS.md カード追加チェックリスト)。
+function highlightSquaresForEvents(events: GameEvent[]): Position[] {
+  const out: Position[] = [];
+  const seen = new Set<string>();
+  const add = (p: Position) => {
+    const key = `${p.row}-${p.col}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ row: p.row, col: p.col });
+  };
+  for (const ev of events) {
+    if (ev.kind === "moveEvent") {
+      if (ev.move.from) add(ev.move.from);
+      add(ev.move.to);
+    } else if (ev.kind === "cardPlayEvent") {
+      if (ev.target?.kind === "square") add({ row: ev.target.row, col: ev.target.col });
+    } else if (ev.kind === "trapTriggerEvent" && ev.capturedPieces) {
+      for (const cp of ev.capturedPieces) add({ row: cp.row, col: cp.col });
+    }
+  }
+  return out;
+}
+
+// Issue #242: moveHistory 末尾手から緑ハイライトを導出するフォールバック (drop は to のみ)。
+// 初期化 (新規 / リロードで eventLog が空) / 待った復元時に使う。カード由来ハイライトは
+// moveHistory に乗らないためリロードで消えるが、通常手の緑は従来どおり維持される (非デグレ)。
+export function lastMoveHighlightSquares(gameState: GameState): Position[] {
+  const lm = gameState.moveHistory[gameState.moveHistory.length - 1];
+  if (!lm) return [];
+  return lm.from ? [lm.from, lm.to] : [lm.to];
 }
 
 
@@ -602,6 +652,8 @@ export function reducer(
             gameState: result.gameState,
             cardState: result.cardState,
             eventLog: [...state.eventLog, ...result.events],
+            // 二手指し1手目で詰み → 1手目の軌跡を緑に
+            lastActionHighlights: highlightSquaresForEvents(result.events),
             selectedSquare: null,
             selectedHandPiece: null,
             legalMoves: [],
@@ -618,6 +670,8 @@ export function reducer(
           gameState: { ...result.gameState, currentPlayer: dm.active },
           cardState: result.cardState,
           eventLog: [...state.eventLog, ...result.events],
+          // 二手指し1手目の軌跡を緑に (2手目完了時に move2 分を蓄積する)
+          lastActionHighlights: highlightSquaresForEvents(result.events),
           selectedSquare: null,
           selectedHandPiece: null,
           legalMoves: [],
@@ -640,6 +694,11 @@ export function reducer(
           gameState: result.gameState, // currentPlayer は applyMove で正しく opponent に
           cardState: result.cardState,
           eventLog: [...state.eventLog, ...result.events],
+          // 二手指し: 1手目 (state.lastActionHighlights) + 2手目 (result.events) の軌跡を蓄積
+          lastActionHighlights: [
+            ...state.lastActionHighlights,
+            ...highlightSquaresForEvents(result.events),
+          ],
           selectedSquare: null,
           selectedHandPiece: null,
           legalMoves: [],
@@ -660,6 +719,8 @@ export function reducer(
         gameState: result.gameState,
         cardState: result.cardState,
         eventLog: [...state.eventLog, ...result.events],
+        // 通常手 (+ 発動時は王手崩しの除去位置) を緑に。applyTurnEndEffects は ...state で透過保持。
+        lastActionHighlights: highlightSquaresForEvents(result.events),
         selectedSquare: null,
         selectedHandPiece: null,
         legalMoves: [],
@@ -705,6 +766,8 @@ export function reducer(
             gameState: result.gameState,
             cardState: result.cardState,
             eventLog: [...state.eventLog, ...result.events],
+            // 二手指し1手目 (成り) で詰み → 1手目の軌跡を緑に
+            lastActionHighlights: highlightSquaresForEvents(result.events),
             promotionPendingMove: null,
             selectedSquare: null,
             selectedHandPiece: null,
@@ -720,6 +783,8 @@ export function reducer(
           gameState: { ...result.gameState, currentPlayer: dm.active },
           cardState: result.cardState,
           eventLog: [...state.eventLog, ...result.events],
+          // 二手指し1手目 (成り) の軌跡を緑に (2手目完了時に move2 分を蓄積する)
+          lastActionHighlights: highlightSquaresForEvents(result.events),
           promotionPendingMove: null,
           selectedSquare: null,
           selectedHandPiece: null,
@@ -742,6 +807,11 @@ export function reducer(
           gameState: result.gameState,
           cardState: result.cardState,
           eventLog: [...state.eventLog, ...result.events],
+          // 二手指し: 1手目 (state.lastActionHighlights) + 2手目 (result.events) の軌跡を蓄積
+          lastActionHighlights: [
+            ...state.lastActionHighlights,
+            ...highlightSquaresForEvents(result.events),
+          ],
           promotionPendingMove: null,
           selectedSquare: null,
           selectedHandPiece: null,
@@ -762,6 +832,8 @@ export function reducer(
         gameState: result.gameState,
         cardState: result.cardState,
         eventLog: [...state.eventLog, ...result.events],
+        // 通常手 (成り、+ 発動時は王手崩しの除去位置) を緑に。applyTurnEndEffects は ...state で透過保持。
+        lastActionHighlights: highlightSquaresForEvents(result.events),
         promotionPendingMove: null,
         selectedSquare: null,
         legalMoves: [],
@@ -819,6 +891,9 @@ export function reducer(
           pendingCard: null,
         },
         eventLog: target.eventLog,
+        // Issue #242: 復元後の盤の直前手 (moveHistory 末尾) を緑に再導出する。
+        // 待った復元分のカード由来ハイライトは moveHistory に乗らないため通常手基準へ戻す。
+        lastActionHighlights: lastMoveHighlightSquares(target.gameState),
         // UI 一時 state はすべてクリア
         selectedSquare: null,
         selectedHandPiece: null,
@@ -1080,11 +1155,16 @@ export function reducer(
       // (王手解除ガードは applyCardEffectLogic 内蔵)。
       if (!applied) return state;
 
+      // Issue #242: カード作用マスを緑に。歩戻し/駒戻し/二歩指しは square ターゲットを持つので
+      // それを緑にする。mana_up / トラップセットは盤面を変えず空集合になるため、直前の緑
+      // (= 相手の直前手など) を保持してちらつきを防ぐ (盤面が見た目変わらない以上、緑も変えない)。
+      const cardHighlights = highlightSquaresForEvents([applied.event]);
       return {
         ...state,
         gameState: applied.gameState,
         // kernel は pendingCard を変更しないため明示クリア (カード使用 = pendingCard 解消)。
         cardState: { ...applied.cardState, pendingCard: null },
+        lastActionHighlights: cardHighlights.length ? cardHighlights : state.lastActionHighlights,
         // 駒選択状態もクリア
         selectedSquare: null,
         selectedHandPiece: null,
@@ -1173,6 +1253,8 @@ export function reducer(
         gameState: dm.preFirstMoveState.gameState,
         cardState: { ...dm.preFirstMoveState.cardState, pendingCard: null },
         eventLog: dm.preFirstMoveState.eventLog,
+        // Issue #242: 1手目を取り消した → 復元盤の直前手 (相手の手) を緑に戻す (move1 の緑を残さない)
+        lastActionHighlights: lastMoveHighlightSquares(dm.preFirstMoveState.gameState),
         selectedSquare: null,
         selectedHandPiece: null,
         legalMoves: [],
@@ -1207,6 +1289,8 @@ export function reducer(
         gameState: dm.preCardState.gameState,
         cardState: { ...dm.preCardState.cardState, pendingCard: null },
         eventLog: dm.preCardState.eventLog,
+        // Issue #242: カード使用自体を取り消した → 復元盤の直前手 (相手の手) を緑に戻す
+        lastActionHighlights: lastMoveHighlightSquares(dm.preCardState.gameState),
         selectedSquare: null,
         selectedHandPiece: null,
         legalMoves: [],

--- a/src/hooks/use-card-shogi-game.ts
+++ b/src/hooks/use-card-shogi-game.ts
@@ -18,7 +18,7 @@ import { isValidCardTargetSquare } from "@/lib/shogi/cards/effects";
 // Step 5 (Issue #107): reducer (Action 型 / state 型 / makeMoveWithEffects /
 // reducer 関数本体) は src/hooks/card-shogi/reducer.ts に分離。本ファイルは
 // useReducer + useEffect + useCallback の薄いフックとして公開 API のみを担う。
-import { reducer } from "./card-shogi/reducer";
+import { reducer, lastMoveHighlightSquares } from "./card-shogi/reducer";
 import { turnActionToReducerActions } from "./card-shogi/ai-action-bridge";
 import { canUndoFromState } from "./card-shogi/undo-policy";
 import { useDbPersistenceGuard } from "./card-shogi/use-db-persistence-guard";
@@ -70,6 +70,9 @@ export function useCardShogiGame({
     promotionPendingMove: null,
     cardState: initialCardState,
     eventLog: [],
+    // Issue #242: 初期化 (新規 / リロード) は moveHistory 末尾手から緑を導出。
+    // リロード後 (eventLog 空) でも通常手の直前手ハイライトを従来どおり維持する。
+    lastActionHighlights: lastMoveHighlightSquares(initialState),
     isDrawing: false,
     pendingDrawPlayer: null,
     pendingDrawSource: null,
@@ -696,6 +699,8 @@ export function useCardShogiGame({
     // Issue #82 (二手指し): 2手目で「禁止された詰み手」(mateInOneAvailable=false 時)。
     // UI で赤×表示し、クリック時にダイアログで禁止理由を説明するため legalMoves と別管理。
     forbiddenMateMoves: state.forbiddenMateMoves,
+    // Issue #242: 直前アクションの緑ハイライト集合 (通常手 / カード作用 / 二手指し軌跡 / 王手崩し)。
+    lastActionHighlights: state.lastActionHighlights,
     isAiThinking: state.isAiThinking,
     promotionPendingMove: state.promotionPendingMove,
     cardState: state.cardState,

--- a/src/lib/shogi/kernel/__tests__/world-kernel-equivalence.test.ts
+++ b/src/lib/shogi/kernel/__tests__/world-kernel-equivalence.test.ts
@@ -164,6 +164,7 @@ function makeReducerState(
     pendingPlayCardOpponent: null,
     isCheckBreakAnimating: false,
     doubleMove: null,
+    lastActionHighlights: [],
     undoSnapshots: [],
     spectatorMode: true, // DP-4 決定論化
     isPaused: false,


### PR DESCRIPTION
## Summary
カードによる駒移動 (歩戻し / 駒戻し / 二歩指し / 二手指し / 王手崩し) で、直前手を示す緑ハイライトが盤面に反映されず、どのマスに作用したか一目で分からなかったバグを修正。

緑ハイライトは従来 `gameState.moveHistory` 末尾手の from/to からのみ導出していたが、カード効果は `moveHistory` を更新しない設計のため緑が出なかった (二手指しは末尾1手のみ)。reducer に「直前アクションで緑にすべきマス集合」`lastActionHighlights` を単一情報源として持たせ、各遷移が生成した `GameEvent` から純粋関数 `highlightSquaresForEvents` で導出する方式に変更した。

## 変更内容
- `src/hooks/card-shogi/reducer.ts`: `lastActionHighlights` + ヘルパ2つ (`highlightSquaresForEvents` / `lastMoveHighlightSquares`) + 全遷移 (通常手 / 二手指し各手 / カード / UNDO系) でセット・dedupe
- `src/hooks/use-card-shogi-game.ts`: 初期化 (リロード対応) + hook 公開
- `src/components/game/card-shogi/card-shogi-game.tsx`: 2 レイアウトへ `lastMoveSquares` 伝播
- `src/components/game/shogi-board.tsx`: `lastMoveSquares` prop 追加 (標準将棋・board-design は従来の `lastMove` フォールバックで非デグレ)
- tests: reducer 統合 (通常手 / 歩戻し / 駒戻し / 二歩指し / mana_up保持 / 二手指し蓄積 / UNDO / 王手崩し) + fixture 更新
- `docs/plans/issue-242-card-move-highlight.md`: 設計計画書

## 設計判断
- reducer 単一情報源 + イベント駆動。カード効果は moveHistory を更新しないため moveHistory 末尾だけでは表現不可。reducer は各遷移で何が起きたか把握しており、events から導出する方式が eventLog 後方走査 (ターン境界判定が脆い) より堅牢で疎結合。
- UI 派生 state のため DB 非永続。初期化/リロード/待った復元は moveHistory 末尾から再導出 → 通常手の緑は従来どおり維持 (非デグレ)、カード由来の緑のみリロードで消える (直前強調という性質上許容)。

## Test plan
- `npm run lint`: 0 errors
- `npm run typecheck`: pass
- `npm run test:ci`: 703 passed (新規9件含む、デグレなし)
- `npm run build`: 成功
- 実機 (Vercel プレビュー) で緑ハイライト挙動を確認済 (動作良好)

rule 8 の M1 (計画) / M2 (実装完了) マイルストーンで多角レビューを実施し全指摘を反映。

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
