### PR TITLE
chore: .gitignore に local-data を追加 (数百MBの誤コミットを防ぐ)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # Claude Code (personal local override)
 .claude/settings.local.json
+
+# 学習データ (Issue #245): 自己対戦/export の JSONL 等。再生成可能ゆえ git 非追跡。
+/local-data/


### PR DESCRIPTION
## Summary

学習データ用ディレクトリ `local-data/` (棋譜 JSONL・学習済みモデル・DB スナップショット等、合計数百 MB) の除外行が **`feature/#245-phase1-plan` にしか無く main には存在しなかった**問題を修正します。

main 起点でブランチを切ると `local-data/` が「未追跡かつ未無視」の状態で `git status` に現れ、`git add -A` を実行した瞬間に数百 MB がコミットされます。Issue #250 の作業中 (main 起点の worktree) に実際に `?? local-data/` が現れることを確認しました。過去に `git add -A` で worktree gitlink を誤コミットした事故もあり、運用ルール (「`git add -A` を使わずファイルを明示指定する」) だけに頼るのは危ういため、除外を**仕組み側**に置きます。

## 変更内容

- `.gitignore`: `/local-data/` を追加 (コメント込み 2 行)

`feature/#245-phase1-plan` 側の記述と**バイト単位で同一**にしたため、当該ブランチを将来マージする際に衝突しません (`diff` で確認済み)。

## Test plan

- [x] `git check-ignore -v local-data/probe.jsonl` → `.gitignore:47` にヒット
- [x] `git status` に `local-data/` が現れない (`.gitignore` の変更のみ)
- [x] `diff <(git show origin/feature/#245-phase1-plan:.gitignore) .gitignore` → 差分なし (将来のマージ衝突なし)
- [x] `npm run lint` (0 error / 既存 warning 22) / `npm run typecheck` 緑
  - `.gitignore` はソースでなく tsc / eslint も参照しないため本来影響しないが、AGENTS 実装ガイドライン 6 に従い確認
- [x] `npm run build` は省略 (ソース非変更のため。実装ガイドライン 6 の「ドキュメントのみの変更」に準ずる)

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)